### PR TITLE
Refactor and fix combine_sqw C++ unit tests

### DIFF
--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -32,7 +32,7 @@ protected:
     std::ifstream data_file_bin(TEST_FILE_NAME,
                                 std::ios::in | std::ios::binary);
     if (!data_file_bin.is_open()) {
-      throw std::exception("Can not open test data file");
+      throw std::runtime_error("Can not open test data file");
     }
     try {
       // Read npix data

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -496,9 +496,8 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
 
   std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
   std::vector<float> pix_buffer(NUM_PIXBLOCK_COLS * 1000);
-  float *pPix_info = &pix_buffer[0];
 
-  reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
+  reader.get_pix_for_bin(0, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
   EXPECT_EQ(num_bin_pix, 3);
@@ -506,12 +505,12 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
-  reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
+  reader.get_pix_for_bin(127, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 338);
   EXPECT_EQ(num_bin_pix, 0);
 
-  reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num,
+  reader.get_pix_for_bin(126, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
@@ -520,8 +519,8 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
   }
 
   start_buf_pos = 5;
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
-                         pix_start_num, num_bin_pix, false);
+  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pix_buffer.data(),
+                         start_buf_pos, pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
@@ -529,8 +528,8 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
               pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
-                         pix_start_num, num_bin_pix, false);
+  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pix_buffer.data(),
+                         start_buf_pos, pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
@@ -539,7 +538,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
   }
 
   start_buf_pos = 2;
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
+  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pix_buffer.data(), start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
@@ -568,9 +567,8 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
 
   std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
   std::vector<float> pix_buffer(NUM_PIXBLOCK_COLS * 1000);
-  float *pPix_info = &pix_buffer[0];
 
-  reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
+  reader.get_pix_for_bin(0, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
   EXPECT_EQ(num_bin_pix, 3);
@@ -578,12 +576,12 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
-  reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
+  reader.get_pix_for_bin(127, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 338);
   EXPECT_EQ(num_bin_pix, 0);
 
-  reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num,
+  reader.get_pix_for_bin(126, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
@@ -591,8 +589,8 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   start_buf_pos = 5;
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
-                         pix_start_num, num_bin_pix, false);
+  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pix_buffer.data(),
+                         start_buf_pos, pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
@@ -600,8 +598,8 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
               pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
-                         pix_start_num, num_bin_pix, false);
+  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pix_buffer.data(),
+                         start_buf_pos, pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
@@ -610,7 +608,7 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
   }
 
   start_buf_pos = 2;
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
+  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pix_buffer.data(), start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
@@ -639,9 +637,8 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
 
   std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
   std::vector<float> pix_buffer(NUM_PIXBLOCK_COLS * 1000);
-  float *pPix_info = &pix_buffer[0];
 
-  reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
+  reader.get_pix_for_bin(0, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
   EXPECT_EQ(num_bin_pix, 3);
@@ -649,12 +646,12 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
-  reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
+  reader.get_pix_for_bin(127, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 338);
   EXPECT_EQ(num_bin_pix, 0);
 
-  reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num,
+  reader.get_pix_for_bin(126, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
@@ -662,16 +659,16 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   start_buf_pos = 5;
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
-                         pix_start_num, num_bin_pix, false);
+  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pix_buffer.data(),
+                         start_buf_pos, pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
               pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
-                         pix_start_num, num_bin_pix, false);
+  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pix_buffer.data(),
+                         start_buf_pos, pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
@@ -680,7 +677,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
   }
 
   start_buf_pos = 2;
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
+  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pix_buffer.data(), start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
@@ -698,9 +695,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
   file_par.nbin_start_pos = BIN_POS_IN_FILE;
   file_par.pix_start_pos = PIX_POS_IN_FILE;
   file_par.total_NfileBins = NUM_BINS_IN_FILE;
-  std::vector<float> pix_buffer;
-  pix_buffer.resize(this->pixels.size());
-  float *pPix_info = &pix_buffer[0];
+  std::vector<float> pix_buffer(this->pixels.size());
   std::size_t start_buf_pos(0), pix_start_num, num_bin_pix;
   // --------------------------------------------------------------------------------------------
   reader.init(file_par, false, false, 0);
@@ -708,7 +703,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
   auto t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
   for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
-    reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
+    reader.get_pix_for_bin(i, pix_buffer.data(), start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
   }
@@ -728,7 +723,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
   t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
   for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
-    reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
+    reader.get_pix_for_bin(i, pix_buffer.data(), start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
   }
@@ -749,7 +744,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
   t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
   for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
-    reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
+    reader.get_pix_for_bin(i, pix_buffer.data(), start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
   }
@@ -769,7 +764,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
   t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
   for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
-    reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
+    reader.get_pix_for_bin(i, pix_buffer.data(), start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
   }

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -50,7 +50,7 @@ protected:
 
   // Called once, before the first test is executed.
   static void SetUpTestSuite() {
-    std::string HORACE_ROOT {
+    std::string HORACE_ROOT{
         Environment::get_env_variable(Environment::HORACE_ROOT, ".")};
     test_file_name = HORACE_ROOT + "/_test/test_symmetrisation/w3d_sqw.sqw";
     num_bin_in_file = 472392;
@@ -161,669 +161,729 @@ TEST_F(TestCombineSQW, Read_NBins) {
 }
 
 TEST_F(TestCombineSQW, Get_NPix_For_Bins) {
-    // test_get_npix_for_bins
-    pix_mem_map pix_map;
+  // test_get_npix_for_bins
+  pix_mem_map pix_map;
 
-    pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 0, false);
+  pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 0,
+               false);
 
-    // number of pixels in file is unknown
-    ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
+  // number of pixels in file is unknown
+  ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
-    size_t pix_start, npix;
-    pix_map.get_npix_for_bin(0, pix_start, npix);
-    ASSERT_EQ(0, pix_start);
-    ASSERT_EQ(sample_npix[0], npix);
+  size_t pix_start, npix;
+  pix_map.get_npix_for_bin(0, pix_start, npix);
+  ASSERT_EQ(0, pix_start);
+  ASSERT_EQ(sample_npix[0], npix);
 
-    pix_map.get_npix_for_bin(114, pix_start, npix);
-    ASSERT_EQ(sample_npix[114], npix);
-    ASSERT_EQ(sample_pix_pos[114], pix_start);
+  pix_map.get_npix_for_bin(114, pix_start, npix);
+  ASSERT_EQ(sample_npix[114], npix);
+  ASSERT_EQ(sample_pix_pos[114], pix_start);
 
-    pix_map.get_npix_for_bin(511, pix_start, npix);
-    ASSERT_EQ(sample_npix[511], npix);
-    ASSERT_EQ(sample_pix_pos[511], pix_start);
+  pix_map.get_npix_for_bin(511, pix_start, npix);
+  ASSERT_EQ(sample_npix[511], npix);
+  ASSERT_EQ(sample_pix_pos[511], pix_start);
 
-    pix_map.get_npix_for_bin(600, pix_start, npix);
-    ASSERT_EQ(sample_npix[600], npix);
-    ASSERT_EQ(sample_pix_pos[600], pix_start);
+  pix_map.get_npix_for_bin(600, pix_start, npix);
+  ASSERT_EQ(sample_npix[600], npix);
+  ASSERT_EQ(sample_pix_pos[600], pix_start);
 
-    pix_map.get_npix_for_bin(2400, pix_start, npix);
-    ASSERT_EQ(sample_npix[2400], npix);
-    ASSERT_EQ(sample_pix_pos[2400], pix_start);
+  pix_map.get_npix_for_bin(2400, pix_start, npix);
+  ASSERT_EQ(sample_npix[2400], npix);
+  ASSERT_EQ(sample_pix_pos[2400], pix_start);
 
-    // number of pixels in file is unknown
-    ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
-    pix_map.get_npix_for_bin(2, pix_start, npix);
+  // number of pixels in file is unknown
+  ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
+  pix_map.get_npix_for_bin(2, pix_start, npix);
 
-    ASSERT_EQ(sample_npix[2], npix);
-    ASSERT_EQ(sample_pix_pos[2], pix_start);
+  ASSERT_EQ(sample_npix[2], npix);
+  ASSERT_EQ(sample_pix_pos[2], pix_start);
 
-    pix_map.get_npix_for_bin(num_bin_in_file - 2, pix_start, npix);
-    ASSERT_EQ(sample_npix[num_bin_in_file - 2], 0);
-    ASSERT_EQ(sample_pix_pos[num_bin_in_file - 2], pix_start);
+  pix_map.get_npix_for_bin(num_bin_in_file - 2, pix_start, npix);
+  ASSERT_EQ(sample_npix[num_bin_in_file - 2], 0);
+  ASSERT_EQ(sample_pix_pos[num_bin_in_file - 2], pix_start);
 
-    // number of pixels in file is known
-    ASSERT_NE(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
+  // number of pixels in file is known
+  ASSERT_NE(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
-    ASSERT_EQ(pix_map.num_pix_in_file(), sample_pix_pos[num_bin_in_file - 1] + sample_npix[num_bin_in_file - 1]);
+  ASSERT_EQ(pix_map.num_pix_in_file(), sample_pix_pos[num_bin_in_file - 1] +
+                                           sample_npix[num_bin_in_file - 1]);
 }
 
 TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start) {
-    pix_mem_map pix_map;
+  pix_mem_map pix_map;
 
-    pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512, false);
+  pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512,
+               false);
 
-    bool end_pix_reached;
-    size_t num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
-    ASSERT_FALSE(end_pix_reached);
-    ASSERT_EQ(512, num_pix);
+  bool end_pix_reached;
+  size_t num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
+  ASSERT_FALSE(end_pix_reached);
+  ASSERT_EQ(512, num_pix);
 
-    // Read whole map in memory requesting map for much bigger number of npixels then the real npix number in the file.
-    num_pix = pix_map.check_expand_pix_map(0, 2 * 1164180, end_pix_reached);
-    // the file contains
-    ASSERT_EQ(sample_pix_pos[num_bin_in_file - 1] + sample_npix[num_bin_in_file - 1], num_pix);
-    ASSERT_TRUE(end_pix_reached);
-    // check whole map is loaded in memory
-    size_t first_mem_bin, last_mem_bin, n_tot_bins;
-    pix_map.get_map_param(first_mem_bin, last_mem_bin, n_tot_bins);
-    ASSERT_EQ(first_mem_bin, 0);
-    ASSERT_EQ(last_mem_bin, n_tot_bins);
-    ASSERT_EQ(last_mem_bin, num_bin_in_file);
+  // Read whole map in memory requesting map for much bigger number of npixels
+  // then the real npix number in the file.
+  num_pix = pix_map.check_expand_pix_map(0, 2 * 1164180, end_pix_reached);
+  // the file contains
+  ASSERT_EQ(sample_pix_pos[num_bin_in_file - 1] +
+                sample_npix[num_bin_in_file - 1],
+            num_pix);
+  ASSERT_TRUE(end_pix_reached);
+  // check whole map is loaded in memory
+  size_t first_mem_bin, last_mem_bin, n_tot_bins;
+  pix_map.get_map_param(first_mem_bin, last_mem_bin, n_tot_bins);
+  ASSERT_EQ(first_mem_bin, 0);
+  ASSERT_EQ(last_mem_bin, n_tot_bins);
+  ASSERT_EQ(last_mem_bin, num_bin_in_file);
 
-    for (size_t i = 0; i < num_bin_in_file; i++) {
-        size_t pix_start, npix;
-        pix_map.get_npix_for_bin(i, pix_start, npix);
-        ASSERT_EQ(pix_start, sample_pix_pos[i]);
-        ASSERT_EQ(npix, sample_npix[i]);
-    }
-    ASSERT_EQ(pix_map.num_pix_in_file(), num_pix);
+  for (size_t i = 0; i < num_bin_in_file; i++) {
+    size_t pix_start, npix;
+    pix_map.get_npix_for_bin(i, pix_start, npix);
+    ASSERT_EQ(pix_start, sample_pix_pos[i]);
+    ASSERT_EQ(npix, sample_npix[i]);
+  }
+  ASSERT_EQ(pix_map.num_pix_in_file(), num_pix);
 }
 
 TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
-    pix_mem_map pix_map;
+  pix_mem_map pix_map;
 
-    pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512, false);
+  pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512,
+               false);
 
-    bool end_pix_reached;
-    size_t num_pix0 = pix_map.check_expand_pix_map(511, 512, end_pix_reached);
-    ASSERT_FALSE(end_pix_reached);
-    ASSERT_EQ(510, num_pix0);
+  bool end_pix_reached;
+  size_t num_pix0 = pix_map.check_expand_pix_map(511, 512, end_pix_reached);
+  ASSERT_FALSE(end_pix_reached);
+  ASSERT_EQ(510, num_pix0);
 
-    size_t pix_pos, npix;
-    pix_map.get_npix_for_bin(511, pix_pos, npix);
-    ASSERT_EQ(sample_pix_pos[511], pix_pos);
-    ASSERT_EQ(sample_npix[511], npix);
+  size_t pix_pos, npix;
+  pix_map.get_npix_for_bin(511, pix_pos, npix);
+  ASSERT_EQ(sample_pix_pos[511], pix_pos);
+  ASSERT_EQ(sample_npix[511], npix);
 
-    // Read whole map in memory requesting map for much bigger number of npixels then the real npix number in the file.
-    size_t num_pix = pix_map.check_expand_pix_map(512, 2 * 1164180, end_pix_reached);
-    // the file contains
-    ASSERT_EQ(sample_pix_pos[num_bin_in_file - 1] + sample_npix[num_bin_in_file - 1] - pix_pos - npix, num_pix);
-    ASSERT_TRUE(end_pix_reached);
+  // Read whole map in memory requesting map for much bigger number of npixels
+  // then the real npix number in the file.
+  size_t num_pix =
+      pix_map.check_expand_pix_map(512, 2 * 1164180, end_pix_reached);
+  // the file contains
+  ASSERT_EQ(sample_pix_pos[num_bin_in_file - 1] +
+                sample_npix[num_bin_in_file - 1] - pix_pos - npix,
+            num_pix);
+  ASSERT_TRUE(end_pix_reached);
 
-    for (size_t i = 512; i < num_bin_in_file; i++) {
-        size_t pix_start, npix;
-        pix_map.get_npix_for_bin(i, pix_start, npix);
-        ASSERT_EQ(pix_start, sample_pix_pos[i]);
-        ASSERT_EQ(npix, sample_npix[i]);
+  for (size_t i = 512; i < num_bin_in_file; i++) {
+    size_t pix_start, npix;
+    pix_map.get_npix_for_bin(i, pix_start, npix);
+    ASSERT_EQ(pix_start, sample_pix_pos[i]);
+    ASSERT_EQ(npix, sample_npix[i]);
+  }
+  ASSERT_EQ(pix_map.num_pix_in_file(), num_pix + pix_pos + npix);
 
-    }
-    ASSERT_EQ(pix_map.num_pix_in_file(), num_pix + pix_pos + npix);
+  num_pix = pix_map.check_expand_pix_map(512, 512, end_pix_reached);
+  ASSERT_FALSE(end_pix_reached);
+  ASSERT_EQ(512, num_pix);
 
-    num_pix = pix_map.check_expand_pix_map(512, 512, end_pix_reached);
-    ASSERT_FALSE(end_pix_reached);
-    ASSERT_EQ(512, num_pix);
+  num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
+  ASSERT_FALSE(end_pix_reached);
+  ASSERT_EQ(512, num_pix);
 
-    num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
-    ASSERT_FALSE(end_pix_reached);
-    ASSERT_EQ(512, num_pix);
-
-    pix_map.get_npix_for_bin(512 + 4, pix_pos, npix);
-    ASSERT_EQ(sample_pix_pos[512 + 4], pix_pos);
-    ASSERT_EQ(sample_npix[512 + 4], npix);
+  pix_map.get_npix_for_bin(512 + 4, pix_pos, npix);
+  ASSERT_EQ(sample_pix_pos[512 + 4], pix_pos);
+  ASSERT_EQ(sample_npix[512 + 4], npix);
 }
 
 TEST_F(TestCombineSQW, Normal_Expand_Mode) {
-    pix_mem_map pix_map;
+  pix_mem_map pix_map;
 
-    pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512, false);
-    size_t pix_pos, npix;
-    pix_map.get_npix_for_bin(0, pix_pos, npix);
-    ASSERT_EQ(sample_pix_pos[0], pix_pos);
-    ASSERT_EQ(sample_npix[0], npix);
+  pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512,
+               false);
+  size_t pix_pos, npix;
+  pix_map.get_npix_for_bin(0, pix_pos, npix);
+  ASSERT_EQ(sample_pix_pos[0], pix_pos);
+  ASSERT_EQ(sample_npix[0], npix);
 
-    bool end_pix_reached;
+  bool end_pix_reached;
 
-    size_t bin_num(0), pix_buf_size(512), num_pix, ic(0);
-    while (bin_num < num_bin_in_file - pix_buf_size) {
-        bin_num += pix_buf_size;
-        pix_map.get_npix_for_bin(bin_num, pix_pos, npix);
-        size_t n_pix = pix_map.num_pix_described(bin_num);
-        if (n_pix < pix_buf_size) {
-            num_pix = pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
-        }
-        ASSERT_EQ(sample_pix_pos[bin_num], pix_pos);
-        ASSERT_EQ(sample_npix[bin_num], npix);
-        ic++;
+  size_t bin_num(0), pix_buf_size(512), num_pix, ic(0);
+  while (bin_num < num_bin_in_file - pix_buf_size) {
+    bin_num += pix_buf_size;
+    pix_map.get_npix_for_bin(bin_num, pix_pos, npix);
+    size_t n_pix = pix_map.num_pix_described(bin_num);
+    if (n_pix < pix_buf_size) {
+      num_pix =
+          pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
     }
+    ASSERT_EQ(sample_pix_pos[bin_num], pix_pos);
+    ASSERT_EQ(sample_npix[bin_num], npix);
+    ic++;
+  }
 }
 
 TEST_F(TestCombineSQW, Thread_Job) {
-    pix_map_tester pix_map;
-    pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 0, true);
-    size_t first_th_bin,last_tr_bin,buf_end;
+  pix_map_tester pix_map;
+  pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 0, true);
+  size_t first_th_bin, last_tr_bin, buf_end;
 
-    pix_map.thread_query_data(first_th_bin, last_tr_bin, buf_end);
-    ASSERT_EQ(first_th_bin,0);
-    ASSERT_EQ(last_tr_bin, 1024);
-    ASSERT_EQ(buf_end,1024);
+  pix_map.thread_query_data(first_th_bin, last_tr_bin, buf_end);
+  ASSERT_EQ(first_th_bin, 0);
+  ASSERT_EQ(last_tr_bin, 1024);
+  ASSERT_EQ(buf_end, 1024);
 
-    pix_map.thread_request_to_read(1600);
-    pix_map.thread_query_data(first_th_bin, last_tr_bin, buf_end);
-    ASSERT_EQ(first_th_bin, 1600);
-    ASSERT_EQ(last_tr_bin, 1600+1024);
-    ASSERT_EQ(buf_end, 1024);
+  pix_map.thread_request_to_read(1600);
+  pix_map.thread_query_data(first_th_bin, last_tr_bin, buf_end);
+  ASSERT_EQ(first_th_bin, 1600);
+  ASSERT_EQ(last_tr_bin, 1600 + 1024);
+  ASSERT_EQ(buf_end, 1024);
 
-    std::vector<pix_mem_map::bin_info> buf;
-    pix_map.thread_get_data(first_th_bin, buf,last_tr_bin, buf_end);
+  std::vector<pix_mem_map::bin_info> buf;
+  pix_map.thread_get_data(first_th_bin, buf, last_tr_bin, buf_end);
 
