### PR TITLE
fake sqw with q range

### DIFF
--- a/_test/test_sqw/test_fake_sqw.m
+++ b/_test/test_sqw/test_fake_sqw.m
@@ -32,10 +32,10 @@ classdef test_fake_sqw < TestCase
         par_file
         % the random parameters for the transformation
         %   {      emode efix,   alatt,     angdeg,         u,               v,            psi,
-        gen_sqw_par = {1,35,[4.4,5.5,6.6],[100,105,110],[1.02,0.99,0.02],[0.025,-0.01,1.04],80,...
-            10,0.1,3,2.4}; %omega, dpsi, gl, gs};
-        %gen_sqw_par = {1,35,[2,2,2],[90,90,90],[1,0,0],[0,0,1],80,...
-        %    0,0,0,0}; %omega, dpsi, gl, gs};
+%         gen_sqw_par = {1,35,[4.4,5.5,6.6],[100,105,110],[1.02,0.99,0.02],[0.025,-0.01,1.04],80,...
+%             10,0.1,3,2.4}; %omega, dpsi, gl, gs};
+        gen_sqw_par = {1,35,[2,2,2],[90,90,90],[1,0,0],[0,0,1],80,...
+           0,0,0,0}; %omega, dpsi, gl, gs};
         
     end
     
@@ -85,8 +85,9 @@ classdef test_fake_sqw < TestCase
             de0 = pix(4,:)==0;
             assertEqual(sum(de0),96);
             
-            q_range = pix(1:3,de0)';
-
+            q_range = pix(1:3,de0)'; % this is q-range in crystal catresizan
+            u_to_rlu = tsqw.data.u_to_rlu(1:3,1:3);
+            q_range = q_range*u_to_rlu ; % convert q into hkl
             % verify the fact that the detector positions, processed from
             % the pixel information provide the same result as normal
             % detector positions

--- a/_test/test_sqw/test_fake_sqw.m
+++ b/_test/test_sqw/test_fake_sqw.m
@@ -1,44 +1,30 @@
 classdef test_fake_sqw < TestCase
     % Test fake_sqw routine
     %
-    % Optionally writes results to output file to compare with previously
-    % saved sample test results
     %---------------------------------------------------------------------
     % Usage:
     %
-    %1) Normal usage:
-    % Run all unit tests and compare their results with previously saved
-    % results stored in test_gen_sqw_accumulate_sqw_output.mat file
-    % located in the same folder as this function:
-    %
-    %>>runtests test_gen_sqw_accumulate_sqw_sep_session
-    %---------------------------------------------------------------------
-    %2) Run particular test case from the suite:
-    %
+    %>>runtests test_fake_sqw
+    % run all unit tests class contains
+    % or
+    %>>runtests test_fake_sqw:test_det_from_q
+    %run the particular test
+    % or
     %>>tc = test_gen_sqw_accumulate_sqw_sep_session();
-    %>>tc.test_[particular_test_name] e.g.:
-    %>>tc.test_accumulate_sqw14();
-    %or
-    %>>tc.test_gen_sqw();
-    %---------------------------------------------------------------------
-    %3) Generate test file to store test results to compare with them later
-    %   (it stores test results into tmp folder.)
-    %
-    %>>tc=test_gen_sqw_accumulate_sqw_sep_session('save');
-    %>>tc.save():
+    %>>tc.test_det_from_q()
+    %Run particular test saving construction time.
     properties
         working_dir
         % test parameters file, used in fake_sqw calculations
         par_file
         % the random parameters for the transformation
         %   {      emode efix,   alatt,     angdeg,         u,               v,            psi,
-         gen_sqw_par = {1,35,[4.4,5.5,6.6],[100,105,110],[1.02,0.99,0.02],[0.025,-0.01,1.04],80,...
-             10,0.1,3,2.4}; %omega, dpsi, gl, gs};
-%         gen_sqw_par = {1,35,[2,2,2],[90,90,90],[1,0,0],[0,0,1],80,...
-%            0,0,0,0}; %omega, dpsi, gl, gs};
-        
+        gen_sqw_par = {1,35,[4.4,5.5,6.6],[100,105,110],[1.02,0.99,0.02],[0.025,-0.01,1.04],80,...
+            10,0.1,3,2.4}; %omega, dpsi, gl, gs};
+        % for debugging purposes generate orthogonal projection matrix.
+        %         gen_sqw_par = {1,35,[2,2,2],[90,90,90],[1,0,0],[0,0,1],80,...
+        %            0,0,0,0}; %omega, dpsi, gl, gs};
     end
