### PR TITLE
Use Jenkins `unsuccessful` block to post failure statuses

### DIFF
--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -186,7 +186,7 @@ pipeline {
       post_github_status("success", "The build succeeded")
     }
 
-    failure {
+    unsuccessful {
       post_github_status("failure", "The build failed")
     }
 


### PR DESCRIPTION
Previously we were using the "failure" stage to post unsuccessful build, statuses to GitHub, however this block is not entered if the build is manually aborted. This meant that aborted jobs were stuck with the "build running" status on GitHub.

The `unsuccessful` block is entered if the build has any status other than `success` (including `aborted`).

Fixes #150 