-    pix_map.thread_query_data(first_th_bin, last_tr_bin, buf_end);
-    ASSERT_EQ(first_th_bin, 1024+1600);
-    ASSERT_EQ(last_tr_bin, 1600 + 2048);
-    ASSERT_EQ(buf_end, 1024);
+  pix_map.thread_query_data(first_th_bin, last_tr_bin, buf_end);
+  ASSERT_EQ(first_th_bin, 1024 + 1600);
+  ASSERT_EQ(last_tr_bin, 1600 + 2048);
+  ASSERT_EQ(buf_end, 1024);
 }
 
 TEST_F(TestCombineSQW, Get_NPix_For_Bins_Threads) {
-    pix_mem_map pix_map;
+  pix_mem_map pix_map;
 
-    pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 0, true);
+  pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 0, true);
 
-    // number of pixels in file is unknown
-    ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
+  // number of pixels in file is unknown
+  ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
-    size_t pix_start, npix;
-    pix_map.get_npix_for_bin(0, pix_start, npix);
-    ASSERT_EQ(0, pix_start);
-    ASSERT_EQ(sample_npix[0], npix);
+  size_t pix_start, npix;
+  pix_map.get_npix_for_bin(0, pix_start, npix);
+  ASSERT_EQ(0, pix_start);
+  ASSERT_EQ(sample_npix[0], npix);
 
-    pix_map.get_npix_for_bin(114, pix_start, npix);
-    ASSERT_EQ(sample_npix[114], npix);
-    ASSERT_EQ(sample_pix_pos[114], pix_start);
+  pix_map.get_npix_for_bin(114, pix_start, npix);
+  ASSERT_EQ(sample_npix[114], npix);
+  ASSERT_EQ(sample_pix_pos[114], pix_start);
 
-    pix_map.get_npix_for_bin(511, pix_start, npix);
-    ASSERT_EQ(sample_npix[511], npix);
-    ASSERT_EQ(sample_pix_pos[511], pix_start);
+  pix_map.get_npix_for_bin(511, pix_start, npix);
+  ASSERT_EQ(sample_npix[511], npix);
+  ASSERT_EQ(sample_pix_pos[511], pix_start);
 
-    pix_map.get_npix_for_bin(600, pix_start, npix);
-    ASSERT_EQ(sample_npix[600], npix);
-    ASSERT_EQ(sample_pix_pos[600], pix_start);
+  pix_map.get_npix_for_bin(600, pix_start, npix);
+  ASSERT_EQ(sample_npix[600], npix);
+  ASSERT_EQ(sample_pix_pos[600], pix_start);
 
-    pix_map.get_npix_for_bin(2400, pix_start, npix);
-    ASSERT_EQ(sample_npix[2400], npix);
-    ASSERT_EQ(sample_pix_pos[2400], pix_start);
+  pix_map.get_npix_for_bin(2400, pix_start, npix);
+  ASSERT_EQ(sample_npix[2400], npix);
+  ASSERT_EQ(sample_pix_pos[2400], pix_start);
 
-    // number of pixels in file is unknown
-    ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
+  // number of pixels in file is unknown
+  ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
-    pix_map.get_npix_for_bin(2, pix_start, npix);
-    ASSERT_EQ(sample_npix[2], npix);
-    ASSERT_EQ(sample_pix_pos[2], pix_start);
+  pix_map.get_npix_for_bin(2, pix_start, npix);
+  ASSERT_EQ(sample_npix[2], npix);
+  ASSERT_EQ(sample_pix_pos[2], pix_start);
 
-    pix_map.get_npix_for_bin(num_bin_in_file - 2, pix_start, npix);
-    ASSERT_EQ(sample_npix[num_bin_in_file - 2], 0);
-    ASSERT_EQ(sample_pix_pos[num_bin_in_file - 2], pix_start);
+  pix_map.get_npix_for_bin(num_bin_in_file - 2, pix_start, npix);
+  ASSERT_EQ(sample_npix[num_bin_in_file - 2], 0);
+  ASSERT_EQ(sample_pix_pos[num_bin_in_file - 2], pix_start);
 
-    // number of pixels in file is known
-    ASSERT_NE(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
+  // number of pixels in file is known
+  ASSERT_NE(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
-    ASSERT_EQ(pix_map.num_pix_in_file(), sample_pix_pos[num_bin_in_file - 1] + sample_npix[num_bin_in_file - 1]);
+  ASSERT_EQ(pix_map.num_pix_in_file(), sample_pix_pos[num_bin_in_file - 1] +
+                                           sample_npix[num_bin_in_file - 1]);
 }
 
 TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start_Threads) {
-    pix_mem_map pix_map;
+  pix_mem_map pix_map;
 
-    pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512, true);
+  pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512,
+               true);
 
-    bool end_pix_reached;
-    size_t num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
-    ASSERT_FALSE(end_pix_reached);
-    ASSERT_EQ(512, num_pix);
+  bool end_pix_reached;
+  size_t num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
+  ASSERT_FALSE(end_pix_reached);
+  ASSERT_EQ(512, num_pix);
 
-    // Read whole map in memory requesting map for much bigger number of npixels then the real npix number in the file.
-    num_pix = pix_map.check_expand_pix_map(0, 2 * 1164180, end_pix_reached);
-    // the file contains
-    ASSERT_EQ(sample_pix_pos[num_bin_in_file - 1] + sample_npix[num_bin_in_file - 1], num_pix);
-    ASSERT_TRUE(end_pix_reached);
-    // check whole map is loaded in memory
-    size_t first_mem_bin, last_mem_bin, n_tot_bins;
-    pix_map.get_map_param(first_mem_bin, last_mem_bin, n_tot_bins);
-    ASSERT_EQ(first_mem_bin,0);
-    ASSERT_EQ(last_mem_bin, n_tot_bins);
-    ASSERT_EQ(last_mem_bin, num_bin_in_file);
+  // Read whole map in memory requesting map for much bigger number of npixels
+  // then the real npix number in the file.
+  num_pix = pix_map.check_expand_pix_map(0, 2 * 1164180, end_pix_reached);
+  // the file contains
+  ASSERT_EQ(sample_pix_pos[num_bin_in_file - 1] +
+                sample_npix[num_bin_in_file - 1],
+            num_pix);
+  ASSERT_TRUE(end_pix_reached);
+  // check whole map is loaded in memory
+  size_t first_mem_bin, last_mem_bin, n_tot_bins;
+  pix_map.get_map_param(first_mem_bin, last_mem_bin, n_tot_bins);
+  ASSERT_EQ(first_mem_bin, 0);
+  ASSERT_EQ(last_mem_bin, n_tot_bins);
+  ASSERT_EQ(last_mem_bin, num_bin_in_file);
 
-    for (size_t i = 0; i < num_bin_in_file; i++) {
-        size_t pix_start, npix;
-        pix_map.get_npix_for_bin(i, pix_start, npix);
-        ASSERT_EQ(pix_start, sample_pix_pos[i]);
-        ASSERT_EQ(npix, sample_npix[i]);
-
-    }
-    ASSERT_EQ(pix_map.num_pix_in_file(), num_pix);
+  for (size_t i = 0; i < num_bin_in_file; i++) {
+    size_t pix_start, npix;
+    pix_map.get_npix_for_bin(i, pix_start, npix);
+    ASSERT_EQ(pix_start, sample_pix_pos[i]);
+    ASSERT_EQ(npix, sample_npix[i]);
+  }
+  ASSERT_EQ(pix_map.num_pix_in_file(), num_pix);
 }
 
 TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
-    pix_mem_map pix_map;
-    pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512, true);
+  pix_mem_map pix_map;
+  pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512,
+               true);
 
-    bool end_pix_reached;
-    size_t num_pix1 = pix_map.check_expand_pix_map(511, 512, end_pix_reached);
-    ASSERT_FALSE(end_pix_reached);
-    ASSERT_EQ(510, num_pix1);
+  bool end_pix_reached;
+  size_t num_pix1 = pix_map.check_expand_pix_map(511, 512, end_pix_reached);
+  ASSERT_FALSE(end_pix_reached);
+  ASSERT_EQ(510, num_pix1);
 
-    size_t pix_pos, npix;
-    pix_map.get_npix_for_bin(511, pix_pos, npix);
-    ASSERT_EQ(sample_pix_pos[511], pix_pos);
-    ASSERT_EQ(sample_npix[511], npix);
+  size_t pix_pos, npix;
+  pix_map.get_npix_for_bin(511, pix_pos, npix);
+  ASSERT_EQ(sample_pix_pos[511], pix_pos);
+  ASSERT_EQ(sample_npix[511], npix);
 
-    // Read whole map in memory requesting map for much bigger number of npixels then the real npix number in the file.
-    size_t num_pix = pix_map.check_expand_pix_map(512, 2 * 1164180, end_pix_reached);
-    // the file contains
-    ASSERT_EQ(sample_pix_pos[num_bin_in_file - 1] + sample_npix[num_bin_in_file - 1] - pix_pos - npix, num_pix);
-    ASSERT_TRUE(end_pix_reached);
+  // Read whole map in memory requesting map for much bigger number of npixels
+  // then the real npix number in the file.
+  size_t num_pix =
+      pix_map.check_expand_pix_map(512, 2 * 1164180, end_pix_reached);
+  // the file contains
+  ASSERT_EQ(sample_pix_pos[num_bin_in_file - 1] +
+                sample_npix[num_bin_in_file - 1] - pix_pos - npix,
+            num_pix);
+  ASSERT_TRUE(end_pix_reached);
 
-    for (size_t i = 512; i < num_bin_in_file; i++) {
-        size_t pix_start, npix;
-        pix_map.get_npix_for_bin(i, pix_start, npix);
-        ASSERT_EQ(pix_start, sample_pix_pos[i]);
-        ASSERT_EQ(npix, sample_npix[i]);
-    }
-    ASSERT_EQ(pix_map.num_pix_in_file(), num_pix + pix_pos + npix);
+  for (size_t i = 512; i < num_bin_in_file; i++) {
+    size_t pix_start, npix;
+    pix_map.get_npix_for_bin(i, pix_start, npix);
+    ASSERT_EQ(pix_start, sample_pix_pos[i]);
+    ASSERT_EQ(npix, sample_npix[i]);
+  }
+  ASSERT_EQ(pix_map.num_pix_in_file(), num_pix + pix_pos + npix);
 
-    num_pix = pix_map.check_expand_pix_map(512, 512, end_pix_reached);
-    ASSERT_FALSE(end_pix_reached);
-    ASSERT_EQ(512, num_pix);
+  num_pix = pix_map.check_expand_pix_map(512, 512, end_pix_reached);
+  ASSERT_FALSE(end_pix_reached);
+  ASSERT_EQ(512, num_pix);
 
-    num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
-    ASSERT_FALSE(end_pix_reached);
-    ASSERT_EQ(512, num_pix);
+  num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
+  ASSERT_FALSE(end_pix_reached);
+  ASSERT_EQ(512, num_pix);
 
-    pix_map.get_npix_for_bin(512 + 4, pix_pos, npix);
-    ASSERT_EQ(sample_pix_pos[512 + 4], pix_pos);
-    ASSERT_EQ(sample_npix[512 + 4], npix);
+  pix_map.get_npix_for_bin(512 + 4, pix_pos, npix);
+  ASSERT_EQ(sample_pix_pos[512 + 4], pix_pos);
+  ASSERT_EQ(sample_npix[512 + 4], npix);
 }
 
 TEST_F(TestCombineSQW, Normal_Expand_Mode_Threads) {
-    pix_mem_map pix_map;
-    pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512, true);
+  pix_mem_map pix_map;
+  pix_map.init(this->test_file_name, bin_pos_in_file, num_bin_in_file, 512,
+               true);
 
-    size_t pix_pos, npix;
-    pix_map.get_npix_for_bin(0, pix_pos, npix);
-    ASSERT_EQ(sample_pix_pos[0], pix_pos);
-    ASSERT_EQ(sample_npix[0], npix);
+  size_t pix_pos, npix;
+  pix_map.get_npix_for_bin(0, pix_pos, npix);
+  ASSERT_EQ(sample_pix_pos[0], pix_pos);
+  ASSERT_EQ(sample_npix[0], npix);
 
-    bool end_pix_reached;
+  bool end_pix_reached;
 
-    size_t bin_num(0), pix_buf_size(512), num_pix, ic(0);
-    while (bin_num < num_bin_in_file - pix_buf_size) {
-        bin_num += pix_buf_size;
-        pix_map.get_npix_for_bin(bin_num, pix_pos, npix);
-        size_t n_pix = pix_map.num_pix_described(bin_num);
-        if (n_pix < pix_buf_size) {
-            num_pix = pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
-        }
-        ASSERT_EQ(sample_pix_pos[bin_num], pix_pos);
-        ASSERT_EQ(sample_npix[bin_num], npix);
-        ic++;
+  size_t bin_num(0), pix_buf_size(512), num_pix, ic(0);
+  while (bin_num < num_bin_in_file - pix_buf_size) {
+    bin_num += pix_buf_size;
+    pix_map.get_npix_for_bin(bin_num, pix_pos, npix);
+    size_t n_pix = pix_map.num_pix_described(bin_num);
+    if (n_pix < pix_buf_size) {
+      num_pix =
+          pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
     }
+    ASSERT_EQ(sample_pix_pos[bin_num], pix_pos);
+    ASSERT_EQ(sample_npix[bin_num], npix);
+    ic++;
+  }
 }
 
 TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
-    sqw_reader reader;
-    fileParameters file_par;
-    file_par.fileName = test_file_name;
-    file_par.file_id = 0;
-    file_par.nbin_start_pos = bin_pos_in_file;
-    file_par.pix_start_pos = pix_pos_in_file;
-    file_par.total_NfileBins = num_bin_in_file;
-    bool initialized(false);
-    try {
-        reader.init(file_par, false, false, 128);
-        initialized = true;
-    }
-    catch (...) {}
+  sqw_reader reader;
+  fileParameters file_par;
+  file_par.fileName = test_file_name;
+  file_par.file_id = 0;
+  file_par.nbin_start_pos = bin_pos_in_file;
+  file_par.pix_start_pos = pix_pos_in_file;
+  file_par.total_NfileBins = num_bin_in_file;
+  bool initialized(false);
+  try {
+    reader.init(file_par, false, false, 128);
+    initialized = true;
+  } catch (...) {
+  }
 
-    ASSERT_TRUE(initialized);
+  ASSERT_TRUE(initialized);
 
-    size_t pix_start_num, num_bin_pix,start_buf_pos(0);
-    std::vector<float> pix_buffer(9*1000);
-    float *pPix_info = &pix_buffer[0];
+  size_t pix_start_num, num_bin_pix, start_buf_pos(0);
+  std::vector<float> pix_buffer(9 * 1000);
+  float *pPix_info = &pix_buffer[0];
 
-    reader.get_pix_for_bin(0,pPix_info, start_buf_pos,pix_start_num,num_bin_pix,false);
-    ASSERT_EQ(pix_start_num,0);
-    ASSERT_EQ(num_bin_pix, 3);
-    for(size_t i=0;i<num_bin_pix *9;i++){
-        ASSERT_EQ(pixels[pix_start_num*9+i], pix_buffer[i]);
-    }
-    // pix buffer have not changed at all
-    reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, 338);
-    ASSERT_EQ(num_bin_pix, 0);
+  reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
+                         num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, 0);
+  ASSERT_EQ(num_bin_pix, 3);
+  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  }
+  // pix buffer have not changed at all
+  reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
+                         num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, 338);
+  ASSERT_EQ(num_bin_pix, 0);
 
-    reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, 334);
-    ASSERT_EQ(num_bin_pix, 4);
-    // DISABLED
-    // for (size_t i = 0; i<num_bin_pix * 9; i++) {
-    //     ASSERT_EQ(pixels[pix_start_num*9+i], pix_buffer[i]);
-    // }
+  reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num,
+                         num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, 334);
+  ASSERT_EQ(num_bin_pix, 4);
+  // DISABLED
+  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  //     ASSERT_EQ(pixels[pix_start_num*9+i], pix_buffer[i]);
+  // }
 
-    start_buf_pos = 5;
-    reader.get_pix_for_bin(num_bin_in_file-860, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 860]);
-    ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 860]);
-    // DISABLED
-    // for (size_t i = 0; i<num_bin_pix * 9; i++) {
-    //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos*9 + i]);
-    // }
-    //
-    // reader.get_pix_for_bin(num_bin_in_file - 860+1, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    // ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 860+1]);
-    // ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 860+1]);
-    // for (size_t i = 0; i<num_bin_pix * 9; i++) {
-    //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
-    // }
+  start_buf_pos = 5;
+  reader.get_pix_for_bin(num_bin_in_file - 860, pPix_info, start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 860]);
+  ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 860]);
+  // DISABLED
+  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos*9 +
+  //     i]);
+  // }
+  //
+  // reader.get_pix_for_bin(num_bin_in_file - 860+1, pPix_info, start_buf_pos,
+  // pix_start_num, num_bin_pix, false); ASSERT_EQ(pix_start_num,
+  // sample_pix_pos[num_bin_in_file - 860+1]); ASSERT_EQ(num_bin_pix,
+  // sample_npix[num_bin_in_file - 860+1]); for (size_t i = 0; i<num_bin_pix *
+  // 9; i++) {
+  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+  //     i]);
+  // }
 
-    start_buf_pos = 2;
-    reader.get_pix_for_bin(num_bin_in_file - 1, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 1]);
-    ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 1]);
-    for (size_t i = 0; i<num_bin_pix * 9; i++) {
-        ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
-    }
+  start_buf_pos = 2;
+  reader.get_pix_for_bin(num_bin_in_file - 1, pPix_info, start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 1]);
+  ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 1]);
+  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  }
 }
 
 TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
-    sqw_reader reader;
-    fileParameters file_par;
-    file_par.fileName = test_file_name;
-    file_par.file_id = 0;
-    file_par.nbin_start_pos = bin_pos_in_file;
-    file_par.pix_start_pos = pix_pos_in_file;
-    file_par.total_NfileBins = num_bin_in_file;
-    bool initialized(false);
-    try {
-        reader.init(file_par, false, false, 0);
-        initialized = true;
-    }
-    catch (...) {}
+  sqw_reader reader;
+  fileParameters file_par;
+  file_par.fileName = test_file_name;
+  file_par.file_id = 0;
+  file_par.nbin_start_pos = bin_pos_in_file;
+  file_par.pix_start_pos = pix_pos_in_file;
+  file_par.total_NfileBins = num_bin_in_file;
+  bool initialized(false);
+  try {
+    reader.init(file_par, false, false, 0);
+    initialized = true;
+  } catch (...) {
+  }
 
-    ASSERT_TRUE(initialized);
+  ASSERT_TRUE(initialized);
 
-    size_t pix_start_num, num_bin_pix, start_buf_pos(0);
-    std::vector<float> pix_buffer(9 * 1000);
-    float *pPix_info = &pix_buffer[0];
+  size_t pix_start_num, num_bin_pix, start_buf_pos(0);
+  std::vector<float> pix_buffer(9 * 1000);
+  float *pPix_info = &pix_buffer[0];
 
-    reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, 0);
-    ASSERT_EQ(num_bin_pix, 3);
-    for (size_t i = 0; i<num_bin_pix * 9; i++) {
-        ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
-    }
-    // pix buffer have not changed at all
-    reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, 338);
-    ASSERT_EQ(num_bin_pix, 0);
+  reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
+                         num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, 0);
+  ASSERT_EQ(num_bin_pix, 3);
+  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  }
+  // pix buffer have not changed at all
+  reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
+                         num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, 338);
+  ASSERT_EQ(num_bin_pix, 0);
 