-    
     
     methods
         function obj=test_fake_sqw(test_class_name)
@@ -70,12 +56,19 @@ classdef test_fake_sqw < TestCase
             det=build_det_from_q_range([0,0.1,1],obj.gen_sqw_par{2:end});
             assertTrue(isstruct(det));
             assertEqual(numel(det.group),11*11*11)
+            
+            det=build_det_from_q_range([0,0.1,1;0,0.2,2;0,0.3,3],...
+                obj.gen_sqw_par{2:end});
+            assertTrue(isstruct(det));
+            assertEqual(numel(det.group),11*11*11)
+            
         end
         %
         function test_build_fake_sqw(obj)
             % build fake sqw using detector positions and without detector
             % positions.
-            tsqw = fake_sqw(-0.5:1:obj.gen_sqw_par{2}-5, obj.par_file, '', obj.gen_sqw_par{2},obj.gen_sqw_par{1},...
+            tsqw = fake_sqw(-0.5:1:obj.gen_sqw_par{2}-5, obj.par_file, '',...
+                obj.gen_sqw_par{2},obj.gen_sqw_par{1},...
                 obj.gen_sqw_par{3:end});
             tsqw = tsqw{1};
             
@@ -91,15 +84,13 @@ classdef test_fake_sqw < TestCase
             % verify the fact that the detector positions, processed from
             % the pixel information provide the same result as normal
             % detector positions
-            tsqw2 = fake_sqw(-0.5:1:obj.gen_sqw_par{2}-5, q_range , '', obj.gen_sqw_par{2},obj.gen_sqw_par{1},...
+            tsqw2 = fake_sqw(-0.5:1:obj.gen_sqw_par{2}-5, q_range , '',...
+                obj.gen_sqw_par{2},obj.gen_sqw_par{1},...
                 obj.gen_sqw_par{3:end});
             
             tsqw2 = tsqw2{1};
             pix1 = tsqw2.data.pix(1:4,:);
             assertElementsAlmostEqual(pix,pix1,'absolute',1.e-7);
         end
-        
-        %
-        %
     end
 end

--- a/_test/test_sqw/test_fake_sqw.m
+++ b/_test/test_sqw/test_fake_sqw.m
@@ -32,10 +32,10 @@ classdef test_fake_sqw < TestCase
         par_file
         % the random parameters for the transformation
         %   {      emode efix,   alatt,     angdeg,         u,               v,            psi,
-%         gen_sqw_par = {1,35,[4.4,5.5,6.6],[100,105,110],[1.02,0.99,0.02],[0.025,-0.01,1.04],80,...
-%             10,0.1,3,2.4}; %omega, dpsi, gl, gs};
-        gen_sqw_par = {1,35,[2,2,2],[90,90,90],[1,0,0],[0,0,1],80,...
-           0,0,0,0}; %omega, dpsi, gl, gs};
+         gen_sqw_par = {1,35,[4.4,5.5,6.6],[100,105,110],[1.02,0.99,0.02],[0.025,-0.01,1.04],80,...
+             10,0.1,3,2.4}; %omega, dpsi, gl, gs};
+%         gen_sqw_par = {1,35,[2,2,2],[90,90,90],[1,0,0],[0,0,1],80,...
+%            0,0,0,0}; %omega, dpsi, gl, gs};
         
     end
     
@@ -85,9 +85,9 @@ classdef test_fake_sqw < TestCase
             de0 = pix(4,:)==0;
             assertEqual(sum(de0),96);
             
-            q_range = pix(1:3,de0)'; % this is q-range in crystal catresizan
+            q_range = pix(1:3,de0); % this is q-range in crystal catresizan
             u_to_rlu = tsqw.data.u_to_rlu(1:3,1:3);
-            q_range = q_range*u_to_rlu ; % convert q into hkl
+            q_range = (u_to_rlu*q_range)' ; % convert q into hkl
             % verify the fact that the detector positions, processed from
             % the pixel information provide the same result as normal
             % detector positions
@@ -96,7 +96,7 @@ classdef test_fake_sqw < TestCase
             
             tsqw2 = tsqw2{1};
             pix1 = tsqw2.data.pix(1:4,:);
