### PR TITLE
Increase CTest timeout for test_sqw to 25 mins

### DIFF
--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -42,7 +42,7 @@ foreach(_test_dir ${TEST_DIRECTORIES})
     if("${_test_dir}" STREQUAL "test_sqw")
         set(TEST_TIMEOUT_LENGTH "1500")  # 25 minutes
     else()
-        set(TEST_TIMEOUT_LENGTH "900")  # 16 minutes
+        set(TEST_TIMEOUT_LENGTH "960")  # 16 minutes
     endif()
     matlab_add_unit_test(
         NAME "${TEST_NAME}"

--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -37,9 +37,13 @@ set(ENV_VARIABLES
     "TMP=${CMAKE_BINARY_DIR}/tests"
 )
 
-set(TEST_TIMEOUT_LENGTH "1200")  # 40 minutes
 foreach(_test_dir ${TEST_DIRECTORIES})
     set(TEST_NAME "Matlab.${_test_dir}")
+    if("${_test_dir}" STREQUAL "test_sqw")
+        set(TEST_TIMEOUT_LENGTH "1500")  # 25 minutes
+    else()
+        set(TEST_TIMEOUT_LENGTH "900")  # 16 minutes
+    endif()
     matlab_add_unit_test(
         NAME "${TEST_NAME}"
         CUSTOM_TEST_COMMAND


### PR DESCRIPTION
The test was timing out regularly (and at different stages) on the Windows build server.

I've also reduced the timeout length for the other tests, since the previous (20 mins) was a bit long. 

Reasoning for 16min timeout on other tests: `test_tobyfit` is the next longest test and takes ~730 seconds on Windows. If other jobs are running this could easily take another couple of minutes and there's also another TobyFit test to re-enable.

Fixes #180 