-    reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, 334);
-    ASSERT_EQ(num_bin_pix, 4);
-    // DISABLED
-    // for (size_t i = 0; i<num_bin_pix * 9; i++) {
-    //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
-    // }
-    start_buf_pos = 5;
-    reader.get_pix_for_bin(num_bin_in_file - 860, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 860]);
-    ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 860]);
-    // DISABLED
-    // for (size_t i = 0; i<num_bin_pix * 9; i++) {
-    //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
-    // }
+  reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num,
+                         num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, 334);
+  ASSERT_EQ(num_bin_pix, 4);
+  // DISABLED
+  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  // }
+  start_buf_pos = 5;
+  reader.get_pix_for_bin(num_bin_in_file - 860, pPix_info, start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 860]);
+  ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 860]);
+  // DISABLED
+  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+  //     i]);
+  // }
 
-    reader.get_pix_for_bin(num_bin_in_file - 860 + 1, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 860 + 1]);
-    ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 860 + 1]);
-    // DISABLED
-    // for (size_t i = 0; i<num_bin_pix * 9; i++) {
-    //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
-    // }
+  reader.get_pix_for_bin(num_bin_in_file - 860 + 1, pPix_info, start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 860 + 1]);
+  ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 860 + 1]);
+  // DISABLED
+  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+  //     i]);
+  // }
 
-    start_buf_pos = 2;
-    reader.get_pix_for_bin(num_bin_in_file - 1, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 1]);
-    ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 1]);
-    for (size_t i = 0; i<num_bin_pix * 9; i++) {
-        ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
-    }
+  start_buf_pos = 2;
+  reader.get_pix_for_bin(num_bin_in_file - 1, pPix_info, start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 1]);
+  ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 1]);
+  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  }
 }
 
 TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
-    sqw_reader reader;
-    fileParameters file_par;
-    file_par.fileName = test_file_name;
-    file_par.file_id = 0;
-    file_par.nbin_start_pos = bin_pos_in_file;
-    file_par.pix_start_pos = pix_pos_in_file;
-    file_par.total_NfileBins = num_bin_in_file;
-    bool initialized(false);
-    try {
-        reader.init(file_par, false, false, 128,1);
-        initialized = true;
-    }
-    catch (...) {}
+  sqw_reader reader;
+  fileParameters file_par;
+  file_par.fileName = test_file_name;
+  file_par.file_id = 0;
+  file_par.nbin_start_pos = bin_pos_in_file;
+  file_par.pix_start_pos = pix_pos_in_file;
+  file_par.total_NfileBins = num_bin_in_file;
+  bool initialized(false);
+  try {
+    reader.init(file_par, false, false, 128, 1);
+    initialized = true;
+  } catch (...) {
+  }
 
-    ASSERT_TRUE(initialized);
+  ASSERT_TRUE(initialized);
 
-    size_t pix_start_num, num_bin_pix, start_buf_pos(0);
-    std::vector<float> pix_buffer(9 * 1000);
-    float *pPix_info = &pix_buffer[0];
+  size_t pix_start_num, num_bin_pix, start_buf_pos(0);
+  std::vector<float> pix_buffer(9 * 1000);
+  float *pPix_info = &pix_buffer[0];
 
-    reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, 0);
-    ASSERT_EQ(num_bin_pix, 3);
-    for (size_t i = 0; i<num_bin_pix * 9; i++) {
-        ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
-    }
-    // pix buffer have not changed at all
-    reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, 338);
-    ASSERT_EQ(num_bin_pix, 0);
+  reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
+                         num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, 0);
+  ASSERT_EQ(num_bin_pix, 3);
+  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  }
+  // pix buffer have not changed at all
+  reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
+                         num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, 338);
+  ASSERT_EQ(num_bin_pix, 0);
 
-    reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, 334);
-    ASSERT_EQ(num_bin_pix, 4);
-    // DISABLED
-    // for (size_t i = 0; i<num_bin_pix * 9; i++) {
-    //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
-    // }
-    start_buf_pos = 5;
-    reader.get_pix_for_bin(num_bin_in_file - 860, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 860]);
-    ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 860]);
-    // DISABLED
-    // for (size_t i = 0; i<num_bin_pix * 9; i++) {
-    //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
-    // }
-    reader.get_pix_for_bin(num_bin_in_file - 860 + 1, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 860 + 1]);
-    ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 860 + 1]);
-    // DISABLED
-    // for (size_t i = 0; i<num_bin_pix * 9; i++) {
-    //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
-    // }
+  reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num,
+                         num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, 334);
+  ASSERT_EQ(num_bin_pix, 4);
+  // DISABLED
+  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  // }
+  start_buf_pos = 5;
+  reader.get_pix_for_bin(num_bin_in_file - 860, pPix_info, start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 860]);
+  ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 860]);
+  // DISABLED
+  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+  //     i]);
+  // }
+  reader.get_pix_for_bin(num_bin_in_file - 860 + 1, pPix_info, start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 860 + 1]);
+  ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 860 + 1]);
+  // DISABLED
+  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+  //     i]);
+  // }
 
-    start_buf_pos = 2;
-    reader.get_pix_for_bin(num_bin_in_file - 1, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-    ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 1]);
-    ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 1]);
-    for (size_t i = 0; i<num_bin_pix * 9; i++) {
-        ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
-    }
+  start_buf_pos = 2;
+  reader.get_pix_for_bin(num_bin_in_file - 1, pPix_info, start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  ASSERT_EQ(pix_start_num, sample_pix_pos[num_bin_in_file - 1]);
+  ASSERT_EQ(num_bin_pix, sample_npix[num_bin_in_file - 1]);
+  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  }
 }
 
 TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
-    sqw_reader reader;
-    fileParameters file_par;
-    file_par.fileName = test_file_name;
-    file_par.file_id = 0;
-    file_par.nbin_start_pos = bin_pos_in_file;
-    file_par.pix_start_pos = pix_pos_in_file;
-    file_par.total_NfileBins = num_bin_in_file;
-    std::vector<float> pix_buffer;
-    pix_buffer.resize(this->pixels.size());
-    float *pPix_info = &pix_buffer[0];
-    size_t start_buf_pos(0), pix_start_num, num_bin_pix;
-    // --------------------------------------------------------------------------------------------
-    reader.init(file_par, false, false, 0);
+  sqw_reader reader;
+  fileParameters file_par;
+  file_par.fileName = test_file_name;
+  file_par.file_id = 0;
+  file_par.nbin_start_pos = bin_pos_in_file;
+  file_par.pix_start_pos = pix_pos_in_file;
+  file_par.total_NfileBins = num_bin_in_file;
+  std::vector<float> pix_buffer;
+  pix_buffer.resize(this->pixels.size());
+  float *pPix_info = &pix_buffer[0];
+  size_t start_buf_pos(0), pix_start_num, num_bin_pix;
+  // --------------------------------------------------------------------------------------------
+  reader.init(file_par, false, false, 0);
 
-    auto t_start = std::chrono::steady_clock::now();
-    start_buf_pos = 0;
-    for (size_t i = 0; i < this->num_bin_in_file; i++) {
-        reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-        start_buf_pos += num_bin_pix;
-    }
-    auto t_end = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - t_start).count();
-    std::cout << "\n Time to run single thread with system buffer: " << t_end << "ms\n";
+  auto t_start = std::chrono::steady_clock::now();
+  start_buf_pos = 0;
+  for (size_t i = 0; i < this->num_bin_in_file; i++) {
+    reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
+                           num_bin_pix, false);
+    start_buf_pos += num_bin_pix;
+  }
+  auto t_end = std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::steady_clock::now() - t_start)
+                   .count();
+  std::cout << "\n Time to run single thread with system buffer: " << t_end
+            << "ms\n";
 
-    for (size_t i = 0; i < pix_buffer.size(); i++) {
-        ASSERT_EQ(pix_buffer[i], pixels[i]);
-        pix_buffer[i] = 0;
-    }
-    // --------------------------------------------------------------------------------------------
-    reader.init(file_par, false, false, 1024);
+  for (size_t i = 0; i < pix_buffer.size(); i++) {
+    ASSERT_EQ(pix_buffer[i], pixels[i]);
+    pix_buffer[i] = 0;
+  }
+  // --------------------------------------------------------------------------------------------
+  reader.init(file_par, false, false, 1024);
 
-    t_start = std::chrono::steady_clock::now();
-    start_buf_pos = 0;
-    for (size_t i = 0; i < this->num_bin_in_file; i++) {
-        reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-        start_buf_pos += num_bin_pix;
-    }
-    t_end = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - t_start).count();
-    std::cout << "\n Time to run single thread with 1024 words buffer: " << t_end << "ms\n";
+  t_start = std::chrono::steady_clock::now();
+  start_buf_pos = 0;
+  for (size_t i = 0; i < this->num_bin_in_file; i++) {
+    reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
+                           num_bin_pix, false);
+    start_buf_pos += num_bin_pix;
+  }
+  t_end = std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - t_start)
+              .count();
+  std::cout << "\n Time to run single thread with 1024 words buffer: " << t_end
+            << "ms\n";
 
-    for (size_t i = 0; i < pix_buffer.size(); i++) {
-        ASSERT_EQ(pix_buffer[i], pixels[i]);
-        pix_buffer[i] = 0;
-    }
+  for (size_t i = 0; i < pix_buffer.size(); i++) {
+    ASSERT_EQ(pix_buffer[i], pixels[i]);
+    pix_buffer[i] = 0;
+  }
 
-    // --------------------------------------------------------------------------------------------
-    reader.init(file_par, false, false, 512, 1);
+  // --------------------------------------------------------------------------------------------
+  reader.init(file_par, false, false, 512, 1);
 
-    t_start = std::chrono::steady_clock::now();
-    start_buf_pos = 0;
-    for (size_t i = 0; i < this->num_bin_in_file; i++) {
-        reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-        start_buf_pos += num_bin_pix;
-    }
-    t_end = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - t_start).count();
-    std::cout << "\n Time to run threads: " << t_end << "ms\n";
+  t_start = std::chrono::steady_clock::now();
+  start_buf_pos = 0;
+  for (size_t i = 0; i < this->num_bin_in_file; i++) {
+    reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
+                           num_bin_pix, false);
+    start_buf_pos += num_bin_pix;
+  }
+  t_end = std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - t_start)
+              .count();
+  std::cout << "\n Time to run threads: " << t_end << "ms\n";
 
-    for (size_t i = 0; i < pix_buffer.size(); i++) {
-        ASSERT_EQ(pix_buffer[i], pixels[i]);
-        pix_buffer[i] = 0;
-    }
+  for (size_t i = 0; i < pix_buffer.size(); i++) {
+    ASSERT_EQ(pix_buffer[i], pixels[i]);
+    pix_buffer[i] = 0;
+  }
 
-    //--------------------------------------------------------------------------------------------
-    reader.init(file_par, false, false, 0);
+  //--------------------------------------------------------------------------------------------
+  reader.init(file_par, false, false, 0);
 
-    t_start = std::chrono::steady_clock::now();
-    start_buf_pos = 0;
-    for (size_t i = 0; i < this->num_bin_in_file; i++) {
-        reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num, num_bin_pix, false);
-        start_buf_pos += num_bin_pix;
-    }
-    t_end = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - t_start).count();
-    std::cout << "\n Time to run single thread with system buffer: " << t_end << "ms\n";
+  t_start = std::chrono::steady_clock::now();
+  start_buf_pos = 0;
+  for (size_t i = 0; i < this->num_bin_in_file; i++) {
+    reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
+                           num_bin_pix, false);
+    start_buf_pos += num_bin_pix;
+  }
+  t_end = std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - t_start)
+              .count();
+  std::cout << "\n Time to run single thread with system buffer: " << t_end
+            << "ms\n";
 }
 
-
 TEST_F(TestCombineSQW, MXSQW_Reader_Propagate_Pix_Multi) {
-    std::vector<sqw_reader> reader_noThread(1);
+  std::vector<sqw_reader> reader_noThread(1);
 
-    fileParameters file_par;
-    file_par.fileName = test_file_name;
-    file_par.file_id = 0;
-    file_par.nbin_start_pos = bin_pos_in_file;
-    file_par.pix_start_pos  = pix_pos_in_file;
-    file_par.total_NfileBins = num_bin_in_file;
-    bool initialized(false);
-    try {
-        //(fileParam[i], change_fileno, fileno_provided, read_buf_size, read_files_multitreaded);
-        reader_noThread[0].init(file_par, false, false, 64, 0);
-        initialized = true;
-    }
-    catch (...) {
-    }
+  fileParameters file_par;
+  file_par.fileName = test_file_name;
+  file_par.file_id = 0;
+  file_par.nbin_start_pos = bin_pos_in_file;
+  file_par.pix_start_pos = pix_pos_in_file;
+  file_par.total_NfileBins = num_bin_in_file;
+  bool initialized(false);
+  try {
+    //(fileParam[i], change_fileno, fileno_provided, read_buf_size,
+    //read_files_multitreaded);
+    reader_noThread[0].init(file_par, false, false, 64, 0);
+    initialized = true;
+  } catch (...) {
+  }
 
-    ASSERT_TRUE(initialized);
+  ASSERT_TRUE(initialized);
 
-    ProgParameters ProgSettings;
-    ProgSettings.log_level = 2;
-    ProgSettings.nBin2read = 0;
-    ProgSettings.num_log_ticks = 100;
-    ProgSettings.pixBufferSize = 1164180;
-    ProgSettings.totNumBins = num_bin_in_file;
+  ProgParameters ProgSettings;
+  ProgSettings.log_level = 2;
+  ProgSettings.nBin2read = 0;
+  ProgSettings.num_log_ticks = 100;
+  ProgSettings.pixBufferSize = 1164180;
+  ProgSettings.totNumBins = num_bin_in_file;
 
-    exchange_buffer Buffer(ProgSettings.pixBufferSize, file_par.total_NfileBins, ProgSettings.num_log_ticks);
-    nsqw_pix_reader Reader(ProgSettings, reader_noThread, Buffer);
+  exchange_buffer Buffer(ProgSettings.pixBufferSize, file_par.total_NfileBins,
+                         ProgSettings.num_log_ticks);
+  nsqw_pix_reader Reader(ProgSettings, reader_noThread, Buffer);
 
-    std::vector<uint64_t> nbin_Buffer_noThreads(ProgSettings.totNumBins,-1);
-    uint64_t *nbinBuf = &nbin_Buffer_noThreads[0];
+  std::vector<uint64_t> nbin_Buffer_noThreads(ProgSettings.totNumBins, -1);
+  uint64_t *nbinBuf = &nbin_Buffer_noThreads[0];
 
-    size_t n_buf_pixels, n_bins_processed(0);
-    Reader.read_pix_info(n_buf_pixels, n_bins_processed, nbinBuf);
+  size_t n_buf_pixels, n_bins_processed(0);
+  Reader.read_pix_info(n_buf_pixels, n_bins_processed, nbinBuf);
 
-    ASSERT_EQ(n_buf_pixels, ProgSettings.pixBufferSize);
-    ASSERT_EQ(n_bins_processed+1, ProgSettings.totNumBins);
+  ASSERT_EQ(n_buf_pixels, ProgSettings.pixBufferSize);
+  ASSERT_EQ(n_bins_processed + 1, ProgSettings.totNumBins);
 
-    size_t nReadPixels, n_bin_max;
-    const float * buf = reinterpret_cast<const float *>(Buffer.get_write_buffer(nReadPixels, n_bin_max));
-    Buffer.unlock_write_buffer();
-    ASSERT_EQ(nReadPixels, ProgSettings.pixBufferSize);
-    //---------------------------------------------------------------------
-    std::vector<sqw_reader> reader_threads(1);
-    initialized=false;
-    try {
-        //(fileParam[i], change_fileno, fileno_provided, read_buf_size, read_files_multitreaded);
-        reader_threads[0].init(file_par, false, false, 64, 1);
-        initialized = true;
-    }
-    catch (...) {
-    }
-    ASSERT_TRUE(initialized);
+  size_t nReadPixels, n_bin_max;
+  const float *buf = reinterpret_cast<const float *>(
+      Buffer.get_write_buffer(nReadPixels, n_bin_max));
+  Buffer.unlock_write_buffer();
+  ASSERT_EQ(nReadPixels, ProgSettings.pixBufferSize);
+  //---------------------------------------------------------------------
+  std::vector<sqw_reader> reader_threads(1);
+  initialized = false;
+  try {
+    //(fileParam[i], change_fileno, fileno_provided, read_buf_size,
+    //read_files_multitreaded);
+    reader_threads[0].init(file_par, false, false, 64, 1);
+    initialized = true;
+  } catch (...) {
+  }
+  ASSERT_TRUE(initialized);
 
-    nsqw_pix_reader ReaderThr(ProgSettings, reader_threads, Buffer);
+  nsqw_pix_reader ReaderThr(ProgSettings, reader_threads, Buffer);
 
-    std::vector<uint64_t> nbin_Buffer_Threads(ProgSettings.totNumBins,-1);
-    uint64_t *nbinBufThr  = &nbin_Buffer_Threads[0];
+  std::vector<uint64_t> nbin_Buffer_Threads(ProgSettings.totNumBins, -1);
+  uint64_t *nbinBufThr = &nbin_Buffer_Threads[0];
 
-    n_bins_processed = 0;
-    ReaderThr.read_pix_info(n_buf_pixels, n_bins_processed, nbinBufThr);
+  n_bins_processed = 0;
+  ReaderThr.read_pix_info(n_buf_pixels, n_bins_processed, nbinBufThr);
 
-    ASSERT_EQ(n_buf_pixels, ProgSettings.pixBufferSize);
-    ASSERT_EQ(n_bins_processed + 1, ProgSettings.totNumBins);
+  ASSERT_EQ(n_buf_pixels, ProgSettings.pixBufferSize);
+  ASSERT_EQ(n_bins_processed + 1, ProgSettings.totNumBins);
 
-    const float * buf1 = reinterpret_cast<const float *>(Buffer.get_write_buffer(nReadPixels, n_bin_max));
-    Buffer.unlock_write_buffer();
-    ASSERT_EQ(nReadPixels, ProgSettings.pixBufferSize);
+  const float *buf1 = reinterpret_cast<const float *>(
+      Buffer.get_write_buffer(nReadPixels, n_bin_max));
+  Buffer.unlock_write_buffer();
+  ASSERT_EQ(nReadPixels, ProgSettings.pixBufferSize);
 
-    for (size_t i = 0; i < n_bins_processed + 1; i+=10) {
-        ASSERT_EQ(nbin_Buffer_Threads[i], nbin_Buffer_noThreads[i]) << "bin N" << i;
-    }
-    for (size_t i = 0; i < n_buf_pixels; i+=100) {
-        size_t n_pix = i/9;
-        ASSERT_EQ(buf[i], buf1[i]) << "pix N" << n_pix;
-    }
+  for (size_t i = 0; i < n_bins_processed + 1; i += 10) {
+    ASSERT_EQ(nbin_Buffer_Threads[i], nbin_Buffer_noThreads[i]) << "bin N" << i;
+  }
+  for (size_t i = 0; i < n_buf_pixels; i += 100) {
+    size_t n_pix = i / 9;
+    ASSERT_EQ(buf[i], buf1[i]) << "pix N" << n_pix;
+  }
 }

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -495,15 +495,15 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
   ASSERT_TRUE(initialized);
 
   std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
-  std::vector<float> pix_buffer(9 * 1000);
+  std::vector<float> pix_buffer(NUM_PIXBLOCK_COLS * 1000);
   float *pPix_info = &pix_buffer[0];
 
   reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
   EXPECT_EQ(num_bin_pix, 3);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
   reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