-            assertEqual(pix,pix1);
+            assertElementsAlmostEqual(pix,pix1,'absolute',1.e-7);
         end
         
         %

--- a/_test/test_sqw/test_fake_sqw.m
+++ b/_test/test_sqw/test_fake_sqw.m
@@ -1,0 +1,104 @@
+classdef test_fake_sqw < TestCase
+    % Test fake_sqw routine
+    %
+    % Optionally writes results to output file to compare with previously
+    % saved sample test results
+    %---------------------------------------------------------------------
+    % Usage:
+    %
+    %1) Normal usage:
+    % Run all unit tests and compare their results with previously saved
+    % results stored in test_gen_sqw_accumulate_sqw_output.mat file
+    % located in the same folder as this function:
+    %
+    %>>runtests test_gen_sqw_accumulate_sqw_sep_session
+    %---------------------------------------------------------------------
+    %2) Run particular test case from the suite:
+    %
+    %>>tc = test_gen_sqw_accumulate_sqw_sep_session();
+    %>>tc.test_[particular_test_name] e.g.:
+    %>>tc.test_accumulate_sqw14();
+    %or
+    %>>tc.test_gen_sqw();
+    %---------------------------------------------------------------------
+    %3) Generate test file to store test results to compare with them later
+    %   (it stores test results into tmp folder.)
+    %
+    %>>tc=test_gen_sqw_accumulate_sqw_sep_session('save');
+    %>>tc.save():
+    properties
+        working_dir
+        % test parameters file, used in fake_sqw calculations
+        par_file
+        % the random parameters for the transformation
+        %   {      emode efix,   alatt,     angdeg,         u,               v,            psi,
+        gen_sqw_par = {1,35,[4.4,5.5,6.6],[100,105,110],[1.02,0.99,0.02],[0.025,-0.01,1.04],80,...
+            10,0.1,3,2.4}; %omega, dpsi, gl, gs};
+        %gen_sqw_par = {1,35,[2,2,2],[90,90,90],[1,0,0],[0,0,1],80,...
+        %    0,0,0,0}; %omega, dpsi, gl, gs};
+        
+    end
+    
+    
+    methods
+        function obj=test_fake_sqw(test_class_name)
+            % The constructor fake_sqw class
+            
+            if ~exist('test_class_name','var')
+                test_class_name = 'test_fake_sqw';
+            end
+            
+            obj = obj@TestCase(test_class_name);
+            obj.working_dir = tempdir;
+            
+            data_path = fileparts(mfilename('fullpath'));
+            %this.par_file=fullfile(this.results_path,'96dets.par');
+            obj.par_file=fullfile(data_path,'gen_sqw_96dets.nxspe');
+        end
+        function test_det_from_q_invalid(obj)
+            f = @()build_det_from_q_range('wrong_detpar',obj.gen_sqw_par{:});
+            
+            assertExceptionThrown(f,'FAKE_SQW:invalid_argument');
+            
+            f = @()build_det_from_q_range(ones(3,1),obj.gen_sqw_par{:});
+            assertExceptionThrown(f,'FAKE_SQW:invalid_argument');
+            
+        end
+        function test_det_from_q(obj)
+            % check if build_det_from_q_range is working and producing
+            % reasonable result.
+            det=build_det_from_q_range([0,0.1,1],obj.gen_sqw_par{2:end});
+            assertTrue(isstruct(det));
+            assertEqual(numel(det.group),11*11*11)
+        end
+        %
+        function test_build_fake_sqw(obj)
+            % build fake sqw using detector positions and without detector
+            % positions.
+            tsqw = fake_sqw(-0.5:1:obj.gen_sqw_par{2}-5, obj.par_file, '', obj.gen_sqw_par{2},obj.gen_sqw_par{1},...
+                obj.gen_sqw_par{3:end});
+            tsqw = tsqw{1};
+            
+            assertTrue(isa(tsqw,'sqw'));
+            
+            pix = tsqw.data.pix(1:4,:);
+            de0 = pix(4,:)==0;
+            assertEqual(sum(de0),96);
+            
+            q_range = pix(1:3,de0)';
+
+            % verify the fact that the detector positions, processed from
+            % the pixel information provide the same result as normal
+            % detector positions
+            tsqw2 = fake_sqw(-0.5:1:obj.gen_sqw_par{2}-5, q_range , '', obj.gen_sqw_par{2},obj.gen_sqw_par{1},...
+                obj.gen_sqw_par{3:end});
+            
+            tsqw2 = tsqw2{1};
+            pix1 = tsqw2.data.pix(1:4,:);
+            assertEqual(pix,pix1);
+        end
+        
+        %
+        %
+    end
+end

