### PR TITLE
wrong faccess initialization

### DIFF
--- a/_test/test_sqw_file/test_faccess_sqw_v3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3.m
@@ -130,6 +130,7 @@ classdef test_faccess_sqw_v3< TestCase
             inst1 = to.get_instrument(1);
             assertEqual(inst,inst1);
         end
+        %
         function obj = test_get_sqw(obj)
             
             fo = faccess_sqw_v3();
@@ -287,6 +288,44 @@ classdef test_faccess_sqw_v3< TestCase
             
             assertEqual(fo,fr);
         end
+        %
+        function test_wrong_file_name_activated(obj)
+            ld = sqw_formats_factory.instance.get_loader(obj.sample_file);
+            sample_obj = ld.get_sqw();
+            
+            test_name = 'test_wrong_file_name_activated_1.sqw';
+            targ_file = fullfile(tmp_dir(),test_name);
+            
+            wrt =sqw_formats_factory.instance.get_pref_access(sample_obj);
+            wrt = wrt.init(sample_obj,targ_file);
+            
+            % test file has been stored with name test_name.
+            wrt.put_sqw();
+            test_name_2 = 'test_wrong_file_name_activated_2.sqw';
+            targ_file_2 = fullfile(tmp_dir(),test_name_2);
+            wrt.delete();
+            clob1 = onCleanup(@()delete(targ_file));
+            copyfile(targ_file,targ_file_2);
+            clob = onCleanup(@()delete(targ_file_2));
+            
+            % test file has been recovered with the name test_name_2.
+            ld = sqw_formats_factory.instance.get_loader(targ_file_2);
+            assertEqual(ld.filename,test_name_2);
+            assertEqual(ld.filepath,tmp_dir());
+        end
+        %
+        function test_correct_file_activated(obj)
+            test_name = 'test_correct_activation.sqw';
+            targ_file = fullfile(tmp_dir(),test_name);
+            copyfile(obj.sample_file,targ_file);
+            clob = onCleanup(@()delete(targ_file));
+            
+            fo = faccess_sqw_v3();
+            fo = fo.init(targ_file);
+            assertEqual(fo.filename,test_name);
+            assertEqual(fo.filepath,tmp_dir());
+        end
+        
         
     end
 end

--- a/_test/test_sqw_file/test_faccess_sqw_v3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3.m
@@ -304,9 +304,9 @@ classdef test_faccess_sqw_v3< TestCase
             test_name_2 = 'test_wrong_file_name_activated_2.sqw';
             targ_file_2 = fullfile(tmp_dir(),test_name_2);
             wrt.delete();
-            clob1 = onCleanup(@()delete(targ_file));
+            clob_for_tf1 = onCleanup(@()delete(targ_file));
             copyfile(targ_file,targ_file_2);
-            clob = onCleanup(@()delete(targ_file_2));
+            clob_for_tf2 = onCleanup(@()delete(targ_file_2));
             
             % test file has been recovered with the name test_name_2.
             ld = sqw_formats_factory.instance.get_loader(targ_file_2);

--- a/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
+++ b/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
@@ -237,6 +237,9 @@ classdef dnd_binfile_common < dnd_file_interface
                     obj.(flds{i}) = obj_structure_from_saveobj.(flds{i});
                 end
             end
+            if obj.is_activated()
+                return;
+            end
             if ~ischar(obj.num_dim_) && ~isempty(obj.filename_)
                 file = fullfile(obj.filepath,obj.filename);
                 if exist(file,'file') == 2
@@ -452,13 +455,12 @@ classdef dnd_binfile_common < dnd_file_interface
             sqw_obj  = obj.sqw_holder_;
         end
         %
-        function struc = saveobj(obj)
-            % method used to convert object into structure
-            % for saving it to disc.
-            struc = saveobj@dnd_file_interface(obj);
-            flds = obj.fields_to_save_;
-            for i=1:numel(flds)
-                struc.(flds{i}) = obj.(flds{i});
+        function is = is_activated(obj)
+            % check if the file-accessor is bind with open binary file
+            if ~isempty(obj.file_closer_) && obj.file_id_ >0
+                is  = true;
+            else
+                is = false;
             end
         end
         %
@@ -494,7 +496,16 @@ classdef dnd_binfile_common < dnd_file_interface
             end
             obj.file_closer_ = onCleanup(@()obj.fclose());
         end