@@ -515,8 +515,8 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
 
   start_buf_pos = 5;
@@ -524,16 +524,18 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
+              pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
+              pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 
   start_buf_pos = 2;
@@ -541,8 +543,9 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
+              pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 }
 
@@ -564,15 +567,15 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
   ASSERT_TRUE(initialized);
 
   std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
-  std::vector<float> pix_buffer(9 * 1000);
+  std::vector<float> pix_buffer(NUM_PIXBLOCK_COLS * 1000);
   float *pPix_info = &pix_buffer[0];
 
   reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
   EXPECT_EQ(num_bin_pix, 3);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
   reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
@@ -584,24 +587,26 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   start_buf_pos = 5;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
+              pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
+              pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 
   start_buf_pos = 2;
@@ -609,8 +614,9 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
+              pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 }
 
@@ -632,15 +638,15 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
   ASSERT_TRUE(initialized);
 
   std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
-  std::vector<float> pix_buffer(9 * 1000);
+  std::vector<float> pix_buffer(NUM_PIXBLOCK_COLS * 1000);
   float *pPix_info = &pix_buffer[0];
 
   reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
   EXPECT_EQ(num_bin_pix, 3);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
   reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
@@ -652,23 +658,25 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   start_buf_pos = 5;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
+              pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
+              pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 
   start_buf_pos = 2;
@@ -676,8 +684,9 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
-  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
-    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
+    EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
+              pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 }
 
@@ -848,7 +857,7 @@ TEST_F(TestCombineSQW, MXSQW_Reader_Propagate_Pix_Multi) {
     EXPECT_EQ(nbin_Buffer_Threads[i], nbin_Buffer_noThreads[i]) << "bin N" << i;
   }
   for (std::size_t i = 0; i < n_buf_pixels; i += 100) {
-    std::size_t n_pix = i / 9;
+    std::size_t n_pix = i / NUM_PIXBLOCK_COLS;
     EXPECT_EQ(buf[i], buf1[i]) << "pix N" << n_pix;
   }
 }

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -142,7 +142,7 @@ TEST_F(TestCombineSQW, Get_NPix_For_Bins) {
   // number of pixels in file is unknown
   EXPECT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
-  size_t pix_start, npix;
+  std::size_t pix_start, npix;
   pix_map.get_npix_for_bin(0, pix_start, npix);
   EXPECT_EQ(0, pix_start);
   EXPECT_EQ(sample_npix[0], npix);
@@ -188,7 +188,7 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start) {
                pix_buffer_size, false);
 
   bool end_pix_reached;
-  size_t num_pix =
+  std::size_t num_pix =
       pix_map.check_expand_pix_map(4, pix_buffer_size, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
   EXPECT_EQ(pix_buffer_size, num_pix);
@@ -202,14 +202,14 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start) {
             num_pix);
   ASSERT_TRUE(end_pix_reached);
   // check whole map is loaded in memory
-  size_t first_mem_bin, last_mem_bin, n_tot_bins;
+  std::size_t first_mem_bin, last_mem_bin, n_tot_bins;
   pix_map.get_map_param(first_mem_bin, last_mem_bin, n_tot_bins);
   EXPECT_EQ(first_mem_bin, 0);
   EXPECT_EQ(last_mem_bin, n_tot_bins);
   EXPECT_EQ(last_mem_bin, NUM_BINS_IN_FILE);
 
   for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
-    size_t pix_start, npix;
+    std::size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     EXPECT_EQ(pix_start, sample_pix_pos[i]);
     EXPECT_EQ(npix, sample_npix[i]);
@@ -225,20 +225,20 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
 
   bool end_pix_reached;
   const std::size_t pix_position{pix_buffer_size - 1};
-  size_t num_pix0 = pix_map.check_expand_pix_map(pix_position, pix_buffer_size,
-                                                 end_pix_reached);
+  std::size_t num_pix0 = pix_map.check_expand_pix_map(
+      pix_position, pix_buffer_size, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
   EXPECT_EQ(pix_position - 1, num_pix0);
 
-  size_t pix_pos, npix;
+  std::size_t pix_pos, npix;
   pix_map.get_npix_for_bin(pix_position, pix_pos, npix);
   EXPECT_EQ(sample_pix_pos[pix_position], pix_pos);
   EXPECT_EQ(sample_npix[pix_position], npix);
 
   // Read whole map in memory requesting map for much bigger number of npixels
   // then the real npix number in the file.
-  size_t num_pix = pix_map.check_expand_pix_map(pix_buffer_size, 2 * NUM_PIXELS,
-                                                end_pix_reached);
+  std::size_t num_pix = pix_map.check_expand_pix_map(
+      pix_buffer_size, 2 * NUM_PIXELS, end_pix_reached);
   // the file contains
   EXPECT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
                 sample_npix[NUM_BINS_IN_FILE - 1] - pix_pos - npix,
@@ -246,7 +246,7 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
   ASSERT_TRUE(end_pix_reached);
 
   for (std::size_t i = pix_buffer_size; i < NUM_BINS_IN_FILE; i++) {
-    size_t pix_start, npix;
+    std::size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     EXPECT_EQ(pix_start, sample_pix_pos[i]);
     EXPECT_EQ(npix, sample_npix[i]);
@@ -272,18 +272,18 @@ TEST_F(TestCombineSQW, Normal_Expand_Mode) {
   const std::size_t pix_buffer_size{512};
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE,
                pix_buffer_size, false);
-  size_t pix_pos, npix;
+  std::size_t pix_pos, npix;
   pix_map.get_npix_for_bin(0, pix_pos, npix);
   EXPECT_EQ(sample_pix_pos[0], pix_pos);
   EXPECT_EQ(sample_npix[0], npix);
 
   bool end_pix_reached;
 
-  size_t bin_num(0), pix_buf_size(pix_buffer_size), ic(0);
+  std::size_t bin_num(0), pix_buf_size(pix_buffer_size), ic(0);
   while (bin_num < NUM_BINS_IN_FILE - pix_buf_size) {
     bin_num += pix_buf_size;
     pix_map.get_npix_for_bin(bin_num, pix_pos, npix);
-    size_t n_pix = pix_map.num_pix_described(bin_num);
+    std::size_t n_pix = pix_map.num_pix_described(bin_num);
     if (n_pix < pix_buf_size) {
       pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
     }
@@ -296,7 +296,7 @@ TEST_F(TestCombineSQW, Normal_Expand_Mode) {
 TEST_F(TestCombineSQW, Thread_Job) {
   PixMapTester pix_map;
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, 0, true);
-  size_t first_th_bin, last_tr_bin, buf_end;
+  std::size_t first_th_bin, last_tr_bin, buf_end;
 
   pix_map.thread_query_data(first_th_bin, last_tr_bin, buf_end);
   EXPECT_EQ(first_th_bin, 0);
@@ -326,7 +326,7 @@ TEST_F(TestCombineSQW, Get_NPix_For_Bins_Threads) {
   // number of pixels in file is unknown
   EXPECT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
-  size_t pix_start, npix;
+  std::size_t pix_start, npix;
   pix_map.get_npix_for_bin(0, pix_start, npix);
   EXPECT_EQ(0, pix_start);
   EXPECT_EQ(sample_npix[0], npix);
@@ -372,7 +372,7 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start_Threads) {
                pix_buffer_size, true);
 
   bool end_pix_reached;
-  size_t num_pix =
+  std::size_t num_pix =
       pix_map.check_expand_pix_map(4, pix_buffer_size, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
   EXPECT_EQ(pix_buffer_size, num_pix);
@@ -386,14 +386,14 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start_Threads) {
             num_pix);
   ASSERT_TRUE(end_pix_reached);
   // check whole map is loaded in memory
-  size_t first_mem_bin, last_mem_bin, n_tot_bins;
+  std::size_t first_mem_bin, last_mem_bin, n_tot_bins;
   pix_map.get_map_param(first_mem_bin, last_mem_bin, n_tot_bins);
   EXPECT_EQ(first_mem_bin, 0);
   EXPECT_EQ(last_mem_bin, n_tot_bins);
   EXPECT_EQ(last_mem_bin, NUM_BINS_IN_FILE);
 
   for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
-    size_t pix_start, npix;
+    std::size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     EXPECT_EQ(pix_start, sample_pix_pos[i]);
     EXPECT_EQ(npix, sample_npix[i]);
@@ -408,20 +408,20 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
                pix_buffer_size, true);
 
   bool end_pix_reached;
-  size_t num_pix1 =
+  std::size_t num_pix1 =
       pix_map.check_expand_pix_map(511, pix_buffer_size, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
   EXPECT_EQ(510, num_pix1);
 
-  size_t pix_pos, npix;
+  std::size_t pix_pos, npix;
   pix_map.get_npix_for_bin(511, pix_pos, npix);
   EXPECT_EQ(sample_pix_pos[511], pix_pos);
   EXPECT_EQ(sample_npix[511], npix);
 
   // Read whole map in memory requesting map for much bigger number of npixels
   // then the real npix number in the file.
-  size_t num_pix = pix_map.check_expand_pix_map(pix_buffer_size, 2 * NUM_PIXELS,
-                                                end_pix_reached);
+  std::size_t num_pix = pix_map.check_expand_pix_map(
+      pix_buffer_size, 2 * NUM_PIXELS, end_pix_reached);
   // the file contains
   EXPECT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
                 sample_npix[NUM_BINS_IN_FILE - 1] - pix_pos - npix,
@@ -429,7 +429,7 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
   ASSERT_TRUE(end_pix_reached);
 
   for (std::size_t i = pix_buffer_size; i < NUM_BINS_IN_FILE; i++) {
-    size_t pix_start, npix;
+    std::size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     EXPECT_EQ(pix_start, sample_pix_pos[i]);
     EXPECT_EQ(npix, sample_npix[i]);
@@ -456,18 +456,18 @@ TEST_F(TestCombineSQW, Normal_Expand_Mode_Threads) {
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE,
                pix_buffer_size, true);
 
-  size_t pix_pos, npix;
+  std::size_t pix_pos, npix;
   pix_map.get_npix_for_bin(0, pix_pos, npix);
   EXPECT_EQ(sample_pix_pos[0], pix_pos);
   EXPECT_EQ(sample_npix[0], npix);
 
   bool end_pix_reached;
 
-  size_t bin_num(0), pix_buf_size(pix_buffer_size), ic(0);
+  std::size_t bin_num(0), pix_buf_size(pix_buffer_size), ic(0);
   while (bin_num < NUM_BINS_IN_FILE - pix_buf_size) {
     bin_num += pix_buf_size;
     pix_map.get_npix_for_bin(bin_num, pix_pos, npix);
-    size_t n_pix = pix_map.num_pix_described(bin_num);
+    std::size_t n_pix = pix_map.num_pix_described(bin_num);
     if (n_pix < pix_buf_size) {
       pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
     }
@@ -494,7 +494,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
 
   ASSERT_TRUE(initialized);
 
-  size_t pix_start_num, num_bin_pix, start_buf_pos(0);
+  std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
   std::vector<float> pix_buffer(9 * 1000);
   float *pPix_info = &pix_buffer[0];
 
@@ -563,7 +563,7 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
 
   ASSERT_TRUE(initialized);
 
-  size_t pix_start_num, num_bin_pix, start_buf_pos(0);
+  std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
   std::vector<float> pix_buffer(9 * 1000);
   float *pPix_info = &pix_buffer[0];
 
@@ -631,7 +631,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
 
   ASSERT_TRUE(initialized);
 
-  size_t pix_start_num, num_bin_pix, start_buf_pos(0);
+  std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
   std::vector<float> pix_buffer(9 * 1000);
   float *pPix_info = &pix_buffer[0];
 
@@ -692,7 +692,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
   std::vector<float> pix_buffer;
   pix_buffer.resize(this->pixels.size());
   float *pPix_info = &pix_buffer[0];
-  size_t start_buf_pos(0), pix_start_num, num_bin_pix;
+  std::size_t start_buf_pos(0), pix_start_num, num_bin_pix;
   // --------------------------------------------------------------------------------------------
   reader.init(file_par, false, false, 0);
 
@@ -805,13 +805,13 @@ TEST_F(TestCombineSQW, MXSQW_Reader_Propagate_Pix_Multi) {
   std::vector<uint64_t> nbin_Buffer_noThreads(ProgSettings.totNumBins, -1);
   uint64_t *nbinBuf = &nbin_Buffer_noThreads[0];
 
-  size_t n_buf_pixels, n_bins_processed(0);
+  std::size_t n_buf_pixels, n_bins_processed(0);
   Reader.read_pix_info(n_buf_pixels, n_bins_processed, nbinBuf);
 
   EXPECT_EQ(n_buf_pixels, ProgSettings.pixBufferSize);
   EXPECT_EQ(n_bins_processed + 1, ProgSettings.totNumBins);
 
-  size_t nReadPixels, n_bin_max;
+  std::size_t nReadPixels, n_bin_max;
   const float *buf = reinterpret_cast<const float *>(
       Buffer.get_write_buffer(nReadPixels, n_bin_max));
   Buffer.unlock_write_buffer();
@@ -848,7 +848,7 @@ TEST_F(TestCombineSQW, MXSQW_Reader_Propagate_Pix_Multi) {
     EXPECT_EQ(nbin_Buffer_Threads[i], nbin_Buffer_noThreads[i]) << "bin N" << i;
   }
   for (std::size_t i = 0; i < n_buf_pixels; i += 100) {
-    size_t n_pix = i / 9;
+    std::size_t n_pix = i / 9;
     EXPECT_EQ(buf[i], buf1[i]) << "pix N" << n_pix;
   }
 }

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -116,23 +116,23 @@ TEST_F(TestCombineSQW, Read_NBins) {
 
   pix_map.read_bins(0, buffer2, bin_end, buf_end);
 
-  ASSERT_EQ(128, bin_end);
-  ASSERT_EQ(128, buf_end);
-  ASSERT_EQ(sample_npix[125], buffer2[125].num_bin_pixels);
-  ASSERT_EQ(sample_npix[115], buffer2[115].num_bin_pixels);
-  ASSERT_EQ(sample_npix[114], buffer2[114].num_bin_pixels);
-  ASSERT_EQ(sample_npix[0], buffer2[0].num_bin_pixels);
-  ASSERT_EQ(sample_npix[1], buffer2[1].num_bin_pixels);
-  ASSERT_EQ(sample_npix[5], buffer2[5].num_bin_pixels);
+  EXPECT_EQ(128, bin_end);
+  EXPECT_EQ(128, buf_end);
+  EXPECT_EQ(sample_npix[125], buffer2[125].num_bin_pixels);
+  EXPECT_EQ(sample_npix[115], buffer2[115].num_bin_pixels);
+  EXPECT_EQ(sample_npix[114], buffer2[114].num_bin_pixels);
+  EXPECT_EQ(sample_npix[0], buffer2[0].num_bin_pixels);
+  EXPECT_EQ(sample_npix[1], buffer2[1].num_bin_pixels);
+  EXPECT_EQ(sample_npix[5], buffer2[5].num_bin_pixels);
 
   for (auto i = 1; i < buffer2.size(); i++) {
-    ASSERT_EQ(buffer2[i].pix_pos,
+    EXPECT_EQ(buffer2[i].pix_pos,
               buffer2[i - 1].pix_pos + buffer2[i - 1].num_bin_pixels);
   }
 
   pix_map.read_bins(NUM_BINS_IN_FILE - 2, buffer2, bin_end, buf_end);
-  ASSERT_EQ(NUM_BINS_IN_FILE, bin_end);
-  ASSERT_EQ(2, buf_end);
+  EXPECT_EQ(NUM_BINS_IN_FILE, bin_end);
+  EXPECT_EQ(2, buf_end);
 }
 
 TEST_F(TestCombineSQW, Get_NPix_For_Bins) {
@@ -142,44 +142,44 @@ TEST_F(TestCombineSQW, Get_NPix_For_Bins) {
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, 0, false);
 
   // number of pixels in file is unknown
-  ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
+  EXPECT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
   size_t pix_start, npix;
   pix_map.get_npix_for_bin(0, pix_start, npix);
-  ASSERT_EQ(0, pix_start);
-  ASSERT_EQ(sample_npix[0], npix);
+  EXPECT_EQ(0, pix_start);
+  EXPECT_EQ(sample_npix[0], npix);
 
   pix_map.get_npix_for_bin(114, pix_start, npix);
-  ASSERT_EQ(sample_npix[114], npix);
-  ASSERT_EQ(sample_pix_pos[114], pix_start);
+  EXPECT_EQ(sample_npix[114], npix);
+  EXPECT_EQ(sample_pix_pos[114], pix_start);
 
   pix_map.get_npix_for_bin(511, pix_start, npix);
-  ASSERT_EQ(sample_npix[511], npix);
-  ASSERT_EQ(sample_pix_pos[511], pix_start);
+  EXPECT_EQ(sample_npix[511], npix);
+  EXPECT_EQ(sample_pix_pos[511], pix_start);
 
   pix_map.get_npix_for_bin(600, pix_start, npix);
-  ASSERT_EQ(sample_npix[600], npix);
-  ASSERT_EQ(sample_pix_pos[600], pix_start);
+  EXPECT_EQ(sample_npix[600], npix);
+  EXPECT_EQ(sample_pix_pos[600], pix_start);
 
   pix_map.get_npix_for_bin(2400, pix_start, npix);
-  ASSERT_EQ(sample_npix[2400], npix);
-  ASSERT_EQ(sample_pix_pos[2400], pix_start);
+  EXPECT_EQ(sample_npix[2400], npix);
+  EXPECT_EQ(sample_pix_pos[2400], pix_start);
 
   // number of pixels in file is unknown
-  ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
+  EXPECT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
   pix_map.get_npix_for_bin(2, pix_start, npix);
 
-  ASSERT_EQ(sample_npix[2], npix);
-  ASSERT_EQ(sample_pix_pos[2], pix_start);
+  EXPECT_EQ(sample_npix[2], npix);
+  EXPECT_EQ(sample_pix_pos[2], pix_start);
 
   pix_map.get_npix_for_bin(NUM_BINS_IN_FILE - 2, pix_start, npix);
-  ASSERT_EQ(sample_npix[NUM_BINS_IN_FILE - 2], 0);
-  ASSERT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 2], pix_start);
+  EXPECT_EQ(sample_npix[NUM_BINS_IN_FILE - 2], 0);
+  EXPECT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 2], pix_start);
 
   // number of pixels in file is known
   ASSERT_NE(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
-  ASSERT_EQ(pix_map.num_pix_in_file(), sample_pix_pos[NUM_BINS_IN_FILE - 1] +
+  EXPECT_EQ(pix_map.num_pix_in_file(), sample_pix_pos[NUM_BINS_IN_FILE - 1] +
                                            sample_npix[NUM_BINS_IN_FILE - 1]);
 }
 
@@ -191,30 +191,30 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start) {
   bool end_pix_reached;
   size_t num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
-  ASSERT_EQ(512, num_pix);
+  EXPECT_EQ(512, num_pix);
 
   // Read whole map in memory requesting map for much bigger number of npixels
   // then the real npix number in the file.
   num_pix = pix_map.check_expand_pix_map(0, 2 * NUM_PIXELS, end_pix_reached);
   // the file contains
-  ASSERT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
+  EXPECT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
                 sample_npix[NUM_BINS_IN_FILE - 1],
             num_pix);
   ASSERT_TRUE(end_pix_reached);
   // check whole map is loaded in memory
   size_t first_mem_bin, last_mem_bin, n_tot_bins;
   pix_map.get_map_param(first_mem_bin, last_mem_bin, n_tot_bins);
-  ASSERT_EQ(first_mem_bin, 0);
-  ASSERT_EQ(last_mem_bin, n_tot_bins);
-  ASSERT_EQ(last_mem_bin, NUM_BINS_IN_FILE);
+  EXPECT_EQ(first_mem_bin, 0);
+  EXPECT_EQ(last_mem_bin, n_tot_bins);
+  EXPECT_EQ(last_mem_bin, NUM_BINS_IN_FILE);
 
   for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
-    ASSERT_EQ(pix_start, sample_pix_pos[i]);
-    ASSERT_EQ(npix, sample_npix[i]);
+    EXPECT_EQ(pix_start, sample_pix_pos[i]);
+    EXPECT_EQ(npix, sample_npix[i]);
   }
-  ASSERT_EQ(pix_map.num_pix_in_file(), num_pix);
+  EXPECT_EQ(pix_map.num_pix_in_file(), num_pix);
 }
 
 TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
@@ -225,19 +225,19 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
   bool end_pix_reached;
   size_t num_pix0 = pix_map.check_expand_pix_map(511, 512, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
-  ASSERT_EQ(510, num_pix0);
+  EXPECT_EQ(510, num_pix0);
 
   size_t pix_pos, npix;
   pix_map.get_npix_for_bin(511, pix_pos, npix);
-  ASSERT_EQ(sample_pix_pos[511], pix_pos);
-  ASSERT_EQ(sample_npix[511], npix);
+  EXPECT_EQ(sample_pix_pos[511], pix_pos);
+  EXPECT_EQ(sample_npix[511], npix);
 
   // Read whole map in memory requesting map for much bigger number of npixels
   // then the real npix number in the file.
   size_t num_pix =
       pix_map.check_expand_pix_map(512, 2 * NUM_PIXELS, end_pix_reached);
   // the file contains
-  ASSERT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
+  EXPECT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
                 sample_npix[NUM_BINS_IN_FILE - 1] - pix_pos - npix,
             num_pix);
   ASSERT_TRUE(end_pix_reached);
@@ -245,22 +245,22 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
   for (auto i = 512; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
-    ASSERT_EQ(pix_start, sample_pix_pos[i]);
-    ASSERT_EQ(npix, sample_npix[i]);
+    EXPECT_EQ(pix_start, sample_pix_pos[i]);
+    EXPECT_EQ(npix, sample_npix[i]);
   }
-  ASSERT_EQ(pix_map.num_pix_in_file(), num_pix + pix_pos + npix);
+  EXPECT_EQ(pix_map.num_pix_in_file(), num_pix + pix_pos + npix);
 
   num_pix = pix_map.check_expand_pix_map(512, 512, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
-  ASSERT_EQ(512, num_pix);
+  EXPECT_EQ(512, num_pix);
 
   num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
-  ASSERT_EQ(512, num_pix);
+  EXPECT_EQ(512, num_pix);
 
   pix_map.get_npix_for_bin(512 + 4, pix_pos, npix);
-  ASSERT_EQ(sample_pix_pos[512 + 4], pix_pos);
-  ASSERT_EQ(sample_npix[512 + 4], npix);
+  EXPECT_EQ(sample_pix_pos[512 + 4], pix_pos);
+  EXPECT_EQ(sample_npix[512 + 4], npix);
 }
 
 TEST_F(TestCombineSQW, Normal_Expand_Mode) {
@@ -269,8 +269,8 @@ TEST_F(TestCombineSQW, Normal_Expand_Mode) {
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, 512, false);
   size_t pix_pos, npix;
   pix_map.get_npix_for_bin(0, pix_pos, npix);
-  ASSERT_EQ(sample_pix_pos[0], pix_pos);
-  ASSERT_EQ(sample_npix[0], npix);
+  EXPECT_EQ(sample_pix_pos[0], pix_pos);
+  EXPECT_EQ(sample_npix[0], npix);
 
   bool end_pix_reached;
 
@@ -283,8 +283,8 @@ TEST_F(TestCombineSQW, Normal_Expand_Mode) {
       num_pix =
           pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
     }
-    ASSERT_EQ(sample_pix_pos[bin_num], pix_pos);
-    ASSERT_EQ(sample_npix[bin_num], npix);
+    EXPECT_EQ(sample_pix_pos[bin_num], pix_pos);
+    EXPECT_EQ(sample_npix[bin_num], npix);
     ic++;
   }
 }
@@ -295,23 +295,23 @@ TEST_F(TestCombineSQW, Thread_Job) {
   size_t first_th_bin, last_tr_bin, buf_end;
 
   pix_map.thread_query_data(first_th_bin, last_tr_bin, buf_end);
-  ASSERT_EQ(first_th_bin, 0);
-  ASSERT_EQ(last_tr_bin, 1024);
-  ASSERT_EQ(buf_end, 1024);
+  EXPECT_EQ(first_th_bin, 0);
+  EXPECT_EQ(last_tr_bin, 1024);
+  EXPECT_EQ(buf_end, 1024);
 
   pix_map.thread_request_to_read(1600);
   pix_map.thread_query_data(first_th_bin, last_tr_bin, buf_end);
-  ASSERT_EQ(first_th_bin, 1600);
-  ASSERT_EQ(last_tr_bin, 1600 + 1024);
-  ASSERT_EQ(buf_end, 1024);
+  EXPECT_EQ(first_th_bin, 1600);
+  EXPECT_EQ(last_tr_bin, 1600 + 1024);
+  EXPECT_EQ(buf_end, 1024);
 
   std::vector<pix_mem_map::bin_info> buf;
   pix_map.thread_get_data(first_th_bin, buf, last_tr_bin, buf_end);
 
   pix_map.thread_query_data(first_th_bin, last_tr_bin, buf_end);
-  ASSERT_EQ(first_th_bin, 1024 + 1600);
-  ASSERT_EQ(last_tr_bin, 1600 + 2048);
-  ASSERT_EQ(buf_end, 1024);
+  EXPECT_EQ(first_th_bin, 1024 + 1600);
+  EXPECT_EQ(last_tr_bin, 1600 + 2048);
+  EXPECT_EQ(buf_end, 1024);
 }
 
 TEST_F(TestCombineSQW, Get_NPix_For_Bins_Threads) {
@@ -320,44 +320,44 @@ TEST_F(TestCombineSQW, Get_NPix_For_Bins_Threads) {
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, 0, true);
 
   // number of pixels in file is unknown
-  ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
+  EXPECT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
   size_t pix_start, npix;
   pix_map.get_npix_for_bin(0, pix_start, npix);
-  ASSERT_EQ(0, pix_start);
-  ASSERT_EQ(sample_npix[0], npix);
+  EXPECT_EQ(0, pix_start);
+  EXPECT_EQ(sample_npix[0], npix);
 
   pix_map.get_npix_for_bin(114, pix_start, npix);
-  ASSERT_EQ(sample_npix[114], npix);
-  ASSERT_EQ(sample_pix_pos[114], pix_start);
+  EXPECT_EQ(sample_npix[114], npix);
+  EXPECT_EQ(sample_pix_pos[114], pix_start);
 
   pix_map.get_npix_for_bin(511, pix_start, npix);
-  ASSERT_EQ(sample_npix[511], npix);
-  ASSERT_EQ(sample_pix_pos[511], pix_start);
+  EXPECT_EQ(sample_npix[511], npix);
+  EXPECT_EQ(sample_pix_pos[511], pix_start);
 
   pix_map.get_npix_for_bin(600, pix_start, npix);
-  ASSERT_EQ(sample_npix[600], npix);
-  ASSERT_EQ(sample_pix_pos[600], pix_start);
+  EXPECT_EQ(sample_npix[600], npix);
+  EXPECT_EQ(sample_pix_pos[600], pix_start);
 
   pix_map.get_npix_for_bin(2400, pix_start, npix);
-  ASSERT_EQ(sample_npix[2400], npix);
-  ASSERT_EQ(sample_pix_pos[2400], pix_start);
+  EXPECT_EQ(sample_npix[2400], npix);
+  EXPECT_EQ(sample_pix_pos[2400], pix_start);
 
   // number of pixels in file is unknown
-  ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
+  EXPECT_EQ(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
   pix_map.get_npix_for_bin(2, pix_start, npix);
-  ASSERT_EQ(sample_npix[2], npix);
-  ASSERT_EQ(sample_pix_pos[2], pix_start);
+  EXPECT_EQ(sample_npix[2], npix);
+  EXPECT_EQ(sample_pix_pos[2], pix_start);
 
   pix_map.get_npix_for_bin(NUM_BINS_IN_FILE - 2, pix_start, npix);
-  ASSERT_EQ(sample_npix[NUM_BINS_IN_FILE - 2], 0);
-  ASSERT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 2], pix_start);
+  EXPECT_EQ(sample_npix[NUM_BINS_IN_FILE - 2], 0);
+  EXPECT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 2], pix_start);
 
   // number of pixels in file is known
   ASSERT_NE(std::numeric_limits<uint64_t>::max(), pix_map.num_pix_in_file());
 