--- a/algorithms/build_det_from_q_range.m
+++ b/algorithms/build_det_from_q_range.m
@@ -1,5 +1,5 @@
 function  [det_pos,par_file_name] = build_det_from_q_range(q_range,efix,alatt,angdeg,u,v,psi,omega,dpsi,gl,gs,filename)
-% create fake detector file which would cover the q-range provided as input
+% Create fake detector file which would cover the q-range provided as input
 %
 % Inputs:
 % q_range --  3xNdet array of [h,k,l] momentums corresponding to the
@@ -10,6 +10,9 @@ function  [det_pos,par_file_name] = build_det_from_q_range(q_range,efix,alatt,an
 %             q-range (at zero energy transfer) to evaluate sqw file.
 %             The fake detectors positions would be calculated from the
 %             q-range provided.]
+%             or 1x3 vector [q_min,q_step,q_max] providing the same
+%             range in all 3 hkl directions.
+%
 %
 % Goniometer and sample position, defining q-transformation:
 %   efix            Fixed energy (meV)                 [scalar or vector length nfile]
@@ -58,8 +61,8 @@ if size(q_range,2) ~=3
 end
 if all(size(q_range) == [3,3])
     [q1,q2,q3] = ndgrid(q_range(1,1):q_range(1,2):q_range(1,3),...
-        q_range(2,1):q_range(2,2):q_range(2,1),...
-        q_range(3,1):q_range(3,2):q_range(3,1));
+        q_range(2,1):q_range(2,2):q_range(2,3),...
+        q_range(3,1):q_range(3,2):q_range(3,3));
     nq = numel(q1);
     q_range = [reshape(q1,nq,1),reshape(q2,nq,1),reshape(q3,nq,1)];
 elseif all(size(q_range) == [1,3])
@@ -75,7 +78,7 @@ lat = oriented_lattice(alatt,angdeg,psi,u,v,omega,dpsi,gl,gs);
 
 %
 c=neutron_constants;
