### PR TITLE
Add ADR for SAN path and credentials management

### DIFF
--- a/documentation/adr/0012-use-network-storage-for-large-datafiles.md
+++ b/documentation/adr/0012-use-network-storage-for-large-datafiles.md
@@ -1,4 +1,4 @@
-[<-previous](0011-version-project-with-cmake.md) | next->
+[<-previous](0011-version-project-with-cmake.md) |  [next->](./0013-use-jenkins-for-secrets-management.md)
 
 # 12 - Use network storage for large data files
 

--- a/documentation/adr/0013-use-jenkins-for-secrets-management.md
+++ b/documentation/adr/0013-use-jenkins-for-secrets-management.md
@@ -10,7 +10,8 @@ Accepted
 
 ## Context
 
-The build processes for all of the PACE projects require credentials to access GitHub and the SAN area. These need to be securely and accessible as steps in the Jenkinsfile and any scripts launched from that.
+The build processes for all of the PACE projects require credentials to access GitHub and the SAN area. 
+These need to be stored securely and be accessible to steps in the Jenkinsfile and any scripts launched from that.
 
 For security reasons this data cannot be stored in the build or pipeline scripts as these are stored in GitHub.
 
@@ -20,7 +21,7 @@ The data will be stored in ANVIL through the available Jenkins [Credentials](htt
 
 A `file` object will be used for the SAN credentials as this maps directly onto the format required by be `gio mount` syntax on Linux build nodes.
 
-A `string` objects will be used for other credentials types, e.g. GitHub access tokens.
+A `string` object will be used for other credentials types, e.g. GitHub access tokens.
 
 Credentials will be stored in the `PACE-neutrons`  store and use `snake_case` IDs that clearly identify their use. The first word will identify the associated system, e.g. `SAN_credentials_file`.
 

--- a/documentation/adr/0013-use-jenkins-for-secrets-management.md
+++ b/documentation/adr/0013-use-jenkins-for-secrets-management.md
@@ -1,0 +1,45 @@
+[<-previous](./0012-use-network-storage-for-large-datafiles.md) | [next->](./0014-use-jenkins-for-network-path-storage.md)
+
+# 13 - Use Jenkins for Secrets Management
+
+Date: 2020-May-18
+
+## Status
+
+Accepted
+
+## Context
+
+The build processes for all of the PACE projects require credentials to access GitHub and the SAN area. These need to be securely and accessible as steps in the Jenkinsfile and any scripts launched from that.
+
+For security reasons this data cannot be stored in the build or pipeline scripts as these are stored in GitHub.
+
+## Decision
+
+The data will be stored in ANVIL through the available Jenkins [Credentials](https://plugins.jenkins.io/credentials/) plugin.
+
+A `file` object will be used for the SAN credentials as this maps directly onto the format required by be `gio mount` syntax on Linux build nodes.
+
+A `string` objects will be used for other credentials types, e.g. GitHub access tokens.
+
+Credentials will be stored in the `PACE-neutrons`  store and use `snake_case` IDs that clearly identify their use. The first word will identify the associated system, e.g. `SAN_credentials_file`.
+
+
+
+## Consequences
+
+- Credentials are stored in one location and can be accessed by all PACE projects.
+
+- Stored credentials accessible as variables from Jenkinsfile which can be passed into called scripts via 
+
+  ```
+  withCredentials([string(credentialsId: 'github_token', variable: 'my_github_token')]) {
+    sh '''
+      my-script.sh $my_github_token
+    '''
+  }
+  ```
+
+- It is NOT possible to view the values of the credentials stored in the Jenkins Credentials plugin and their values are masked in build logs.
+
+- These credentials will not be available on developer machines executing the build scripts. Access to SAN and GitHub should use the developers credentials.

--- a/documentation/adr/0014-use-jenkins-for-network-path-storage.md
+++ b/documentation/adr/0014-use-jenkins-for-network-path-storage.md
@@ -1,0 +1,41 @@
+[<-previous](./0013-use-jenkins-for-secrets-management.md) | next->
+
+# 14 - Use Jenkins for Network Path Storage
+
+Date: 2020-May-18
+
+## Status
+
+Accepted
+
+## Context
+
+The [large data storage area](./0012-use-network-storage-for-large-datafiles.md) is shared by all the PACE projects and accessed via as network path.
+
+This path should not be hard-coded in any scripts in order that it can be easily updated if the network storage location is moved.
+
+For security reasons it is undesirable for this path to be stored in configuration files in the GitHub repositories.
+
+## Decision
+
+The data will be stored in ANVIL through the available Jenkins [Credentials](https://plugins.jenkins.io/credentials/) plugin.
+
+The path will be stored the `PACE-neutrons`  store with the ID `SAN_path`.
+
+## Consequences
+
+- The path is only stored once and shared across all projects, so may be simply updated.
+
+- The path is accessible as a variable from the Jenkinsfile and passed into called scripts via 
+
+  ```
+  withCredentials([string(credentialsId: 'SAN_path', variable: 'san_path')]) {
+    sh '''
+      my-script.sh $san_path
+    '''
+  }
+  ```
+
+- It is NOT possible to view the values of the path stored in the Jenkins Credentials plugin and its value will be masked in the build logs.
+
+- This path will NOT be accessible on a developer machine. If the path is used as a variable within a build script a separate configuration process must be set up.


### PR DESCRIPTION
Add missing ADRs for the decisions made regarding use of Jenkins for the SAN credentials storage