-  ASSERT_EQ(pix_map.num_pix_in_file(), sample_pix_pos[NUM_BINS_IN_FILE - 1] +
+  EXPECT_EQ(pix_map.num_pix_in_file(), sample_pix_pos[NUM_BINS_IN_FILE - 1] +
                                            sample_npix[NUM_BINS_IN_FILE - 1]);
 }
 
@@ -369,30 +369,30 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start_Threads) {
   bool end_pix_reached;
   size_t num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
-  ASSERT_EQ(512, num_pix);
+  EXPECT_EQ(512, num_pix);
 
   // Read whole map in memory requesting map for much bigger number of npixels
   // then the real npix number in the file.
   num_pix = pix_map.check_expand_pix_map(0, 2 * NUM_PIXELS, end_pix_reached);
   // the file contains
-  ASSERT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
+  EXPECT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
                 sample_npix[NUM_BINS_IN_FILE - 1],
             num_pix);
   ASSERT_TRUE(end_pix_reached);
   // check whole map is loaded in memory
   size_t first_mem_bin, last_mem_bin, n_tot_bins;
   pix_map.get_map_param(first_mem_bin, last_mem_bin, n_tot_bins);
-  ASSERT_EQ(first_mem_bin, 0);
-  ASSERT_EQ(last_mem_bin, n_tot_bins);
-  ASSERT_EQ(last_mem_bin, NUM_BINS_IN_FILE);
+  EXPECT_EQ(first_mem_bin, 0);
+  EXPECT_EQ(last_mem_bin, n_tot_bins);
+  EXPECT_EQ(last_mem_bin, NUM_BINS_IN_FILE);
 
   for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
-    ASSERT_EQ(pix_start, sample_pix_pos[i]);
-    ASSERT_EQ(npix, sample_npix[i]);
+    EXPECT_EQ(pix_start, sample_pix_pos[i]);
+    EXPECT_EQ(npix, sample_npix[i]);
   }
-  ASSERT_EQ(pix_map.num_pix_in_file(), num_pix);
+  EXPECT_EQ(pix_map.num_pix_in_file(), num_pix);
 }
 
 TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
@@ -402,19 +402,19 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
   bool end_pix_reached;
   size_t num_pix1 = pix_map.check_expand_pix_map(511, 512, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
-  ASSERT_EQ(510, num_pix1);
+  EXPECT_EQ(510, num_pix1);
 
   size_t pix_pos, npix;
   pix_map.get_npix_for_bin(511, pix_pos, npix);
-  ASSERT_EQ(sample_pix_pos[511], pix_pos);
-  ASSERT_EQ(sample_npix[511], npix);
+  EXPECT_EQ(sample_pix_pos[511], pix_pos);
+  EXPECT_EQ(sample_npix[511], npix);
 
   // Read whole map in memory requesting map for much bigger number of npixels
   // then the real npix number in the file.
   size_t num_pix =
       pix_map.check_expand_pix_map(512, 2 * NUM_PIXELS, end_pix_reached);
   // the file contains
-  ASSERT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
+  EXPECT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
                 sample_npix[NUM_BINS_IN_FILE - 1] - pix_pos - npix,
             num_pix);
   ASSERT_TRUE(end_pix_reached);
@@ -422,22 +422,22 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
   for (auto i = 512; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
-    ASSERT_EQ(pix_start, sample_pix_pos[i]);
-    ASSERT_EQ(npix, sample_npix[i]);
+    EXPECT_EQ(pix_start, sample_pix_pos[i]);
+    EXPECT_EQ(npix, sample_npix[i]);
   }
-  ASSERT_EQ(pix_map.num_pix_in_file(), num_pix + pix_pos + npix);
+  EXPECT_EQ(pix_map.num_pix_in_file(), num_pix + pix_pos + npix);
 
   num_pix = pix_map.check_expand_pix_map(512, 512, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
-  ASSERT_EQ(512, num_pix);
+  EXPECT_EQ(512, num_pix);
 
   num_pix = pix_map.check_expand_pix_map(4, 512, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
-  ASSERT_EQ(512, num_pix);
+  EXPECT_EQ(512, num_pix);
 
   pix_map.get_npix_for_bin(512 + 4, pix_pos, npix);
-  ASSERT_EQ(sample_pix_pos[512 + 4], pix_pos);
-  ASSERT_EQ(sample_npix[512 + 4], npix);
+  EXPECT_EQ(sample_pix_pos[512 + 4], pix_pos);
+  EXPECT_EQ(sample_npix[512 + 4], npix);
 }
 
 TEST_F(TestCombineSQW, Normal_Expand_Mode_Threads) {
@@ -446,8 +446,8 @@ TEST_F(TestCombineSQW, Normal_Expand_Mode_Threads) {
 
   size_t pix_pos, npix;
   pix_map.get_npix_for_bin(0, pix_pos, npix);
-  ASSERT_EQ(sample_pix_pos[0], pix_pos);
-  ASSERT_EQ(sample_npix[0], npix);
+  EXPECT_EQ(sample_pix_pos[0], pix_pos);
+  EXPECT_EQ(sample_npix[0], npix);
 
   bool end_pix_reached;
 
@@ -460,8 +460,8 @@ TEST_F(TestCombineSQW, Normal_Expand_Mode_Threads) {
       num_pix =
           pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
     }
-    ASSERT_EQ(sample_pix_pos[bin_num], pix_pos);
-    ASSERT_EQ(sample_npix[bin_num], npix);
+    EXPECT_EQ(sample_pix_pos[bin_num], pix_pos);
+    EXPECT_EQ(sample_npix[bin_num], npix);
     ic++;
   }
 }
@@ -489,53 +489,53 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
 
   reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, 0);
-  ASSERT_EQ(num_bin_pix, 3);
+  EXPECT_EQ(pix_start_num, 0);
+  EXPECT_EQ(num_bin_pix, 3);
   for (auto i = 0; i < num_bin_pix * 9; i++) {
-    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
   reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, 338);
-  ASSERT_EQ(num_bin_pix, 0);
+  EXPECT_EQ(pix_start_num, 338);
+  EXPECT_EQ(num_bin_pix, 0);
 
   reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, 334);
-  ASSERT_EQ(num_bin_pix, 4);
+  EXPECT_EQ(pix_start_num, 334);
+  EXPECT_EQ(num_bin_pix, 4);
   // DISABLED
   // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     ASSERT_EQ(pixels[pix_start_num*9+i], pix_buffer[i]);
+  //     EXPECT_EQ(pixels[pix_start_num*9+i], pix_buffer[i]);
   // }
 
   start_buf_pos = 5;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
-  ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
+  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
   // DISABLED
   // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos*9 +
+  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos*9 +
   //     i]);
   // }
   //
   // reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860+1, pPix_info, start_buf_pos,
-  // pix_start_num, num_bin_pix, false); ASSERT_EQ(pix_start_num,
-  // sample_pix_pos[NUM_BINS_IN_FILE - 860+1]); ASSERT_EQ(num_bin_pix,
+  // pix_start_num, num_bin_pix, false); EXPECT_EQ(pix_start_num,
+  // sample_pix_pos[NUM_BINS_IN_FILE - 860+1]); EXPECT_EQ(num_bin_pix,
   // sample_npix[NUM_BINS_IN_FILE - 860+1]); for (auto i = 0; i<num_bin_pix *
   // 9; i++) {
-  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
   //     i]);
   // }
 
   start_buf_pos = 2;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
-  ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
+  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
   for (auto i = 0; i < num_bin_pix * 9; i++) {
-    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
   }
 }
 
@@ -562,53 +562,53 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
 
   reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, 0);
-  ASSERT_EQ(num_bin_pix, 3);
+  EXPECT_EQ(pix_start_num, 0);
+  EXPECT_EQ(num_bin_pix, 3);
   for (auto i = 0; i < num_bin_pix * 9; i++) {
-    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
   reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, 338);
-  ASSERT_EQ(num_bin_pix, 0);
+  EXPECT_EQ(pix_start_num, 338);
+  EXPECT_EQ(num_bin_pix, 0);
 
   reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, 334);
-  ASSERT_EQ(num_bin_pix, 4);
+  EXPECT_EQ(pix_start_num, 334);
+  EXPECT_EQ(num_bin_pix, 4);
   // DISABLED
   // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   // }
   start_buf_pos = 5;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
-  ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
+  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
   // DISABLED
   // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
   //     i]);
   // }
 
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
-  ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
+  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
   // DISABLED
   // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
   //     i]);
   // }
 
   start_buf_pos = 2;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
-  ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
+  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
   for (auto i = 0; i < num_bin_pix * 9; i++) {
-    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
   }
 }
 
@@ -635,52 +635,52 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
 
   reader.get_pix_for_bin(0, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, 0);
-  ASSERT_EQ(num_bin_pix, 3);
+  EXPECT_EQ(pix_start_num, 0);
+  EXPECT_EQ(num_bin_pix, 3);
   for (auto i = 0; i < num_bin_pix * 9; i++) {
-    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
   reader.get_pix_for_bin(127, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, 338);
-  ASSERT_EQ(num_bin_pix, 0);
+  EXPECT_EQ(pix_start_num, 338);
+  EXPECT_EQ(num_bin_pix, 0);
 
   reader.get_pix_for_bin(126, pPix_info, start_buf_pos, pix_start_num,
                          num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, 334);
-  ASSERT_EQ(num_bin_pix, 4);
+  EXPECT_EQ(pix_start_num, 334);
+  EXPECT_EQ(num_bin_pix, 4);
   // DISABLED
   // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   // }
   start_buf_pos = 5;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
-  ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
+  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
   // DISABLED
   // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
   //     i]);
   // }
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
-  ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
+  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
   // DISABLED
   // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
   //     i]);
   // }
 
   start_buf_pos = 2;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
-  ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
-  ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
+  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
   for (auto i = 0; i < num_bin_pix * 9; i++) {
-    ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
   }
 }
 
@@ -713,7 +713,7 @@ TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
             << "ms\n";
 
   for (auto i = 0; i < pix_buffer.size(); i++) {
-    ASSERT_EQ(pix_buffer[i], pixels[i]);
+    EXPECT_EQ(pix_buffer[i], pixels[i]);
     pix_buffer[i] = 0;
   }
   // --------------------------------------------------------------------------------------------
@@ -733,7 +733,7 @@ TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
             << "ms\n";
 
   for (auto i = 0; i < pix_buffer.size(); i++) {
-    ASSERT_EQ(pix_buffer[i], pixels[i]);
+    EXPECT_EQ(pix_buffer[i], pixels[i]);
     pix_buffer[i] = 0;
   }
 
@@ -753,7 +753,7 @@ TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
   std::cout << "\n Time to run threads: " << t_end << "ms\n";
 
   for (auto i = 0; i < pix_buffer.size(); i++) {
-    ASSERT_EQ(pix_buffer[i], pixels[i]);
+    EXPECT_EQ(pix_buffer[i], pixels[i]);
     pix_buffer[i] = 0;
   }
 