-k_to_e = c.c_k_to_emev;  
+k_to_e = c.c_k_to_emev;
 ki = sqrt(efix/k_to_e);
 %
 detdcn  = ([1;0;0]- spec_to_rlu\q_range'/ki)' ;

--- a/algorithms/build_det_from_q_range.m
+++ b/algorithms/build_det_from_q_range.m
@@ -1,0 +1,92 @@
+function  [det_pos,par_file_name] = build_det_from_q_range(q_range,efix,alatt,angdeg,u,v,psi,omega,dpsi,gl,gs,filename)
+% create fake detector file which would cover the q-range provided as input
+%
+% Inputs:
+% q_range --  3xNdet array of [h,k,l] momentums corresponding to the
+%             detectors positions (in elastic scattering)
+%             or
+%             3x3 matrix in the format [qh_min,qh_step,qh_max;
+%             qk_min;qk_step,qk_max;ql_min;q;_step,q;_max] providing
+%             q-range (at zero energy transfer) to evaluate sqw file.
+%             The fake detectors positions would be calculated from the
+%             q-range provided.]
+%
+% Goniometer and sample position, defining q-transformation:
+%   efix            Fixed energy (meV)                 [scalar or vector length nfile]
+%   alatt           Lattice parameters (Ang^-1)        [row or column vector]
+%   angdeg          Lattice angles (deg)               [row or column vector]
+%   u               First vector (1x3) defining scattering plane (r.l.u.)
+%   v               Second vector (1x3) defining scattering plane (r.l.u.)
+%   psi             Angle of u w.r.t. ki (deg)         [scalar or vector length nfile]
+%   omega           Angle of axis of small goniometer arc w.r.t. notional u (deg) [scalar or vector length nfile]
+%   dpsi            Correction to psi (deg)            [scalar or vector length nfile]
+%   gl              Large goniometer arc angle (deg)   [scalar or vector length nfile]
+%   gs              Small goniometer arc angle (deg)   [scalar or vector length nfile]
+% Optional (Not implemented)
+%  filename  -- if present, defines the name of the par file to save
+%               detector information. If absent, detector infornation is
+%               stored in mem-file.
+%
+% Outputs:
+% det_pos     The structure containing calculated detectors positions (in
+%             Horace format)
+%Not implemented:
+% par_file_name -- if provided, disables par file saving and contains the
+%             name of mem file containing the detector positions
+%             information.
+%
+
+if ischar(q_range) || ~isnumeric(q_range)
+    error('FAKE_SQW:invalid_argument','q_range should be a matrix')
+end
+if ~exist('filename','var')
+    par_file_name = ['q_det_',upper(str_random(6)),'.mem'];
+    save_real_file = false;
+else
+    save_real_file = true;
+    par_file_name  = filename;
+end
+if nargout > 1
+    save_real_file = false;
+    [fp,fn]  = fileparts(par_file_name);
+    par_file_name = fullfile(fp,[fn,'.mem']);
+end
+if size(q_range,2) ~=3
+    error('FAKE_SQW:invalid_argument',...
+        'second dimension of the q-range matrix should is not 3 but %d',...
+        size(q_range,2))
+end
+if all(size(q_range) == [3,3])
+    [q1,q2,q3] = ndgrid(q_range(1,1):q_range(1,2):q_range(1,3),...
+        q_range(2,1):q_range(2,2):q_range(2,1),...
+        q_range(3,1):q_range(3,2):q_range(3,1));
+    nq = numel(q1);
+    q_range = [reshape(q1,nq,1),reshape(q2,nq,1),reshape(q3,nq,1)];
+elseif all(size(q_range) == [1,3])
+    [q1,q2,q3] = ndgrid(q_range(1):q_range(2):q_range(3),...
+        q_range(1):q_range(2):q_range(3),...
+        q_range(1):q_range(2):q_range(3));
+    nq = numel(q1);
+    q_range = [reshape(q1,nq,1),reshape(q2,nq,1),reshape(q3,nq,1)];
+end
+
+lat = oriented_lattice(alatt,angdeg,psi,u,v,omega,dpsi,gl,gs);
+[~, ~, spec_to_rlu] = lat.calc_proj_matrix();
+
+%
+c=neutron_constants;
+k_to_e = c.c_k_to_emev;  
+ki = sqrt(efix/k_to_e);
+%
+detdcn  = [1,0,0]- q_range/(spec_to_rlu*ki) ;
+[azim,el,r] = cart2sph(detdcn(:,2),detdcn(:,3),detdcn(:,1));
+
+det_pos = convert_to_det_pos(azim,pi/2-el,r);
+%
+det_pos = get_hor_format(det_pos',par_file_name);
+
+
+
+function det_pos = convert_to_det_pos(azim,theta,r)
+np = numel(azim);
+det_pos = [r,theta*(180/pi),azim*(180/pi),ones(np,1),ones(np,1),(1:np)'];

--- a/algorithms/build_det_from_q_range.m
+++ b/algorithms/build_det_from_q_range.m
@@ -78,7 +78,7 @@ c=neutron_constants;
 k_to_e = c.c_k_to_emev;  
 ki = sqrt(efix/k_to_e);
 %
-detdcn  = [1,0,0]- q_range/(spec_to_rlu*ki) ;
+detdcn  = ([1;0;0]- spec_to_rlu\q_range'/ki)' ;
 [azim,el,r] = cart2sph(detdcn(:,2),detdcn(:,3),detdcn(:,1));
 
 det_pos = convert_to_det_pos(azim,pi/2-el,r);

--- a/algorithms/private/gen_sqw_check_files.m
+++ b/algorithms/private/gen_sqw_check_files.m
@@ -42,7 +42,7 @@ spe_file_out=[]; par_file_out=[]; sqw_file_out=[]; spe_exist=[]; spe_unique=[]; 
 
 %RAE - is_string fails in Matlab versions earlier than 2015b
 %this is a nasty fix for this one example - are there others???
-%try 
+%try
 tf=is_string(spe_file);
 %catch
 %    tf=isstring(spe_file);
@@ -102,19 +102,30 @@ end
 if ~isempty(par_file)
     if is_string(par_file) && ~isempty(strtrim(par_file))
         par_file_out=strtrim(par_file);
+        det_par_file = true;
+    elseif isstruct(par_file)
+        det_par_file = false;
     else
         ok=false; mess='If given, par filename  must be a non-empty string'; return
     end
-    % Check par file exists
-    [path,name,ext]=fileparts(par_file_out);
-    if any(strcmpi(ext,[ext_horace,'.spe']))
-        ok=false; 
-        mess=['Detector parameter files must not have the reserved extension ''',ext,...
-            '''. Check the file is .par type and rename.'];
-        return
-    end
-    if ~exist(par_file_out,'file')
-        ok=false; mess=['Detector parameter file ',par_file_out,' not found']; return
+    if det_par_file        
+        % Check par file exists
+        [~,~,ext]=fileparts(par_file_out);
+        if any(strcmpi(ext,[ext_horace,'.spe']))
+            ok=false;
+            mess=['Detector parameter files must not have the reserved extension ''',ext,...
+                '''. Check the file is .par type and rename.'];
+            return
+        end
+        if ~exist(par_file_out,'file')
+            ok=false; mess=['Detector parameter file ',par_file_out,' not found']; return
+        end
+    else
+        pf = {'filename','filepath','group','x2','phi','azim','width','height'};
+        if ~all(isfield(par_file,pf))
+            ok=false; mess='Detector parameter information should be in Horace par_file format'; return            
+        end
+        par_file_out = par_file.filename;
     end
 else
     par_file_out='';
@@ -125,7 +136,7 @@ end
 % ---------------
 
 %See above (RAE)
-%try 
+%try
 tf=is_string(sqw_file);
 %catch
 %    tf=isstring(sqw_file);
@@ -171,3 +182,6 @@ end
 % ----------------
 ok=true;
 mess='';
+if ~det_par_file
+    par_file_out = par_file;
+end

--- a/algorithms/private/range_add_border.m
+++ b/algorithms/private/range_add_border.m
@@ -12,13 +12,14 @@ function urange=range_add_border(urange_in, tol)
 %               tol=0   No border
 %               tol>0   Absolute value of thickness of border
 %               tol<0   Relative size as a proportion of the range along
-%                       each axis.
+%                       each axis. If the range is zero, absolute tol value
+%                       is used.
 %
 % Output:
 % -------
 %   urange      Expanded range
 
-ndim=size(urange_in,1);
+ndim=size(urange_in,2);
 if tol==0
     urange=urange_in;
     return
@@ -30,4 +31,6 @@ elseif tol<0
     border=[-border;border];
     urange=urange_in;
     urange(:,~no_range)=urange(:,~no_range)+border(:,~no_range);
+    abs_tol = abs(tol)*([-ones(1,ndim);ones(1,ndim)]);
+    urange(:,no_range)  = urange(:,no_range)+abs_tol(:,no_range);   
 end

--- a/sqw/@rundatah/private/calc_sqw_.m
+++ b/sqw/@rundatah/private/calc_sqw_.m
@@ -222,3 +222,6 @@ sqw_data.e=sum(pix(9,:));   % take advantage of the squaring that has already be
 sqw_data.npix=ne*ndet;
 sqw_data.urange=urange;
 sqw_data.pix=pix;
+u_to_rlu4 = eye(4);
+u_to_rlu4(1:3,1:3) = u_to_rlu;
+sqw_data.u_to_rlu = u_to_rlu4;

--- a/sqw/@rundatah/private/calc_sqw_.m
+++ b/sqw/@rundatah/private/calc_sqw_.m
@@ -222,6 +222,4 @@ sqw_data.e=sum(pix(9,:));   % take advantage of the squaring that has already be
 sqw_data.npix=ne*ndet;
 sqw_data.urange=urange;
 sqw_data.pix=pix;
-u_to_rlu4 = eye(4);
-u_to_rlu4(1:3,1:3) = u_to_rlu;
-sqw_data.u_to_rlu = u_to_rlu4;
+


### PR DESCRIPTION
This modifies fake_sqw to accept range of hkl values instead of detector positions to be able to compare the generated sqw object with the results of theoretical simulations. 

The validity of the operations are illustrated by unit test provided. If one generates sqw object using detectors and then deploy q-range as input to another fake sqw, the fake_sqw correctly recovers the detectors positions and produce the result, similar to the one, generated by initial fake_sqw