### PR TITLE
ADR for CPP test file layout

### DIFF
--- a/documentation/adr/0001-record-architecture-decisions.md
+++ b/documentation/adr/0001-record-architecture-decisions.md
@@ -1,3 +1,5 @@
+<-previous | [next->](0002-use-githib-for-documentation.md)
+
 # 1. Record architecture decisions
 
 Date: 2019-11-04
@@ -17,3 +19,4 @@ We will use Architecture Decision Records, as described by Michael Nygard in thi
 ## Consequences
 
 See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's _adr-tools_ at https://github.com/npryce/adr-tools.
+

--- a/documentation/adr/0002-use-github-for-documentation.md
+++ b/documentation/adr/0002-use-github-for-documentation.md
@@ -1,3 +1,5 @@
+[<-previous](0001-record-architecture-decisions.md) | [next->](0003-use-cmake-for-build.md)
+
 # 2. Use GitHub for Project Documentation
 
 Date: 2019-11-06

--- a/documentation/adr/0003-use-cmake-for-build.md
+++ b/documentation/adr/0003-use-cmake-for-build.md
@@ -1,3 +1,5 @@
+[<-previous](0002-record-architecture-decisions.md) | [next->](0004-cpp-tests-in-separate-projects.md)
+
 # 3. Use CMake for build tool
 
 Date: 2019-11-06

--- a/documentation/adr/0004-cpp-tests-in-separate-projects.md
+++ b/documentation/adr/0004-cpp-tests-in-separate-projects.md
@@ -42,8 +42,10 @@ service\
 
 The test projects will include the associated function project as an explicit reference e.g.
 
-```
-target_link_libraries(functionOne.Tests functionOne ...)
+```cmake
+add_executable("functionOne.test" ${TEST_SRC_FILES} ${TEST_HDR_FILES} ${SRC_FILES} ${HDR_FILES})
+target_include_directories("functionOne.test" PRIVATE ${CMAKE_SOURCE_DIR}/_LowLevelCode/cpp")
+target_link_libraries("functionOne.test" gtest_main)
 ```
 
 This enables the test artifacts and dependencies to be simply excluded from system components that  will be deployed. The separation will also provide a clear cognitive separation between `function` and `function.Test` and support further extension to `function.IntegrationTest`.
@@ -51,5 +53,14 @@ This enables the test artifacts and dependencies to be simply excluded from syst
 ## Consequences
 
 * Consistent code layout across project
+
 * Test code simply excluded from release builds
+
 * Additional C++ project overhead
+
+* For C++ projects including a mex wrapper, the MATLAB mex libraries must be added explicitly, i.e.
+
+  ```cmake
+   target_include_directories("functionOne.test" PRIVATE "${CMAKE_SOURCE_DIR}/_LowLevelCode/cpp" "${Matlab_INCLUDE_DIRS}")
+   target_link_libraries("functionOne.test" gtest_main "${Matlab_MEX_LIBRARY}" "${Matlab_MX_LIBRARY}" "${Matlab_UT_LIBRARY}")
+  ```

--- a/documentation/adr/0004-cpp-tests-in-separate-projects.md
+++ b/documentation/adr/0004-cpp-tests-in-separate-projects.md
@@ -1,0 +1,55 @@
+[<-previous](0003-use-cmake-for-build.md) | next->
+
+# 4 - CPP tests in separate projects
+
+Date: 2019-NOV-20
+
+## Status
+
+Accepted
+
+## Context
+
+A large number of test files will be created  during the project. These should be stored in
+a consistent location across the C++ projects.
+
+A number of options are available:
+
+* filing alongside the source files
+* in a `tests/` folder within the source tree
+* in a `.Tests` project created alongside the application source
+
+## Decision
+
+We will create a parallel directory structure of test projects for each C++ project.
+
+``` file listing
+service\
+  functionOne\
+    CMakeLists.txt
+    ...
+  functionTwo\
+    CMakeLists.txt
+    ...
+  tests\
+    functionOne.Tests\
+      CMakeLists.txt
+      ...
+    functionTwo.Tests\
+      CMakeLists.txt
+      ...
+```
+
+The test projects will include the associated function project as an explicit reference e.g.
+
+```
+target_link_libraries(functionOne.Tests functionOne ...)
+```
+
+This enables the test artifacts and dependencies to be simply excluded from system components that  will be deployed. The separation will also provide a clear cognitive separation between `function` and `function.Test` and support further extension to `function.IntegrationTest`.
+
+## Consequences
+
+* Consistent code layout across project
+* Test code simply excluded from release builds
+* Additional C++ project overhead


### PR DESCRIPTION
Create ADR document decisions about C++ test file layout

@hsautessella can you verify the CMake `target_link_libraries` directive is sufficient

Related to #32 