@@ -811,14 +811,14 @@ TEST_F(TestCombineSQW, MXSQW_Reader_Propagate_Pix_Multi) {
   size_t n_buf_pixels, n_bins_processed(0);
   Reader.read_pix_info(n_buf_pixels, n_bins_processed, nbinBuf);
 
-  ASSERT_EQ(n_buf_pixels, ProgSettings.pixBufferSize);
-  ASSERT_EQ(n_bins_processed + 1, ProgSettings.totNumBins);
+  EXPECT_EQ(n_buf_pixels, ProgSettings.pixBufferSize);
+  EXPECT_EQ(n_bins_processed + 1, ProgSettings.totNumBins);
 
   size_t nReadPixels, n_bin_max;
   const float *buf = reinterpret_cast<const float *>(
       Buffer.get_write_buffer(nReadPixels, n_bin_max));
   Buffer.unlock_write_buffer();
-  ASSERT_EQ(nReadPixels, ProgSettings.pixBufferSize);
+  EXPECT_EQ(nReadPixels, ProgSettings.pixBufferSize);
   //---------------------------------------------------------------------
   std::vector<sqw_reader> reader_threads(1);
   initialized = false;
@@ -839,19 +839,19 @@ TEST_F(TestCombineSQW, MXSQW_Reader_Propagate_Pix_Multi) {
   n_bins_processed = 0;
   ReaderThr.read_pix_info(n_buf_pixels, n_bins_processed, nbinBufThr);
 
-  ASSERT_EQ(n_buf_pixels, ProgSettings.pixBufferSize);
-  ASSERT_EQ(n_bins_processed + 1, ProgSettings.totNumBins);
+  EXPECT_EQ(n_buf_pixels, ProgSettings.pixBufferSize);
+  EXPECT_EQ(n_bins_processed + 1, ProgSettings.totNumBins);
 
   const float *buf1 = reinterpret_cast<const float *>(
       Buffer.get_write_buffer(nReadPixels, n_bin_max));
   Buffer.unlock_write_buffer();
-  ASSERT_EQ(nReadPixels, ProgSettings.pixBufferSize);
+  EXPECT_EQ(nReadPixels, ProgSettings.pixBufferSize);
 
   for (auto i = 0; i < n_bins_processed + 1; i += 10) {
-    ASSERT_EQ(nbin_Buffer_Threads[i], nbin_Buffer_noThreads[i]) << "bin N" << i;
+    EXPECT_EQ(nbin_Buffer_Threads[i], nbin_Buffer_noThreads[i]) << "bin N" << i;
   }
   for (auto i = 0; i < n_buf_pixels; i += 100) {
     size_t n_pix = i / 9;
-    ASSERT_EQ(buf[i], buf1[i]) << "pix N" << n_pix;
+    EXPECT_EQ(buf[i], buf1[i]) << "pix N" << n_pix;
   }
 }

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -40,7 +40,7 @@ protected:
       data_file_bin.read(reinterpret_cast<char *>(sample_npix.data()),
                          NUM_BINS_IN_FILE * sizeof(sample_npix[0]));
       // Fill the sample_pix_pos vector
-      for (auto i = 1; i < sample_npix.size(); i++) {
+      for (std::size_t i = 1; i < sample_npix.size(); i++) {
         sample_pix_pos[i] = sample_pix_pos[i - 1] + sample_npix[i - 1];
       }
 
@@ -70,10 +70,10 @@ TEST_F(TestCombineSQW,
 
   EXPECT_EQ(256, bin_end);
   EXPECT_EQ(256, buf_end);
-  for (auto i = 1; i < buffer.size(); i++) {
+  for (std::size_t i = 1; i < buffer.size(); i++) {
     EXPECT_EQ(sample_npix[i], buffer[i].num_bin_pixels);
   }
-  for (auto i = 1; i < buffer.size(); i++) {
+  for (std::size_t i = 1; i < buffer.size(); i++) {
     EXPECT_EQ(buffer[i].pix_pos,
               buffer[i - 1].pix_pos + buffer[i - 1].num_bin_pixels);
   }
@@ -125,7 +125,7 @@ TEST_F(TestCombineSQW, Read_NBins) {
   EXPECT_EQ(sample_npix[1], buffer2[1].num_bin_pixels);
   EXPECT_EQ(sample_npix[5], buffer2[5].num_bin_pixels);
 
-  for (auto i = 1; i < buffer2.size(); i++) {
+  for (std::size_t i = 1; i < buffer2.size(); i++) {
     EXPECT_EQ(buffer2[i].pix_pos,
               buffer2[i - 1].pix_pos + buffer2[i - 1].num_bin_pixels);
   }
@@ -208,7 +208,7 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start) {
   EXPECT_EQ(last_mem_bin, n_tot_bins);
   EXPECT_EQ(last_mem_bin, NUM_BINS_IN_FILE);
 
-  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     EXPECT_EQ(pix_start, sample_pix_pos[i]);
@@ -242,7 +242,7 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
             num_pix);
   ASSERT_TRUE(end_pix_reached);
 
-  for (auto i = 512; i < NUM_BINS_IN_FILE; i++) {
+  for (std::size_t i = 512; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     EXPECT_EQ(pix_start, sample_pix_pos[i]);
@@ -274,14 +274,13 @@ TEST_F(TestCombineSQW, Normal_Expand_Mode) {
 
   bool end_pix_reached;
 
-  size_t bin_num(0), pix_buf_size(512), num_pix, ic(0);
+  size_t bin_num(0), pix_buf_size(512), ic(0);
   while (bin_num < NUM_BINS_IN_FILE - pix_buf_size) {
     bin_num += pix_buf_size;
     pix_map.get_npix_for_bin(bin_num, pix_pos, npix);
     size_t n_pix = pix_map.num_pix_described(bin_num);
     if (n_pix < pix_buf_size) {
-      num_pix =
-          pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
+      pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
     }
     EXPECT_EQ(sample_pix_pos[bin_num], pix_pos);
     EXPECT_EQ(sample_npix[bin_num], npix);
@@ -386,7 +385,7 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start_Threads) {
   EXPECT_EQ(last_mem_bin, n_tot_bins);
   EXPECT_EQ(last_mem_bin, NUM_BINS_IN_FILE);
 
-  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     EXPECT_EQ(pix_start, sample_pix_pos[i]);
@@ -419,7 +418,7 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
             num_pix);
   ASSERT_TRUE(end_pix_reached);
 
-  for (auto i = 512; i < NUM_BINS_IN_FILE; i++) {
+  for (std::size_t i = 512; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     EXPECT_EQ(pix_start, sample_pix_pos[i]);
@@ -451,14 +450,13 @@ TEST_F(TestCombineSQW, Normal_Expand_Mode_Threads) {
 
   bool end_pix_reached;
 
-  size_t bin_num(0), pix_buf_size(512), num_pix, ic(0);
+  size_t bin_num(0), pix_buf_size(512), ic(0);
   while (bin_num < NUM_BINS_IN_FILE - pix_buf_size) {
     bin_num += pix_buf_size;
     pix_map.get_npix_for_bin(bin_num, pix_pos, npix);
     size_t n_pix = pix_map.num_pix_described(bin_num);
     if (n_pix < pix_buf_size) {
-      num_pix =
-          pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
+      pix_map.check_expand_pix_map(bin_num, pix_buf_size, end_pix_reached);
     }
     EXPECT_EQ(sample_pix_pos[bin_num], pix_pos);
     EXPECT_EQ(sample_npix[bin_num], npix);
@@ -491,7 +489,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
   EXPECT_EQ(num_bin_pix, 3);
-  for (auto i = 0; i < num_bin_pix * 9; i++) {
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
@@ -504,35 +502,33 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
-   for (auto i = 0; i<num_bin_pix * 9; i++) {
-       EXPECT_EQ(pixels[pix_start_num*9+i], pix_buffer[i]);
-   }
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  }
 
   start_buf_pos = 5;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
-   for (auto i = 0; i<num_bin_pix * 9; i++) {
-       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos*9 +
-       i]);
-   }
-  
-   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860+1, pPix_info, start_buf_pos,
-   pix_start_num, num_bin_pix, false); EXPECT_EQ(pix_start_num,
-   sample_pix_pos[NUM_BINS_IN_FILE - 860+1]); EXPECT_EQ(num_bin_pix,
-   sample_npix[NUM_BINS_IN_FILE - 860+1]); for (auto i = 0; i<num_bin_pix *
-   9; i++) {
-       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
-       i]);
-   }
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  }
+
+  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
+  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  }
 
   start_buf_pos = 2;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
-  for (auto i = 0; i < num_bin_pix * 9; i++) {
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
   }
 }
@@ -562,7 +558,7 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
   EXPECT_EQ(num_bin_pix, 3);
-  for (auto i = 0; i < num_bin_pix * 9; i++) {
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
@@ -575,34 +571,32 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
-   for (auto i = 0; i<num_bin_pix * 9; i++) {
-       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
-   }
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  }
   start_buf_pos = 5;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
-   for (auto i = 0; i<num_bin_pix * 9; i++) {
-       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
-       i]);
-   }
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  }
 
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
-   for (auto i = 0; i<num_bin_pix * 9; i++) {
-       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
-       i]);
-   }
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  }
 
   start_buf_pos = 2;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
-  for (auto i = 0; i < num_bin_pix * 9; i++) {
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
   }
 }
@@ -632,7 +626,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
   EXPECT_EQ(num_bin_pix, 3);
-  for (auto i = 0; i < num_bin_pix * 9; i++) {
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
@@ -645,33 +639,31 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
-   for (auto i = 0; i<num_bin_pix * 9; i++) {
-       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
-   }
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+  }
   start_buf_pos = 5;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
-   for (auto i = 0; i<num_bin_pix * 9; i++) {
-       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
-       i]);
-   }
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  }
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
-   for (auto i = 0; i<num_bin_pix * 9; i++) {
-       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
-       i]);
-   }
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
+    EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
+  }
 
   start_buf_pos = 2;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
-  for (auto i = 0; i < num_bin_pix * 9; i++) {
+  for (std::size_t i = 0; i < num_bin_pix * 9; i++) {
     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
   }
 }
@@ -693,7 +685,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
 
   auto t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
-  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
     reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
@@ -704,7 +696,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
   std::cout << "\n Time to run single thread with system buffer: " << t_end
             << "ms\n";
 
