### PR TITLE
Initial ADRs for PACE work on Horace

### DIFF
--- a/documentation/adr/0001-record-architecture-decisions.md
+++ b/documentation/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2019-11-04
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard in this article: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's _adr-tools_ at https://github.com/npryce/adr-tools.

--- a/documentation/adr/0002-use-github-for-documentation.md
+++ b/documentation/adr/0002-use-github-for-documentation.md
@@ -1,0 +1,27 @@
+# 2. Use GitHub for Project Documentation
+
+Date: 2019-11-06
+
+## Status
+
+Accepted
+
+## Context
+
+We need to store project documentation (Developer Guides, System Architecture, System Maintenance, Test Plans) somewhere that it is easy to read and update.
+
+Documentation will directly reference Horace and Herbert projects.
+
+The GitHub Wiki repository does not support pull requests, or the display of any content not on the the `master` branch.
+
+## Decision
+
+We will store documentation in the `Horace/documentation` folder and link to this from the the [GitHub Wiki](https://github.com/pace-neutrons/pace-developers/wiki) which is attached to the PACE project on GitHub. 
+
+## Consequences
+
+- Documentation will be written in markdown.
+- Storing in the main source repository means changes can be tracked and reviewed through pull requests. 
+- Pdf versions of the documentation can be quickly and simply generated using some off-the-shelf tooling if required.
+- Markdown stored at [pace-developers/wiki](https://github.com/pace-neutrons/pace-developers.wiki.git) will link to the documentation.
+- Documentation will be stored as part of the Horace project [Horace/documentation](https://github.com/pace-neutrons/horace.git).

--- a/documentation/adr/0003-use-cmake-for-build.md
+++ b/documentation/adr/0003-use-cmake-for-build.md
@@ -1,0 +1,19 @@
+# 3. Use CMake for build tool
+
+Date: 2019-11-06
+
+## Status
+
+Accepted
+
+## Context
+
+The project will need to be built for multiple platforms Windows (VStudio), MacOS, Linux (gcc/Make) and include compilation of Matlab and C++ (with Matlab API wrapper).
+
+## Decision
+
+We will use [CMake](https://cmake.org/) to provide a platform agnostic build definition that can be configured for each target platform. 
+
+## Consequences
+
+Exactly one definition of the build will exist.

--- a/documentation/adr/0003-use-cmake-for-build.md
+++ b/documentation/adr/0003-use-cmake-for-build.md
@@ -16,5 +16,5 @@ We will use [CMake](https://cmake.org/) to provide a platform agnostic build def
 
 ## Consequences
 
-Exactly one definition of the build will exist.
-The generated makefiles and vcproj files will need to be bundled into the releases to enable users to rebuild locally without CMake
+- Exactly one definition of the build will exist.
+- The generated makefiles and vcproj files will need to be bundled into the releases to enable users to rebuild locally without CMake.

--- a/documentation/adr/0003-use-cmake-for-build.md
+++ b/documentation/adr/0003-use-cmake-for-build.md
@@ -17,3 +17,4 @@ We will use [CMake](https://cmake.org/) to provide a platform agnostic build def
 ## Consequences
 
 Exactly one definition of the build will exist.
+The generated makefiles and vcproj files will need to be bundled into the releases to enable users to rebuild locally without CMake


### PR DESCRIPTION
The `documentation/adr` folder will be linked from the pace-developers.wiki once this is merged.

See ADR-0002 below for discussion around split between documentation on the wiki and in the Horace project source.