### PR TITLE
Remove references to Fortran in docs and code

### DIFF
--- a/admin/horace_mex.m
+++ b/admin/horace_mex.m
@@ -1,8 +1,8 @@
 function horace_mex
 % Usage:
 % horace_mex;
-% Create mex files for all the Horace Fortran and C(++) routines
-% assuming that proper mex file compilers are configured for Matlab
+% Create mex files for all the Horace C(++) routines assuming that proper mex 
+% file compilers are configured for Matlab
 %
 % to configure a gcc compiler (version >= 4.3 requested)  to produce omp
 % code one have to edit  ~/.matlab/mexoptions.sh file and add -fopenmp key
@@ -48,11 +48,10 @@ try % mex C++
     disp('**********> Creating mex files from C++ code')
     % root directory is assumed to be that in which this function resides
     cd(root_dir);
-    
-    fortran_in_rel_dir = ['_LowLevelCode',filesep,'intel',filesep];
+
     cpp_in_rel_dir = ['_LowLevelCode',filesep,'cpp',filesep];
     % get folder names corresponding to the current Matlab version and OS
-    [VerFolderName,versionDLLextention,OSdirname]=matlab_version_folder();
+    [VerFolderName, ~, OSdirname] = matlab_version_folder();
     if ispc
         out_rel_dir = fullfile('horace_core','DLL',OSdirname);
         out_hdf_dir = fullfile('horace_core','DLL',OSdirname,VerFolderName);
@@ -95,23 +94,9 @@ catch ME
     message=ME.message;
     warning('**********> Can not create C++ combining procedure, reason: %s. combining using C++ is not availile',message);
 end
-%
-F_compiled=false;
-try  % mex FORTRAN
-    disp('**********> Creating mex files from FORTRAN code')
-    %    mex_single(fortran_in_rel_dir, out_rel_dir,'get_par_fortran.F','IIget_par_fortran.f');
-    %    mex_single(fortran_in_rel_dir, out_rel_dir,'get_phx_fortran.f','IIget_phx_fortran.f');
-    %    mex_single([fortran_in_rel_dir 'get_spe_fortran' filesep 'get_spe_fortran'], out_rel_dir,'get_spe_fortran.F','IIget_spe_fortran.F');
-    %
-    %    disp('**********> Successfully created all requested mex files from FORTRAN')
-    disp('**********> No FORTRAN functions used at the moment')
-    F_compiled=true;
-catch ME
-    message=ME.message;
-    warning('**********> Can not create FORTRAN mex files, reason: %s Please try to do it manually.',message);
-end
+
 cd(start_dir);
-if C_compiled && F_compiled
+if C_compiled
     set(hor_config,'use_mex',true);
 end
 
@@ -202,7 +187,7 @@ end
 
 function access =check_access(outdir,filename)
 
-[spath,sfname] = fileparts(filename);
+[~, sfname] = fileparts(filename);
 fname = fullfile(outdir,[sfname,'.',mexext()]);
 
 if exist(fname,'file')

--- a/documentation/add/01_add.md
+++ b/documentation/add/01_add.md
@@ -4,12 +4,12 @@
 
 Horace is a suite of programs for the visualization and analysis of large datasets from time-of-flight neutron inelastic scattering spectrometers
 
-The code is split into two projects: 
+The code is split into two projects:
 
 - `Horace`: user-level functions
 - `Herbert`: a library of lower-level data manipulation routines that are used by Horace, but may be used independently.
 
-Both projects include a small number of C++ and Fortran implementations of performance critical routines.
+Both projects include a small number of C++ implementations of performance critical routines.
 
 The Horace code base includes a fallback implementation of each of the C++ routines for use in the compiled source has not been loaded.
 
@@ -32,18 +32,9 @@ These operations include:
 - read ASCII Tobyfit `.par` files, `.spe` or `.phx` data files
 - combine_sqw
 
-### Fortran
-
-The routines which do rebinning and integration are still needed, as these operations are not ones that are intrinsically vectorisable -- there were situations when the equivalent MATLAB was vastly slower - say two orders of magnitude when the number of bins in the input data that was being rebinned when they were written. 
-
-There are some utility routines that are called by the rebinning and integration routines (e.g. upper_index). There is no C++ that performs the same functions. 
-
-Other Fortran is no longer needed, for example that which reads the old Mslice slices and cuts (Mslice is a MATLAB program that is still use a bit to look at neutron data at ISIS and elsewhere), but there are MATLAB routines which do the same job and they can be retained as a fallback. 
-
 ### Python
 
 TBI - this will replicate the MATLAB API to support users with Python rather than MATLAB skills.
-
 
 ## MPI Framework
 
@@ -60,15 +51,13 @@ The MATLAB source for Horace  defines two core data objects that represent exper
 - SQW is the core data object for Horace. The object contains the raw pixel data (file-backed), methods to transform, combine. slice and process it and metadata describing the instrument and experiment.
 - DND objects share common structure with SQW but exclude the raw pixel data, detector information and other headers
 
-
 #### V3 Implementation
 
-The Horace v3 [implementation](./02_sqw_current_implementation.md) 
+The Horace v3 [implementation](./02_sqw_current_implementation.md)
 
 - uses "classic" MATLAB classes
 - implements over 150 public methods in the API
 - includes significant code duplication between the SQW and DND objects