-  for (auto i = 0; i < pix_buffer.size(); i++) {
+  for (std::size_t i = 0; i < pix_buffer.size(); i++) {
     EXPECT_EQ(pix_buffer[i], pixels[i]);
     pix_buffer[i] = 0;
   }
@@ -713,7 +705,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
 
   t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
-  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
     reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
@@ -724,7 +716,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
   std::cout << "\n Time to run single thread with 1024 words buffer: " << t_end
             << "ms\n";
 
-  for (auto i = 0; i < pix_buffer.size(); i++) {
+  for (std::size_t i = 0; i < pix_buffer.size(); i++) {
     EXPECT_EQ(pix_buffer[i], pixels[i]);
     pix_buffer[i] = 0;
   }
@@ -734,7 +726,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
 
   t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
-  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
     reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
@@ -744,7 +736,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
               .count();
   std::cout << "\n Time to run threads: " << t_end << "ms\n";
 
-  for (auto i = 0; i < pix_buffer.size(); i++) {
+  for (std::size_t i = 0; i < pix_buffer.size(); i++) {
     EXPECT_EQ(pix_buffer[i], pixels[i]);
     pix_buffer[i] = 0;
   }
@@ -754,7 +746,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
 
   t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
-  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (std::size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
     reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
@@ -839,10 +831,10 @@ TEST_F(TestCombineSQW, MXSQW_Reader_Propagate_Pix_Multi) {
   Buffer.unlock_write_buffer();
   EXPECT_EQ(nReadPixels, ProgSettings.pixBufferSize);
 
-  for (auto i = 0; i < n_bins_processed + 1; i += 10) {
+  for (std::size_t i = 0; i < n_bins_processed + 1; i += 10) {
     EXPECT_EQ(nbin_Buffer_Threads[i], nbin_Buffer_noThreads[i]) << "bin N" << i;
   }
-  for (auto i = 0; i < n_buf_pixels; i += 100) {
+  for (std::size_t i = 0; i < n_buf_pixels; i += 100) {
     size_t n_pix = i / 9;
     EXPECT_EQ(buf[i], buf1[i]) << "pix N" << n_pix;
   }

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -29,9 +29,6 @@ protected:
 
   // Called once, before the first test is executed.
   static void SetUpTestSuite() {
-    sample_npix.resize(NUM_BINS_IN_FILE);
-    sample_pix_pos.resize(NUM_BINS_IN_FILE, 0);
-    pixels.resize(NUM_PIXELS * 9, 0);
     std::ifstream data_file_bin;
     data_file_bin.open(TEST_FILE_NAME, std::ios::in | std::ios::binary);
     if (!data_file_bin.is_open()) {
@@ -51,9 +48,9 @@ protected:
   }
 };
 
-std::vector<uint64_t> TestCombineSQW::sample_npix;
-std::vector<uint64_t> TestCombineSQW::sample_pix_pos;
-std::vector<float> TestCombineSQW::pixels;
+std::vector<uint64_t> TestCombineSQW::sample_npix(NUM_BINS_IN_FILE, 0);
+std::vector<uint64_t> TestCombineSQW::sample_pix_pos(NUM_BINS_IN_FILE, 0);
+std::vector<float> TestCombineSQW::pixels(NUM_PIXELS * 9, 0);
 
 TEST_F(TestCombineSQW, Read_NBins) {
   PixMapTester pix_map;

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -79,35 +79,38 @@ TEST_F(TestCombineSQW,
   }
 }
 
+TEST_F(TestCombineSQW,
+       read_bins_extracts_correct_bin_data_from_file_reading_from_given_index) {
+  PixMapTester pix_map;
+  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, 0, false);
+
+  std::vector<pix_mem_map::bin_info> buffer1(1);
+  std::size_t bin_end, buf_end;
+  pix_map.read_bins(0, buffer1, bin_end, buf_end);
+  EXPECT_EQ(1, bin_end);
+  EXPECT_EQ(1, buf_end);
+  EXPECT_EQ(sample_npix[0], buffer1[0].num_bin_pixels);
+
+  pix_map.read_bins(125, buffer1, bin_end, buf_end);
+  EXPECT_EQ(sample_npix[125], buffer1[0].num_bin_pixels);
+  EXPECT_EQ(126, bin_end);
+  EXPECT_EQ(1, buf_end);
+
+  pix_map.read_bins(115, buffer1, bin_end, buf_end);
+  EXPECT_EQ(sample_npix[115], buffer1[0].num_bin_pixels);
+  EXPECT_EQ(116, bin_end);
+  EXPECT_EQ(1, buf_end);
+
+  pix_map.read_bins(5, buffer1, bin_end, buf_end);
+  EXPECT_EQ(sample_npix[5], buffer1[0].num_bin_pixels);
+}
+
 TEST_F(TestCombineSQW, Read_NBins) {
   PixMapTester pix_map;
   std::vector<pix_mem_map::bin_info> buffer(256);
   std::size_t bin_end, buf_end;
 
   //--------------------------------------------------------------------------------------------
-  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, 0, false);
-  std::vector<pix_mem_map::bin_info> buffer1(1);
-
-  pix_map.read_bins(0, buffer1, bin_end, buf_end);
-  ASSERT_EQ(1, bin_end);
-  ASSERT_EQ(1, buf_end);
-  ASSERT_EQ(sample_npix[0], buffer1[0].num_bin_pixels);
-
-  pix_map.read_bins(125, buffer1, bin_end, buf_end);
-  ASSERT_EQ(sample_npix[125], buffer1[0].num_bin_pixels);
-  ASSERT_EQ(126, bin_end);
-  ASSERT_EQ(1, buf_end);
-
-  pix_map.read_bins(115, buffer1, bin_end, buf_end);
-  ASSERT_EQ(sample_npix[115], buffer1[0].num_bin_pixels);
-  ASSERT_EQ(116, bin_end);
-  ASSERT_EQ(1, buf_end);
-
-  pix_map.read_bins(5, buffer1, bin_end, buf_end);
-  ASSERT_EQ(sample_npix[5], buffer1[0].num_bin_pixels);
-
-  //--------------------------------------------------------------------------------------------
-
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, 0, false);
   std::vector<pix_mem_map::bin_info> buffer2(128);
 

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -59,29 +59,30 @@ std::vector<uint64_t> TestCombineSQW::sample_npix(NUM_BINS_IN_FILE, 0);
 std::vector<uint64_t> TestCombineSQW::sample_pix_pos(NUM_BINS_IN_FILE, 0);
 std::vector<float> TestCombineSQW::pixels(NUM_PIXELS * 9, 0);
 
-TEST_F(TestCombineSQW, Read_NBins) {
+TEST_F(TestCombineSQW,
+       read_bins_extracts_correct_bin_data_from_file_reading_from_start) {
   PixMapTester pix_map;
-
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, 128, false);
-  std::vector<pix_mem_map::bin_info> buffer(256);
 
+  std::vector<pix_mem_map::bin_info> buffer(256);
   std::size_t bin_end, buf_end;
   pix_map.read_bins(0, buffer, bin_end, buf_end);
 
-  ASSERT_EQ(256, bin_end);
-  ASSERT_EQ(256, buf_end);
-  ASSERT_EQ(sample_npix[125], buffer[125].num_bin_pixels);
-  ASSERT_EQ(sample_npix[115], buffer[115].num_bin_pixels);
-  ASSERT_EQ(sample_npix[114], buffer[114].num_bin_pixels);
-  ASSERT_EQ(sample_npix[0], buffer[0].num_bin_pixels);
-  ASSERT_EQ(sample_npix[1], buffer[1].num_bin_pixels);
-  ASSERT_EQ(sample_npix[5], buffer[5].num_bin_pixels);
-  ASSERT_EQ(sample_npix[129], buffer[129].num_bin_pixels);
-
+  EXPECT_EQ(256, bin_end);
+  EXPECT_EQ(256, buf_end);
   for (auto i = 1; i < buffer.size(); i++) {
-    ASSERT_EQ(buffer[i].pix_pos,
+    EXPECT_EQ(sample_npix[i], buffer[i].num_bin_pixels);
+  }
+  for (auto i = 1; i < buffer.size(); i++) {
+    EXPECT_EQ(buffer[i].pix_pos,
               buffer[i - 1].pix_pos + buffer[i - 1].num_bin_pixels);
   }
+}
+
+TEST_F(TestCombineSQW, Read_NBins) {
+  PixMapTester pix_map;
+  std::vector<pix_mem_map::bin_info> buffer(256);
+  std::size_t bin_end, buf_end;
 
   //--------------------------------------------------------------------------------------------
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, 0, false);

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -224,16 +224,16 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
                pix_buffer_size, false);
 
   bool end_pix_reached;
-  const std::size_t pix_position{pix_buffer_size - 1};
+  const std::size_t final_pix_position{pix_buffer_size - 1};
   std::size_t num_pix0 = pix_map.check_expand_pix_map(
-      pix_position, pix_buffer_size, end_pix_reached);
+      final_pix_position, pix_buffer_size, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
-  EXPECT_EQ(pix_position - 1, num_pix0);
+  EXPECT_EQ(final_pix_position - 1, num_pix0);
 
   std::size_t pix_pos, npix;
-  pix_map.get_npix_for_bin(pix_position, pix_pos, npix);
-  EXPECT_EQ(sample_pix_pos[pix_position], pix_pos);
-  EXPECT_EQ(sample_npix[pix_position], npix);
+  pix_map.get_npix_for_bin(final_pix_position, pix_pos, npix);
+  EXPECT_EQ(sample_pix_pos[final_pix_position], pix_pos);
+  EXPECT_EQ(sample_npix[final_pix_position], npix);
 
   // Read whole map in memory requesting map for much bigger number of npixels
   // then the real npix number in the file.

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -37,7 +37,7 @@ protected:
     char *buf = reinterpret_cast<char *>(&sample_npix[0]);
     data_file_bin.seekg(BIN_POS_IN_FILE);
     data_file_bin.read(buf, NUM_BINS_IN_FILE * 8);
-    for (std::size_t i = 1; i < sample_npix.size(); i++) {
+    for (auto i = 1; i < sample_npix.size(); i++) {
       sample_pix_pos[i] = sample_pix_pos[i - 1] + sample_npix[i - 1];
     }
     data_file_bin.seekg(PIX_POS_IN_FILE);
@@ -71,7 +71,7 @@ TEST_F(TestCombineSQW, Read_NBins) {
   ASSERT_EQ(sample_npix[5], buffer[5].num_bin_pixels);
   ASSERT_EQ(sample_npix[129], buffer[129].num_bin_pixels);
 
-  for (std::size_t i = 1; i < buffer.size(); i++) {
+  for (auto i = 1; i < buffer.size(); i++) {
     ASSERT_EQ(buffer[i].pix_pos,
               buffer[i - 1].pix_pos + buffer[i - 1].num_bin_pixels);
   }
@@ -114,7 +114,7 @@ TEST_F(TestCombineSQW, Read_NBins) {
   ASSERT_EQ(sample_npix[1], buffer2[1].num_bin_pixels);
   ASSERT_EQ(sample_npix[5], buffer2[5].num_bin_pixels);
 
-  for (std::size_t i = 1; i < buffer2.size(); i++) {
+  for (auto i = 1; i < buffer2.size(); i++) {
     ASSERT_EQ(buffer2[i].pix_pos,
               buffer[i - 1].pix_pos + buffer[i - 1].num_bin_pixels);
   }
@@ -197,7 +197,7 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start) {
   ASSERT_EQ(last_mem_bin, n_tot_bins);
   ASSERT_EQ(last_mem_bin, NUM_BINS_IN_FILE);
 
-  for (size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     ASSERT_EQ(pix_start, sample_pix_pos[i]);
@@ -231,7 +231,7 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
             num_pix);
   ASSERT_TRUE(end_pix_reached);
 
-  for (size_t i = 512; i < NUM_BINS_IN_FILE; i++) {
+  for (auto i = 512; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     ASSERT_EQ(pix_start, sample_pix_pos[i]);
@@ -375,7 +375,7 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start_Threads) {
   ASSERT_EQ(last_mem_bin, n_tot_bins);
   ASSERT_EQ(last_mem_bin, NUM_BINS_IN_FILE);
 
-  for (size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     ASSERT_EQ(pix_start, sample_pix_pos[i]);
@@ -408,7 +408,7 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
             num_pix);
   ASSERT_TRUE(end_pix_reached);
 
-  for (size_t i = 512; i < NUM_BINS_IN_FILE; i++) {
+  for (auto i = 512; i < NUM_BINS_IN_FILE; i++) {
     size_t pix_start, npix;
     pix_map.get_npix_for_bin(i, pix_start, npix);
     ASSERT_EQ(pix_start, sample_pix_pos[i]);
@@ -480,7 +480,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
                          num_bin_pix, false);
   ASSERT_EQ(pix_start_num, 0);
   ASSERT_EQ(num_bin_pix, 3);
-  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+  for (auto i = 0; i < num_bin_pix * 9; i++) {
     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
@@ -494,7 +494,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
   ASSERT_EQ(pix_start_num, 334);
   ASSERT_EQ(num_bin_pix, 4);
   // DISABLED
-  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  // for (auto i = 0; i<num_bin_pix * 9; i++) {
   //     ASSERT_EQ(pixels[pix_start_num*9+i], pix_buffer[i]);
   // }
 
@@ -504,7 +504,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
   ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
   // DISABLED
-  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  // for (auto i = 0; i<num_bin_pix * 9; i++) {
   //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos*9 +
   //     i]);
   // }
@@ -512,7 +512,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
   // reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860+1, pPix_info, start_buf_pos,
   // pix_start_num, num_bin_pix, false); ASSERT_EQ(pix_start_num,
   // sample_pix_pos[NUM_BINS_IN_FILE - 860+1]); ASSERT_EQ(num_bin_pix,
-  // sample_npix[NUM_BINS_IN_FILE - 860+1]); for (size_t i = 0; i<num_bin_pix *
+  // sample_npix[NUM_BINS_IN_FILE - 860+1]); for (auto i = 0; i<num_bin_pix *
   // 9; i++) {
   //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
   //     i]);
@@ -523,7 +523,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
                          pix_start_num, num_bin_pix, false);
   ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
-  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+  for (auto i = 0; i < num_bin_pix * 9; i++) {
     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
   }
 }
@@ -553,7 +553,7 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
                          num_bin_pix, false);
   ASSERT_EQ(pix_start_num, 0);
   ASSERT_EQ(num_bin_pix, 3);
-  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+  for (auto i = 0; i < num_bin_pix * 9; i++) {
     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
@@ -567,7 +567,7 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
   ASSERT_EQ(pix_start_num, 334);
   ASSERT_EQ(num_bin_pix, 4);
   // DISABLED
-  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  // for (auto i = 0; i<num_bin_pix * 9; i++) {
   //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   // }
   start_buf_pos = 5;
@@ -576,7 +576,7 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
   ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
   // DISABLED
-  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  // for (auto i = 0; i<num_bin_pix * 9; i++) {
   //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
   //     i]);
   // }
@@ -586,7 +586,7 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
   ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
   // DISABLED
-  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  // for (auto i = 0; i<num_bin_pix * 9; i++) {
   //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
   //     i]);
   // }
@@ -596,7 +596,7 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
                          pix_start_num, num_bin_pix, false);
   ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
-  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+  for (auto i = 0; i < num_bin_pix * 9; i++) {
     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
   }
 }
@@ -626,7 +626,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
                          num_bin_pix, false);
   ASSERT_EQ(pix_start_num, 0);
   ASSERT_EQ(num_bin_pix, 3);
-  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+  for (auto i = 0; i < num_bin_pix * 9; i++) {
     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
@@ -640,7 +640,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
   ASSERT_EQ(pix_start_num, 334);
   ASSERT_EQ(num_bin_pix, 4);
   // DISABLED
-  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  // for (auto i = 0; i<num_bin_pix * 9; i++) {
   //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
   // }
   start_buf_pos = 5;
@@ -649,7 +649,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
   ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
   // DISABLED
-  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  // for (auto i = 0; i<num_bin_pix * 9; i++) {
   //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
   //     i]);
   // }
@@ -658,7 +658,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
   ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
   // DISABLED
-  // for (size_t i = 0; i<num_bin_pix * 9; i++) {
+  // for (auto i = 0; i<num_bin_pix * 9; i++) {
   //     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
   //     i]);
   // }
@@ -668,7 +668,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
                          pix_start_num, num_bin_pix, false);
   ASSERT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 1]);
   ASSERT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 1]);
-  for (size_t i = 0; i < num_bin_pix * 9; i++) {
+  for (auto i = 0; i < num_bin_pix * 9; i++) {
     ASSERT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 + i]);
   }
 }
@@ -690,7 +690,7 @@ TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
 
   auto t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
-  for (size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
     reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
@@ -701,7 +701,7 @@ TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
   std::cout << "\n Time to run single thread with system buffer: " << t_end
             << "ms\n";
 
-  for (size_t i = 0; i < pix_buffer.size(); i++) {
+  for (auto i = 0; i < pix_buffer.size(); i++) {
     ASSERT_EQ(pix_buffer[i], pixels[i]);
     pix_buffer[i] = 0;
   }
@@ -710,7 +710,7 @@ TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
 
   t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
-  for (size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
     reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
@@ -721,7 +721,7 @@ TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
   std::cout << "\n Time to run single thread with 1024 words buffer: " << t_end
             << "ms\n";
 
-  for (size_t i = 0; i < pix_buffer.size(); i++) {
+  for (auto i = 0; i < pix_buffer.size(); i++) {
     ASSERT_EQ(pix_buffer[i], pixels[i]);
     pix_buffer[i] = 0;
   }
@@ -731,7 +731,7 @@ TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
 
   t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
-  for (size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
     reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
@@ -741,7 +741,7 @@ TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
               .count();
   std::cout << "\n Time to run threads: " << t_end << "ms\n";
 
-  for (size_t i = 0; i < pix_buffer.size(); i++) {
+  for (auto i = 0; i < pix_buffer.size(); i++) {
     ASSERT_EQ(pix_buffer[i], pixels[i]);
     pix_buffer[i] = 0;
   }
@@ -751,7 +751,7 @@ TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
 
   t_start = std::chrono::steady_clock::now();
   start_buf_pos = 0;
-  for (size_t i = 0; i < NUM_BINS_IN_FILE; i++) {
+  for (auto i = 0; i < NUM_BINS_IN_FILE; i++) {
     reader.get_pix_for_bin(i, pPix_info, start_buf_pos, pix_start_num,
                            num_bin_pix, false);
     start_buf_pos += num_bin_pix;
@@ -836,10 +836,10 @@ TEST_F(TestCombineSQW, MXSQW_Reader_Propagate_Pix_Multi) {
   Buffer.unlock_write_buffer();
   ASSERT_EQ(nReadPixels, ProgSettings.pixBufferSize);
 
-  for (size_t i = 0; i < n_bins_processed + 1; i += 10) {
+  for (auto i = 0; i < n_bins_processed + 1; i += 10) {
     ASSERT_EQ(nbin_Buffer_Threads[i], nbin_Buffer_noThreads[i]) << "bin N" << i;
   }
-  for (size_t i = 0; i < n_buf_pixels; i += 100) {
+  for (auto i = 0; i < n_buf_pixels; i += 100) {
     size_t n_pix = i / 9;
     ASSERT_EQ(buf[i], buf1[i]) << "pix N" << n_pix;
   }

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -90,7 +90,7 @@ TEST_F(TestCombineSQW, Read_NBins) {
   pix_map.read_bins(0, buffer1, bin_end, buf_end);
   ASSERT_EQ(1, bin_end);
   ASSERT_EQ(1, buf_end);
-  ASSERT_EQ(sample_npix[0], buffer[0].num_bin_pixels);
+  ASSERT_EQ(sample_npix[0], buffer1[0].num_bin_pixels);
 
   pix_map.read_bins(125, buffer1, bin_end, buf_end);
   ASSERT_EQ(sample_npix[125], buffer1[0].num_bin_pixels);
@@ -123,7 +123,7 @@ TEST_F(TestCombineSQW, Read_NBins) {
 
   for (auto i = 1; i < buffer2.size(); i++) {
     ASSERT_EQ(buffer2[i].pix_pos,
-              buffer[i - 1].pix_pos + buffer[i - 1].num_bin_pixels);
+              buffer2[i - 1].pix_pos + buffer2[i - 1].num_bin_pixels);
   }
 
   pix_map.read_bins(NUM_BINS_IN_FILE - 2, buffer2, bin_end, buf_end);

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -498,8 +498,8 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
   std::vector<float> pix_buffer(NUM_PIXBLOCK_COLS * 1000);
 
   std::size_t bin_number{0};
-  reader.get_pix_for_bin(0, pix_buffer.data(), start_buf_pos, pix_start_num,
-                         num_bin_pix, false);
+  reader.get_pix_for_bin(bin_number, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
   EXPECT_EQ(num_bin_pix, 3);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
@@ -573,8 +573,8 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
   std::vector<float> pix_buffer(NUM_PIXBLOCK_COLS * 1000);
 
   std::size_t bin_number{0};
-  reader.get_pix_for_bin(0, pix_buffer.data(), start_buf_pos, pix_start_num,
-                         num_bin_pix, false);
+  reader.get_pix_for_bin(bin_number, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
   EXPECT_EQ(num_bin_pix, 3);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -221,14 +221,15 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, pix_buffer_size, false);
 
   bool end_pix_reached;
-  size_t num_pix0 = pix_map.check_expand_pix_map(511, pix_buffer_size, end_pix_reached);
+  const std::size_t pix_position{ pix_buffer_size - 1 };
+  size_t num_pix0 = pix_map.check_expand_pix_map(pix_position, pix_buffer_size, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
-  EXPECT_EQ(510, num_pix0);
+  EXPECT_EQ(pix_position - 1, num_pix0);
 
   size_t pix_pos, npix;
-  pix_map.get_npix_for_bin(511, pix_pos, npix);
-  EXPECT_EQ(sample_pix_pos[511], pix_pos);
-  EXPECT_EQ(sample_npix[511], npix);
+  pix_map.get_npix_for_bin(pix_position, pix_pos, npix);
+  EXPECT_EQ(sample_pix_pos[pix_position], pix_pos);
+  EXPECT_EQ(sample_npix[pix_position], npix);
 
   // Read whole map in memory requesting map for much bigger number of npixels
   // then the real npix number in the file.

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -84,53 +84,50 @@ TEST_F(TestCombineSQW,
   PixMapTester pix_map;
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, 0, false);
 
-  std::vector<pix_mem_map::bin_info> buffer1(1);
+  std::vector<pix_mem_map::bin_info> buffer(1);
   std::size_t bin_end, buf_end;
-  pix_map.read_bins(0, buffer1, bin_end, buf_end);
+  pix_map.read_bins(0, buffer, bin_end, buf_end);
   EXPECT_EQ(1, bin_end);
   EXPECT_EQ(1, buf_end);
-  EXPECT_EQ(sample_npix[0], buffer1[0].num_bin_pixels);
+  EXPECT_EQ(sample_npix[0], buffer[0].num_bin_pixels);
 
-  pix_map.read_bins(125, buffer1, bin_end, buf_end);
-  EXPECT_EQ(sample_npix[125], buffer1[0].num_bin_pixels);
+  pix_map.read_bins(125, buffer, bin_end, buf_end);
+  EXPECT_EQ(sample_npix[125], buffer[0].num_bin_pixels);
   EXPECT_EQ(126, bin_end);
   EXPECT_EQ(1, buf_end);
 
-  pix_map.read_bins(115, buffer1, bin_end, buf_end);
-  EXPECT_EQ(sample_npix[115], buffer1[0].num_bin_pixels);
+  pix_map.read_bins(115, buffer, bin_end, buf_end);
+  EXPECT_EQ(sample_npix[115], buffer[0].num_bin_pixels);
   EXPECT_EQ(116, bin_end);
   EXPECT_EQ(1, buf_end);
 
-  pix_map.read_bins(5, buffer1, bin_end, buf_end);
-  EXPECT_EQ(sample_npix[5], buffer1[0].num_bin_pixels);
+  pix_map.read_bins(5, buffer, bin_end, buf_end);
+  EXPECT_EQ(sample_npix[5], buffer[0].num_bin_pixels);
 }
 
 TEST_F(TestCombineSQW, Read_NBins) {
   PixMapTester pix_map;
-  std::vector<pix_mem_map::bin_info> buffer(256);
-  std::size_t bin_end, buf_end;
-
-  //--------------------------------------------------------------------------------------------
   pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, 0, false);
-  std::vector<pix_mem_map::bin_info> buffer2(128);
 
-  pix_map.read_bins(0, buffer2, bin_end, buf_end);
+  std::size_t bin_end, buf_end;
+  std::vector<pix_mem_map::bin_info> buffer(128);
+  pix_map.read_bins(0, buffer, bin_end, buf_end);
 
   EXPECT_EQ(128, bin_end);
   EXPECT_EQ(128, buf_end);
-  EXPECT_EQ(sample_npix[125], buffer2[125].num_bin_pixels);
-  EXPECT_EQ(sample_npix[115], buffer2[115].num_bin_pixels);
-  EXPECT_EQ(sample_npix[114], buffer2[114].num_bin_pixels);
-  EXPECT_EQ(sample_npix[0], buffer2[0].num_bin_pixels);
-  EXPECT_EQ(sample_npix[1], buffer2[1].num_bin_pixels);
-  EXPECT_EQ(sample_npix[5], buffer2[5].num_bin_pixels);
+  EXPECT_EQ(sample_npix[125], buffer[125].num_bin_pixels);
+  EXPECT_EQ(sample_npix[115], buffer[115].num_bin_pixels);
+  EXPECT_EQ(sample_npix[114], buffer[114].num_bin_pixels);
+  EXPECT_EQ(sample_npix[0], buffer[0].num_bin_pixels);
+  EXPECT_EQ(sample_npix[1], buffer[1].num_bin_pixels);
+  EXPECT_EQ(sample_npix[5], buffer[5].num_bin_pixels);
 
-  for (std::size_t i = 1; i < buffer2.size(); i++) {
-    EXPECT_EQ(buffer2[i].pix_pos,
-              buffer2[i - 1].pix_pos + buffer2[i - 1].num_bin_pixels);
+  for (std::size_t i = 1; i < buffer.size(); i++) {
+    EXPECT_EQ(buffer[i].pix_pos,
+              buffer[i - 1].pix_pos + buffer[i - 1].num_bin_pixels);
   }
 
-  pix_map.read_bins(NUM_BINS_IN_FILE - 2, buffer2, bin_end, buf_end);
+  pix_map.read_bins(NUM_BINS_IN_FILE - 2, buffer, bin_end, buf_end);
   EXPECT_EQ(NUM_BINS_IN_FILE, bin_end);
   EXPECT_EQ(2, buf_end);
 }

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -29,22 +29,29 @@ protected:
 
   // Called once, before the first test is executed.
   static void SetUpTestSuite() {
-    std::ifstream data_file_bin;
-    data_file_bin.open(TEST_FILE_NAME, std::ios::in | std::ios::binary);
+    std::ifstream data_file_bin(TEST_FILE_NAME,
+                                std::ios::in | std::ios::binary);
     if (!data_file_bin.is_open()) {
-      throw "Can not open test data file";
+      throw std::exception("Can not open test data file");
     }
-    char *buf = reinterpret_cast<char *>(&sample_npix[0]);
-    data_file_bin.seekg(BIN_POS_IN_FILE);
-    data_file_bin.read(buf, NUM_BINS_IN_FILE * 8);
-    for (auto i = 1; i < sample_npix.size(); i++) {
-      sample_pix_pos[i] = sample_pix_pos[i - 1] + sample_npix[i - 1];
-    }
-    data_file_bin.seekg(PIX_POS_IN_FILE);
-    buf = reinterpret_cast<char *>(&pixels[0]);
-    data_file_bin.read(buf, NUM_PIXELS * 9 * 8);
+    try {
+      // Read npix data
+      data_file_bin.seekg(BIN_POS_IN_FILE);
+      data_file_bin.read(reinterpret_cast<char *>(sample_npix.data()),
+                         NUM_BINS_IN_FILE * 8);
+      // Fill the sample_pix_pos vector
+      for (auto i = 1; i < sample_npix.size(); i++) {
+        sample_pix_pos[i] = sample_pix_pos[i - 1] + sample_npix[i - 1];
+      }
 
-    data_file_bin.close();
+      // Read pixel data
+      data_file_bin.seekg(PIX_POS_IN_FILE);
+      data_file_bin.read(reinterpret_cast<char *>(pixels.data()),
+                         NUM_PIXELS * 9 * 8);
+    } catch (...) {
+      data_file_bin.close();
+      throw;
+    }
   }
 };
 

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -38,7 +38,7 @@ protected:
       // Read npix data
       data_file_bin.seekg(BIN_POS_IN_FILE);
       data_file_bin.read(reinterpret_cast<char *>(sample_npix.data()),
-                         NUM_BINS_IN_FILE * 8);
+                         NUM_BINS_IN_FILE * sizeof(sample_npix[0]));
       // Fill the sample_pix_pos vector
       for (auto i = 1; i < sample_npix.size(); i++) {
         sample_pix_pos[i] = sample_pix_pos[i - 1] + sample_npix[i - 1];
@@ -47,7 +47,7 @@ protected:
       // Read pixel data
       data_file_bin.seekg(PIX_POS_IN_FILE);
       data_file_bin.read(reinterpret_cast<char *>(pixels.data()),
-                         NUM_PIXELS * 9 * 8);
+                         NUM_PIXELS * 9 * sizeof(pixels[0]));
     } catch (...) {
       data_file_bin.close();
       throw;
@@ -504,30 +504,28 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
-  // DISABLED
-  // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     EXPECT_EQ(pixels[pix_start_num*9+i], pix_buffer[i]);
-  // }
+   for (auto i = 0; i<num_bin_pix * 9; i++) {
+       EXPECT_EQ(pixels[pix_start_num*9+i], pix_buffer[i]);
+   }
 
   start_buf_pos = 5;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
-  // DISABLED
-  // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos*9 +
-  //     i]);
-  // }
-  //
-  // reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860+1, pPix_info, start_buf_pos,
-  // pix_start_num, num_bin_pix, false); EXPECT_EQ(pix_start_num,
-  // sample_pix_pos[NUM_BINS_IN_FILE - 860+1]); EXPECT_EQ(num_bin_pix,
-  // sample_npix[NUM_BINS_IN_FILE - 860+1]); for (auto i = 0; i<num_bin_pix *
-  // 9; i++) {
-  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
-  //     i]);
-  // }
+   for (auto i = 0; i<num_bin_pix * 9; i++) {
+       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos*9 +
+       i]);
+   }
+  
+   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860+1, pPix_info, start_buf_pos,
+   pix_start_num, num_bin_pix, false); EXPECT_EQ(pix_start_num,
+   sample_pix_pos[NUM_BINS_IN_FILE - 860+1]); EXPECT_EQ(num_bin_pix,
+   sample_npix[NUM_BINS_IN_FILE - 860+1]); for (auto i = 0; i<num_bin_pix *
+   9; i++) {
+       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+       i]);
+   }
 
   start_buf_pos = 2;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
@@ -577,30 +575,27 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
-  // DISABLED
-  // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
-  // }
+   for (auto i = 0; i<num_bin_pix * 9; i++) {
+       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+   }
   start_buf_pos = 5;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
-  // DISABLED
-  // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
-  //     i]);
-  // }
+   for (auto i = 0; i<num_bin_pix * 9; i++) {
+       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+       i]);
+   }
 
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
-  // DISABLED
-  // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
-  //     i]);
-  // }
+   for (auto i = 0; i<num_bin_pix * 9; i++) {
+       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+       i]);
+   }
 
   start_buf_pos = 2;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
@@ -650,29 +645,26 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
-  // DISABLED
-  // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
-  // }
+   for (auto i = 0; i<num_bin_pix * 9; i++) {
+       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[i]);
+   }
   start_buf_pos = 5;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
-  // DISABLED
-  // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
-  //     i]);
-  // }
+   for (auto i = 0; i<num_bin_pix * 9; i++) {
+       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+       i]);
+   }
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pPix_info, start_buf_pos,
                          pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
   EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
-  // DISABLED
-  // for (auto i = 0; i<num_bin_pix * 9; i++) {
-  //     EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
-  //     i]);
-  // }
+   for (auto i = 0; i<num_bin_pix * 9; i++) {
+       EXPECT_EQ(pixels[pix_start_num * 9 + i], pix_buffer[start_buf_pos * 9 +
+       i]);
+   }
 
   start_buf_pos = 2;
   reader.get_pix_for_bin(NUM_BINS_IN_FILE - 1, pPix_info, start_buf_pos,
@@ -684,7 +676,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
   }
 }
 
-TEST_F(TestCombineSQW, DISABLED_SQW_Reader_Read_All) {
+TEST_F(TestCombineSQW, SQW_Reader_Read_All) {
   sqw_reader reader;
   fileParameters file_par;
   file_par.fileName = TEST_FILE_NAME;

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -497,6 +497,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
   std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
   std::vector<float> pix_buffer(NUM_PIXBLOCK_COLS * 1000);
 
+  std::size_t bin_number{0};
   reader.get_pix_for_bin(0, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
@@ -504,14 +505,16 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
+
+  bin_number = 127;
   // pix buffer have not changed at all
-  reader.get_pix_for_bin(127, pix_buffer.data(), start_buf_pos, pix_start_num,
-                         num_bin_pix, false);
+  reader.get_pix_for_bin(bin_number, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 338);
   EXPECT_EQ(num_bin_pix, 0);
 
-  reader.get_pix_for_bin(126, pix_buffer.data(), start_buf_pos, pix_start_num,
-                         num_bin_pix, false);
+  reader.get_pix_for_bin(bin_number - 1, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
@@ -519,19 +522,20 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix) {
   }
 
   start_buf_pos = 5;
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pix_buffer.data(),
-                         start_buf_pos, pix_start_num, num_bin_pix, false);
-  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
-  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
+  bin_number = NUM_BINS_IN_FILE - 860;
+  reader.get_pix_for_bin(bin_number, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[bin_number]);
+  EXPECT_EQ(num_bin_pix, sample_npix[bin_number]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
               pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pix_buffer.data(),
-                         start_buf_pos, pix_start_num, num_bin_pix, false);
-  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
-  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
+  reader.get_pix_for_bin(bin_number + 1, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[bin_number + 1]);
+  EXPECT_EQ(num_bin_pix, sample_npix[bin_number + 1]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
               pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
@@ -568,6 +572,7 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
   std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
   std::vector<float> pix_buffer(NUM_PIXBLOCK_COLS * 1000);
 
+  std::size_t bin_number{0};
   reader.get_pix_for_bin(0, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
@@ -576,32 +581,34 @@ TEST_F(TestCombineSQW, SQW_Reader_NoBuf_Mode) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
-  reader.get_pix_for_bin(127, pix_buffer.data(), start_buf_pos, pix_start_num,
-                         num_bin_pix, false);
+  bin_number = 127;
+  reader.get_pix_for_bin(bin_number, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 338);
   EXPECT_EQ(num_bin_pix, 0);
 
-  reader.get_pix_for_bin(126, pix_buffer.data(), start_buf_pos, pix_start_num,
-                         num_bin_pix, false);
+  reader.get_pix_for_bin(bin_number - 1, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 334);
   EXPECT_EQ(num_bin_pix, 4);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   start_buf_pos = 5;
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pix_buffer.data(),
-                         start_buf_pos, pix_start_num, num_bin_pix, false);
-  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
-  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
+  bin_number = NUM_BINS_IN_FILE - 860;
+  reader.get_pix_for_bin(bin_number, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[bin_number]);
+  EXPECT_EQ(num_bin_pix, sample_npix[bin_number]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
               pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
 
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pix_buffer.data(),
-                         start_buf_pos, pix_start_num, num_bin_pix, false);
-  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
-  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
+  reader.get_pix_for_bin(bin_number + 1, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[bin_number + 1]);
+  EXPECT_EQ(num_bin_pix, sample_npix[bin_number + 1]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
               pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
@@ -638,6 +645,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
   std::size_t pix_start_num, num_bin_pix, start_buf_pos(0);
   std::vector<float> pix_buffer(NUM_PIXBLOCK_COLS * 1000);
 
+  std::size_t bin_number{0};
   reader.get_pix_for_bin(0, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 0);
@@ -646,6 +654,7 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   // pix buffer have not changed at all
+  bin_number = 127;
   reader.get_pix_for_bin(127, pix_buffer.data(), start_buf_pos, pix_start_num,
                          num_bin_pix, false);
   EXPECT_EQ(pix_start_num, 338);
@@ -659,18 +668,19 @@ TEST_F(TestCombineSQW, SQW_Reader_Propagate_Pix_Threads) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i], pix_buffer[i]);
   }
   start_buf_pos = 5;
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860, pix_buffer.data(),
-                         start_buf_pos, pix_start_num, num_bin_pix, false);
-  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860]);
-  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860]);
+  bin_number = NUM_BINS_IN_FILE - 860;
+  reader.get_pix_for_bin(bin_number, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[bin_number]);
+  EXPECT_EQ(num_bin_pix, sample_npix[bin_number]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
               pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);
   }