-        
+        %
+        function struc = saveobj(obj)
+            % method used to convert object into structure
+            % for saving it to disc.
+            struc = saveobj@dnd_file_interface(obj);
+            flds = obj.fields_to_save_;
+            for i=1:numel(flds)
+                struc.(flds{i}) = obj.(flds{i});
+            end
+        end
     end
     %
     methods(Static)

--- a/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
+++ b/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
@@ -456,17 +456,14 @@ classdef dnd_binfile_common < dnd_file_interface
         end
         %
         function is = is_activated(obj)
-            % check if the file-accessor is bind with open binary file
-            if ~isempty(obj.file_closer_) && obj.file_id_ >0
-                is  = true;
-            else
-                is = false;
-            end
+            % Check if the file-accessor is bind with open binary file
+            %
+            is =  ~isempty(obj.file_closer_) && obj.file_id_ >0;
         end
         %
         function obj = deactivate(obj)
-            % close respective file keeping all internal information about
-            % this file alive.
+            % Close respective file keeping all internal information about
+            % this file in memory.
             %
             % To use for MPI transfers between workers when open file can
             % not be transferred between workers but everything else can
@@ -480,7 +477,7 @@ classdef dnd_binfile_common < dnd_file_interface
         function obj = activate(obj)
             % open respective file for reading without reading any
             % supplementary file information. Assume that this information
-            % is correct
+            % is correct.
             %
             % To use for MPI transfers between workers when open file can
             % not be transferred between workers but everything else can

--- a/horace_core/sqw/file_io/@dnd_file_interface/dnd_file_interface.m
+++ b/horace_core/sqw/file_io/@dnd_file_interface/dnd_file_interface.m
@@ -295,6 +295,11 @@ classdef dnd_file_interface
         % write dnd image data, namely s, err and npix ('-update' option updates this
         % information within existing file)
         obj = put_dnd_data(obj,varargin);
+        % Return true if the file accessor is connected to an open file
+        is = is_activated(obj);
+        % initialize 
+        obj = activate(obj)
+        
     end
     methods(Abstract,Access=protected,Hidden=true)
         % init file accessors from sqw object in memory

--- a/horace_core/sqw/file_io/@dnd_file_interface/dnd_file_interface.m
+++ b/horace_core/sqw/file_io/@dnd_file_interface/dnd_file_interface.m
@@ -297,8 +297,13 @@ classdef dnd_file_interface
         obj = put_dnd_data(obj,varargin);
         % Return true if the file accessor is connected to an open file
         is = is_activated(obj);
-        % initialize 
+        % open file, connected to the sqw object, defined as input,
+        % assuming that all information about this file is already loaded
+        % in memory by init/deactivate or deserialize methods.
         obj = activate(obj)
+        % Close files related to this file accessor leaving all information
+        % about this file in memory, e.g. preparing to serialize the class.
+        obj = deactivate(obj)
         
     end
     methods(Abstract,Access=protected,Hidden=true)


### PR DESCRIPTION
This PR fixes issue, mentioned in Toby's letter from 09/04/2020
 test_Toby

*** Writing to C:\Users\tgp98\AppData\Local\Temp\tobyfit_refine_crystal_res.sqw...

Check lattice parameters before application of correction

                                   reference dataset: 5  5  5

Copy of reference dataset before correction applied: 5  5  5

-----------------------------------------------------------------------

Get reorientation matrix to apply to copy of reference dataset only:

-----------------------------------------------------------------------

Check lattice parameters after application of correction

                                  reference dataset: 5  5  5

Copy of reference dataset after correction applied: 4.7468       4.747       4.747

>> 

 

Latest copy, doing the wrong thing:

>> test_Toby

*** Writing to C:\Users\tgp98\AppData\Local\Temp\tobyfit_refine_crystal_res.sqw...

Check lattice parameters before application of correction

                                   reference dataset: 5  5  5

Copy of reference dataset before correction applied: 5  5  5

-----------------------------------------------------------------------

Get reorientation matrix to apply to copy of reference dataset only:

-----------------------------------------------------------------------

Check lattice parameters after application of correction

                                  reference dataset: 4.7468       4.747       4.747

Copy of reference dataset after correction applied: 4.7468       4.747       4.747

>> 