-
 
 #### V4 redesign
 
@@ -99,11 +88,11 @@ Work on Vertical Slices of key project functions:
   - return SQW data object
 - symmetrize : Symmetrize a SQW dataset in a plane specified by the a vector triple.
 - cut-sqw : Take a cut from an SQW object by integrating over one or more axes.
-- projections : 
+- projections :
 
  These slices are all dependent on the `sqw` object for which the updated API must be designed.
 
-See:  
+See:
 - [Generic Projections](./06-generic_projection.md)
 - [SQW Object redesign](./07-sqw_redesign.md)
 

--- a/documentation/smg/08_setting_up_jenkins_ci.md
+++ b/documentation/smg/08_setting_up_jenkins_ci.md
@@ -149,7 +149,6 @@ The build scripts are intended to work locally as well as on Jenkins, so any Jen
 | Argument (`.ps1`) | Argument (`.sh`) | Default | |
 | --------------- | ------- | ---- | ---- |
 | `-build_tests` | `--build_tests`, `-X` | `ON` | Build test files (`ON` \| `OFF`) |
-| `-build_fortran` | `--build_fortran`, `-N` | `OFF` | Build Fortran source (`ON` \| `OFF`) |
 | `-build_config` | `--build_config`, `-C` | `Release` | Build configuration to use (`Release` \| `Debug`) |
 | `-build_dir` | `--build_dir`, `-O` | `./build` | Output directory for CMake build |
 | `-cmake_flags` | `--cmake_flags`, `-F` | | Custom parameters to pass to CMake configure step |
@@ -158,9 +157,9 @@ The build scripts are intended to work locally as well as on Jenkins, so any Jen
 Actions may be combined so to call the script and only build use the `--build` flag, to build and test use both flags `--build --test`.
 
 Notes:
+
 1. The Visual Studio version must match a configured Visual Studio release or an error will be thrown
 2. PowerShell uses *a single dash* for parameters, i.e. `-build -test -package`.
-
 
 ## Authentication
 

--- a/documentation/smg/09_version_compatibility.md
+++ b/documentation/smg/09_version_compatibility.md
@@ -1,15 +1,12 @@
 # Version Compatibility
 
-
-
 For each MATLAB release, MathWorks define a limited compatibility matrix of libraries and compilers.
 
-Information on compiler compatibility is available from the [MathWorks](https://uk.mathworks.com/support/requirements/previous-releases.html) site. This does not document information about library dependencies.
+Information on compiler compatibility is available from the
+[MathWorks](https://uk.mathworks.com/support/requirements/previous-releases.html)
+site. This does not document information about library dependencies.
 
-
-
-### Compilers
-
+## Compilers
 
 | C++  |    | R2019b | R2019a | R2018b | R2018a | R2017b | R2015b |
 | :--- | --- | :---: | :---: | :---: | :---: | :---: | :---: |
@@ -28,37 +25,13 @@ Information on compiler compatibility is available from the [MathWorks](https://
 |            | 7.x  |  | |  | | y |  |
 |            | 6.x  |  | |  | |  | y |
 |            | 5.1+  |  | |  | |  | y |
-| <b>Fortran</b> |       |  | |  | |  |  |
-|Windows (Intel [1]) | XE 2019 |y|y|||||
-|                    | XE 2018 |y|y|y||||
-|                    | XE 2017 |y|y|y|y|y||
-|                    | XE 2016 ||y|y|y|y||
-|                    | XE 2015 ||y|y|y|y||
-|                    | XE 2013 ||||y|y|y|
-|                    | XE 2011 ||||||y|
-|Linux (gFortran) | 6.3.x | y | y | y | y |  |  |
-|                 | 4.9 | | |  | | y |  |
-|                 | 4.7.x |   | |  | |  | y |
-|Mac (Intel [2]) | XE 2019 |y|y|||||
-|                    | XE 2018 |y|y|y||||
-|                    | XE 2017 |y|y|y|y|y||
-|                    | XE 2016 ||y|y|y|y||
-|                    | XE 2015 ||y|y|y|y||
-|                    | XE 2013 |||||y|y|
-
-Notes:
-
-1. Intel Parallel Studio 2015-2019; Intel Visual Fortran Composer 2011-2013
-2. Intel Parallel Studio 2015-2019; Intel Fortran Composer 2013
-
-
 
 ### Libraries
 
 | HDF5 | | R2019b | R2019a | R2018b | R2018a | R2017b | R2015b |
 | :--- | --- | :---: | :---: | :---: | :---: | :---: | :---: |
 | | 1.8.12 | y | y | y | y |  y |  y |
-| <b>MPI</b> |    |  | |  | |  |  |
+| **MPI** |    |  | |  | |  |  |
 | Windows (MSMPI) | 8.0.12438 | y | y | y | y |   | n/a |
 |                 | 5.0.12435 |   |   |   |   | y | n/a |
 | Linux (MPICH2) | 1.4.1p1 | y | y | y | y | ? | n/a |


### PR DESCRIPTION
This PR removes references to Fortran in Horace docs and build scripts now that the Fortran has been removed from Herbert

Fixes #206 