-  reader.get_pix_for_bin(NUM_BINS_IN_FILE - 860 + 1, pix_buffer.data(),
-                         start_buf_pos, pix_start_num, num_bin_pix, false);
-  EXPECT_EQ(pix_start_num, sample_pix_pos[NUM_BINS_IN_FILE - 860 + 1]);
-  EXPECT_EQ(num_bin_pix, sample_npix[NUM_BINS_IN_FILE - 860 + 1]);
+  reader.get_pix_for_bin(bin_number + 1, pix_buffer.data(), start_buf_pos,
+                         pix_start_num, num_bin_pix, false);
+  EXPECT_EQ(pix_start_num, sample_pix_pos[bin_number + 1]);
+  EXPECT_EQ(num_bin_pix, sample_npix[bin_number + 1]);
   for (std::size_t i = 0; i < num_bin_pix * NUM_PIXBLOCK_COLS; i++) {
     EXPECT_EQ(pixels[pix_start_num * NUM_PIXBLOCK_COLS + i],
               pix_buffer[start_buf_pos * NUM_PIXBLOCK_COLS + i]);

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/combine_sqw.test.cpp
@@ -58,7 +58,7 @@ protected:
 
 std::vector<uint64_t> TestCombineSQW::sample_npix(NUM_BINS_IN_FILE, 0);
 std::vector<uint64_t> TestCombineSQW::sample_pix_pos(NUM_BINS_IN_FILE, 0);
-std::vector<float> TestCombineSQW::pixels(NUM_PIXELS * NUM_PIXBLOCK_COLS, 0);
+std::vector<float> TestCombineSQW::pixels(NUM_PIXELS *NUM_PIXBLOCK_COLS, 0);
 
 TEST_F(TestCombineSQW,
        read_bins_extracts_correct_bin_data_from_file_reading_from_start) {
@@ -183,11 +183,13 @@ TEST_F(TestCombineSQW, Get_NPix_For_Bins) {
 
 TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start) {
   pix_mem_map pix_map;
-  const std::size_t pix_buffer_size{ 512 };
-  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, pix_buffer_size, false);
+  const std::size_t pix_buffer_size{512};
+  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE,
+               pix_buffer_size, false);
 
   bool end_pix_reached;
-  size_t num_pix = pix_map.check_expand_pix_map(4, pix_buffer_size, end_pix_reached);
+  size_t num_pix =
+      pix_map.check_expand_pix_map(4, pix_buffer_size, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
   EXPECT_EQ(pix_buffer_size, num_pix);
 
@@ -217,12 +219,14 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start) {
 
 TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
   pix_mem_map pix_map;
-  const std::size_t pix_buffer_size{ 512 };
-  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, pix_buffer_size, false);
+  const std::size_t pix_buffer_size{512};
+  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE,
+               pix_buffer_size, false);
 
   bool end_pix_reached;
-  const std::size_t pix_position{ pix_buffer_size - 1 };
-  size_t num_pix0 = pix_map.check_expand_pix_map(pix_position, pix_buffer_size, end_pix_reached);
+  const std::size_t pix_position{pix_buffer_size - 1};
+  size_t num_pix0 = pix_map.check_expand_pix_map(pix_position, pix_buffer_size,
+                                                 end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
   EXPECT_EQ(pix_position - 1, num_pix0);
 
@@ -233,8 +237,8 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
 
   // Read whole map in memory requesting map for much bigger number of npixels
   // then the real npix number in the file.
-  size_t num_pix =
-      pix_map.check_expand_pix_map(pix_buffer_size, 2 * NUM_PIXELS, end_pix_reached);
+  size_t num_pix = pix_map.check_expand_pix_map(pix_buffer_size, 2 * NUM_PIXELS,
+                                                end_pix_reached);
   // the file contains
   EXPECT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
                 sample_npix[NUM_BINS_IN_FILE - 1] - pix_pos - npix,
@@ -249,7 +253,8 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
   }
   EXPECT_EQ(pix_map.num_pix_in_file(), num_pix + pix_pos + npix);
 
-  num_pix = pix_map.check_expand_pix_map(pix_buffer_size, pix_buffer_size, end_pix_reached);
+  num_pix = pix_map.check_expand_pix_map(pix_buffer_size, pix_buffer_size,
+                                         end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
   EXPECT_EQ(pix_buffer_size, num_pix);
 
@@ -264,8 +269,9 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map) {
 
 TEST_F(TestCombineSQW, Normal_Expand_Mode) {
   pix_mem_map pix_map;
-  const std::size_t pix_buffer_size{ 512 };
-  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, pix_buffer_size, false);
+  const std::size_t pix_buffer_size{512};
+  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE,
+               pix_buffer_size, false);
   size_t pix_pos, npix;
   pix_map.get_npix_for_bin(0, pix_pos, npix);
   EXPECT_EQ(sample_pix_pos[0], pix_pos);
@@ -361,11 +367,13 @@ TEST_F(TestCombineSQW, Get_NPix_For_Bins_Threads) {
 
 TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start_Threads) {
   pix_mem_map pix_map;
-  const std::size_t pix_buffer_size{ 512 };
-  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, pix_buffer_size, true);
+  const std::size_t pix_buffer_size{512};
+  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE,
+               pix_buffer_size, true);
 
   bool end_pix_reached;
-  size_t num_pix = pix_map.check_expand_pix_map(4, pix_buffer_size, end_pix_reached);
+  size_t num_pix =
+      pix_map.check_expand_pix_map(4, pix_buffer_size, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
   EXPECT_EQ(pix_buffer_size, num_pix);
 
@@ -395,11 +403,13 @@ TEST_F(TestCombineSQW, Fully_Expand_Pix_Map_From_Start_Threads) {
 
 TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
   pix_mem_map pix_map;
-  const std::size_t pix_buffer_size{ 512 };
-  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, pix_buffer_size, true);
+  const std::size_t pix_buffer_size{512};
+  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE,
+               pix_buffer_size, true);
 
   bool end_pix_reached;
-  size_t num_pix1 = pix_map.check_expand_pix_map(511, pix_buffer_size, end_pix_reached);
+  size_t num_pix1 =
+      pix_map.check_expand_pix_map(511, pix_buffer_size, end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
   EXPECT_EQ(510, num_pix1);
 
@@ -410,8 +420,8 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
 
   // Read whole map in memory requesting map for much bigger number of npixels
   // then the real npix number in the file.
-  size_t num_pix =
-      pix_map.check_expand_pix_map(pix_buffer_size, 2 * NUM_PIXELS, end_pix_reached);
+  size_t num_pix = pix_map.check_expand_pix_map(pix_buffer_size, 2 * NUM_PIXELS,
+                                                end_pix_reached);
   // the file contains
   EXPECT_EQ(sample_pix_pos[NUM_BINS_IN_FILE - 1] +
                 sample_npix[NUM_BINS_IN_FILE - 1] - pix_pos - npix,
@@ -426,7 +436,8 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
   }
   EXPECT_EQ(pix_map.num_pix_in_file(), num_pix + pix_pos + npix);
 
-  num_pix = pix_map.check_expand_pix_map(pix_buffer_size, pix_buffer_size, end_pix_reached);
+  num_pix = pix_map.check_expand_pix_map(pix_buffer_size, pix_buffer_size,
+                                         end_pix_reached);
   ASSERT_FALSE(end_pix_reached);
   EXPECT_EQ(pix_buffer_size, num_pix);
 
@@ -441,8 +452,9 @@ TEST_F(TestCombineSQW, Check_Expand_Pix_Map_Threads) {
 
 TEST_F(TestCombineSQW, Normal_Expand_Mode_Threads) {
   pix_mem_map pix_map;
-  const std::size_t pix_buffer_size{ 512 };
-  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE, pix_buffer_size, true);
+  const std::size_t pix_buffer_size{512};
+  pix_map.init(TEST_FILE_NAME, BIN_POS_IN_FILE, NUM_BINS_IN_FILE,
+               pix_buffer_size, true);
 
   size_t pix_pos, npix;
   pix_map.get_npix_for_bin(0, pix_pos, npix);

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/pix_map_tester.h
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/pix_map_tester.h
@@ -1,0 +1,33 @@
+#include "combine_sqw/pix_mem_map.h"
+
+class PixMapTester : public pix_mem_map {
+public:
+  void read_bins(std::size_t num_bins,
+                 std::vector<pix_mem_map::bin_info> &buffer,
+                 std::size_t &bin_end, std::size_t &buf_end) {
+    pix_mem_map::_read_bins(num_bins, buffer, bin_end, buf_end);
+  };
+
+  void read_bins_job() { pix_mem_map::read_bins_job(); }
+
+  std::size_t get_first_thread_bin() const { return n_first_rbuf_bin; }
+  std::size_t get_last_thread_bin() const { return rbuf_nbin_end; }
+  std::size_t get_n_buf_pix() const { return rbuf_end; }
+
+  void wait_for_read_to_complete() {
+    std::unique_lock<std::mutex> data_ready(this->exchange_lock);
+    this->bins_ready.wait(data_ready, [this]() { return this->nbins_read; });
+  }
+
+  bool thread_get_data(std::size_t &num_bin, std::vector<bin_info> &inbuf,
+                       std::size_t &bin_end, std::size_t &buf_end) {
+    return pix_mem_map::_thread_get_data(num_bin, inbuf, bin_end, buf_end);
+  }
+  void thread_query_data(std::size_t &num_first_bin, std::size_t &num_last_bin,
+                         std::size_t &buf_end) {
+    pix_mem_map::_thread_query_data(num_first_bin, num_last_bin, buf_end);
+  }
+  void thread_request_to_read(std::size_t start_bin) {
+    pix_mem_map::_thread_request_to_read(start_bin);
+  }
+};

--- a/_LowLevelCode/cpp/test/combine_sqw.tests/pix_map_tester.h
+++ b/_LowLevelCode/cpp/test/combine_sqw.tests/pix_map_tester.h
@@ -2,10 +2,10 @@
 
 class PixMapTester : public pix_mem_map {
 public:
-  void read_bins(std::size_t num_bins,
+  void read_bins(std::size_t starting_bin_num,
                  std::vector<pix_mem_map::bin_info> &buffer,
                  std::size_t &bin_end, std::size_t &buf_end) {
-    pix_mem_map::_read_bins(num_bins, buffer, bin_end, buf_end);
+    pix_mem_map::_read_bins(starting_bin_num, buffer, bin_end, buf_end);
   };
 
   void read_bins_job() { pix_mem_map::read_bins_job(); }

--- a/_test/disabled_tests.md
+++ b/_test/disabled_tests.md
@@ -31,7 +31,3 @@
 - test_proj_captions.m  : part of https://github.com/pace-neutrons/Horace/issues/49 -- generic projection refactoring
 	- test_spher_caption (no ticket)
 	- test_spher_caption2D (no ticket)
-
-- combine_sqw.test.cpp
-	- SQW_Reader_Propagate_Pix
-	- SQW_Reader_Read_All


### PR DESCRIPTION
The disabled tests were failing as they were attempting to read floats from a file, but were reading in 8 bytes, not 4.

I've replaced `ASSERT_EQ` with `EXPECT_EQ` in the tests. As many tests have multiple assertions, this prevents the tests terminating before the rest of the test is run.

There's probably more refactoring/breaking down of tests that can be done, but hopefully this is a start.
