### PR TITLE
Fix typo in combine_sqw_pix_job.m error message

### DIFF
--- a/sqw/file_io/@combine_sqw_pix_job/combine_sqw_pix_job.m
+++ b/sqw/file_io/@combine_sqw_pix_job/combine_sqw_pix_job.m
@@ -262,7 +262,7 @@ classdef combine_sqw_pix_job < JobExecutor
             if count_out ~=9*npix2read
                 error('SQW_FILE_IO:runtime_error',...
                     ' Number of pixels read %d is smaller then the number requested: %d',...
-                    count_ouf/9,npix2read);
+                    count_out/9,npix2read);
             end
             [f_message,f_errnum] = ferror(fid);
             if f_errnum ~=0


### PR DESCRIPTION
This very minor error-message bug will probably never be seen by anyone who is not also (incorrectly) modifying temporary SQW objects which they then write to disk before combining.