### PR TITLE
Add file-backed read access to PixelData API

### DIFF
--- a/_test/test_sqw/FakeFAccess.m
+++ b/_test/test_sqw/FakeFAccess.m
@@ -3,6 +3,7 @@ classdef FakeFAccess < sqw_binfile_common
 
 properties
     fake_data = [];
+    closed = false;
 end
 
 methods
@@ -33,6 +34,18 @@ methods
 
     function new_obj = upgrade_file_format(obj)
         new_obj = [];
+    end
+
+    function obj = fclose(obj)
+        obj.closed = true;
+    end
+
+    function obj = activate(obj)
+        obj.closed = false;
+    end
+
+    function is = is_activated(obj)
+        is = ~obj.closed;
     end
 
 end

--- a/_test/test_sqw/FakeFAccess.m
+++ b/_test/test_sqw/FakeFAccess.m
@@ -19,7 +19,16 @@ methods
             pix_lo = 1;
             pix_hi = size(obj.fake_data, 2);
         end
-        data = obj.fake_data(:, pix_lo:pix_hi);
+        try
+            data = obj.fake_data(:, pix_lo:pix_hi);
+        catch ME
+            switch ME.identifier
+            case 'MATLAB:badsubscript'
+                error('FAKEFACCESS:get_pix', 'End of fake file reached');
+            otherwise
+                rethrow(ME);
+            end
+        end
     end
 
     function new_obj = upgrade_file_format(obj)

--- a/_test/test_sqw/FakeFAccess.m
+++ b/_test/test_sqw/FakeFAccess.m
@@ -1,0 +1,31 @@
+classdef FakeFAccess < sqw_binfile_common
+% A fake file access class that can return data as if from an sqw file
+
+properties
+    fake_data = [];
+end
+
+methods
+
+    function obj = FakeFAccess(data)
+        obj.fake_data = data;
+        obj.npixels_ = size(data, 2);
+    end
+
+    function data = get_pix(obj, varargin)
+        if nargin > 2
+            [pix_lo, pix_hi] = varargin{:};
+        else
+            pix_lo = 1;
+            pix_hi = size(obj.fake_data, 2);
+        end
+        data = obj.fake_data(:, pix_lo:pix_hi);
+    end
+
+    function new_obj = upgrade_file_format(obj)
+        new_obj = [];
+    end
+
+end
+
+end

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -386,9 +386,11 @@ methods
     function test_page_size_is_set_on_construction_when_given_as_argument(obj)
         mem_alloc = obj.small_page_size_;  % 1Mb
         expected_page_size = floor(mem_alloc/(8*9));  % mem_alloc/(double*num_rows)
-        assertEqual(obj.pix_data_small_page.page_size, expected_page_size);
+        % the first page is loaded on access, so this first assert which accesses
+        % .variance is necessary to set pix.page_size
         assertEqual(size(obj.pix_data_small_page.variance), ...
                     [1, obj.pix_data_small_page.page_size]);
+        assertEqual(obj.pix_data_small_page.page_size, expected_page_size);
     end
 
     function test_calling_getter_returns_data_for_single_page(~)

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -346,6 +346,8 @@ methods
     function test_construction_with_file_path_sets_num_pixels_in_file(obj)
         f_accessor = sqw_formats_factory.instance().get_loader(...
                 obj.test_sqw_file_path);
+        assertEqual(obj.pix_data_from_file.num_pixels, f_accessor.npixels);
+    end
 
     function test_construction_with_file_path_sets_size(obj)
         f_accessor = sqw_formats_factory.instance().get_loader(...

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -198,8 +198,15 @@ methods
         assertTrue(isempty(pix_data_obj));
     end
 
-    function test_PIXELDATA_error_if_constructed_with_non_numeric_type(~)
-        f = @() PixelData('non_numeric');
+    function test_PIXELDATA_error_if_constructed_with_struct(~)
+        s = struct();
+        f = @() PixelData(s);
+        assertExceptionThrown(f, 'PIXELDATA:data')
+    end
+
+    function test_PIXELDATA_error_if_constructed_with_cell_array(~)
+        s = {'a', 1};
+        f = @() PixelData(s);
         assertExceptionThrown(f, 'PIXELDATA:data')
     end
 
@@ -311,11 +318,11 @@ methods
         assertExceptionThrown(f, 'PIXELDATA:data');
     end
 
-    function test_construction_with_char_raises_PIXELDATA_error(~)
-        f = @() PixelData('1');
-        assertExceptionThrown(f, 'PIXELDATA:data');
+    function test_construction_with_file_path_sets_file_path_on_object(~)
+        file_path = '../test_sqw_file/sqw_1d_1.sqw';
+        pix_data = PixelData(file_path);
+        assertEqual(pix_data.file_path, file_path);
     end
-
 end
 
 end

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -379,6 +379,13 @@ methods
         assertEqual(obj.pix_data_from_faccess.file_path, expected_abs_path);
     end
 
+    function test_page_size_is_set_on_construction_when_given_as_argument(obj)
+        mem_alloc = 1e6;  % 1Mb
+        pix = PixelData(obj.test_sqw_file_path, mem_alloc);
+        expected_page_size = floor(mem_alloc/(8*9));  % mem_alloc/(double*num_rows)
+        assertEqual(pix.page_size, expected_page_size);
+    end
+
 end
 
 end

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -528,6 +528,16 @@ methods
         assertEqual(pix.page_size, 0);
     end
 
+    function test_constructing_from_PixelData_with_valid_file_inits_faccess(obj)
+        new_pix = PixelData(obj.pix_data_small_page);
+        test_file = java.io.File(pwd(), obj.test_sqw_file_path);
+        expected_file_path = char(test_file.getCanonicalPath());
+        assertEqual(new_pix.file_path, expected_file_path);
+        assertEqual(new_pix.num_pixels, obj.pix_data_small_page.num_pixels);
+        assertEqual(new_pix.signal, obj.pix_data_small_page.signal);
+        assertTrue(new_pix.has_more());
+    end
+
 end
 
 methods (Static)

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -425,9 +425,9 @@ methods
         faccess = FakeFAccess(data);
         mem_alloc = 11*8*9;
         pix = PixelData(faccess, mem_alloc);
-        assertTrue(isempty(pix.data));
+        assertEqual(pix.page_size, 0);
         pix.u1;
-        assertFalse(isempty(pix.data));
+        assertFalse(pix.page_size == 0);
     end
 
     function test_number_of_pixels_in_page_matches_memory_usage_size(~)
@@ -521,6 +521,11 @@ methods
         assertEqual(pix.page_size, 10);
         pix.data = zeros(9, 12);
         assertEqual(pix.page_size, 12);
+    end
+
+    function test_empty_PixelData_object_has_page_size_zero(~)
+        pix = PixelData();
+        assertEqual(pix.page_size, 0);
     end
 
 end

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -4,6 +4,7 @@ properties
     raw_pix_data = rand(9, 10);
     small_page_size_ = 1e6;  % 1Mb
     test_sqw_file_path = '../test_sqw_file/sqw_1d_1.sqw';
+    test_sqw_file_full_path = '';
 
     pixel_data_obj;
     pix_data_from_file;
@@ -27,6 +28,9 @@ methods
 
     function obj = test_PixelData(~)
         obj = obj@TestCase('test_PixelData');
+
+        test_sqw_file = java.io.File(pwd(), obj.test_sqw_file_path);
+        obj.test_sqw_file_full_path = char(test_sqw_file.getCanonicalPath());
 
         % Construct an object from raw data
         obj.pixel_data_obj = PixelData(obj.raw_pix_data);
@@ -335,9 +339,7 @@ methods
 
     % --- Tests for file-backed operations ---
     function test_construction_with_file_path_sets_file_path_on_object(obj)
-        expected_file = java.io.File(fullfile(pwd(), obj.test_sqw_file_path));
-        expected_path = char(expected_file.getCanonicalPath());
-        assertEqual(obj.pix_data_from_file.file_path, expected_path);
+        assertEqual(obj.pix_data_from_file.file_path, obj.test_sqw_file_full_path);
     end
 
     function test_construction_with_file_path_populates_data_from_file(obj)
@@ -378,12 +380,10 @@ methods
     end
 
     function test_construction_with_faccess_sets_file_path(obj)
-        file = java.io.File(fullfile(pwd(), obj.test_sqw_file_path));
-        expected_path = char(file.getCanonicalPath());
-        assertEqual(obj.pix_data_from_faccess.file_path, expected_path);
+        assertEqual(obj.pix_data_from_faccess.file_path, obj.test_sqw_file_full_path);
     end
 
-    function test_page_size_is_set_on_construction_when_given_as_argument(obj)
+    function test_page_size_is_set_after_getter_call_when_given_as_argument(obj)
         mem_alloc = obj.small_page_size_;  % 1Mb
         expected_page_size = floor(mem_alloc/(8*9));  % mem_alloc/(double*num_rows)
         % the first page is loaded on access, so this first assert which accesses
@@ -530,9 +530,7 @@ methods
 
     function test_constructing_from_PixelData_with_valid_file_inits_faccess(obj)
         new_pix = PixelData(obj.pix_data_small_page);
-        test_file = java.io.File(pwd(), obj.test_sqw_file_path);
-        expected_file_path = char(test_file.getCanonicalPath());
-        assertEqual(new_pix.file_path, expected_file_path);
+        assertEqual(new_pix.file_path, obj.test_sqw_file_full_path);
         assertEqual(new_pix.num_pixels, obj.pix_data_small_page.num_pixels);
         assertEqual(new_pix.signal, obj.pix_data_small_page.signal);
         assertTrue(new_pix.has_more());

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -346,8 +346,16 @@ methods
     function test_construction_with_file_path_sets_num_pixels_in_file(obj)
         f_accessor = sqw_formats_factory.instance().get_loader(...
                 obj.test_sqw_file_path);
-        num_pix_in_file = f_accessor.npixels;
-        assertEqual(obj.pix_data_from_file.num_pixels, num_pix_in_file);
+
+    function test_construction_with_file_path_sets_size(obj)
+        f_accessor = sqw_formats_factory.instance().get_loader(...
+                obj.test_sqw_file_path);
+        size_ax_1 = size(obj.pix_data_from_file, 1);
+        assertEqual(size_ax_1, 9);
+
+        size_ax_2 = size(obj.pix_data_from_file, 2);
+        assertEqual(size_ax_2, f_accessor.npixels);
+        assertEqual(obj.pix_data_from_file.num_pixels, f_accessor.npixels);
     end
 
     function test_error_on_construction_with_non_existent_file(~)

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -335,9 +335,9 @@ methods
 
     % --- Tests for file-backed operations ---
     function test_construction_with_file_path_sets_file_path_on_object(obj)
-        [dir_name, file_name, ext] = fileparts(obj.test_sqw_file_path);
-        expected_abs_path = fullfile(what(dir_name).path, [file_name, ext]);
-        assertEqual(obj.pix_data_from_file.file_path, expected_abs_path);
+        expected_file = java.io.File(fullfile(pwd(), obj.test_sqw_file_path));
+        expected_path = char(expected_file.getCanonicalPath());
+        assertEqual(obj.pix_data_from_file.file_path, expected_path);
     end
 
     function test_construction_with_file_path_populates_data_from_file(obj)
@@ -378,9 +378,9 @@ methods
     end
 
     function test_construction_with_faccess_sets_file_path(obj)
-        [dir_name, file_name, ext] = fileparts(obj.test_sqw_file_path);
-        expected_abs_path = fullfile(what(dir_name).path, [file_name, ext]);
-        assertEqual(obj.pix_data_from_faccess.file_path, expected_abs_path);
+        file = java.io.File(fullfile(pwd(), obj.test_sqw_file_path));
+        expected_path = char(file.getCanonicalPath());
+        assertEqual(obj.pix_data_from_faccess.file_path, expected_path);
     end
 
     function test_page_size_is_set_on_construction_when_given_as_argument(obj)

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -428,6 +428,40 @@ methods
         assertFalse(isempty(pix.data));
     end
 
+    function test_number_of_pixels_in_page_matches_memory_usage_size(~)
+        data = rand(9, 30);
+        pix_in_page = 11;
+        faccess = FakeFAccess(data);
+        mem_alloc = pix_in_page*8*9;  % 11 pixels held in memory at a time
+        pix = PixelData(faccess, mem_alloc);
+        pix.u1;
+        assertEqual(size(pix.data, 2), pix_in_page);
+    end
+
+    function test_has_more_rets_true_if_there_are_subsequent_pixels_in_file(~)
+        data = rand(9, 12);
+        pix_in_page = 11;
+        mem_alloc = pix_in_page*8*9;  % 11 pixels held in memory at a time
+        faccess = FakeFAccess(data);
+        pix = PixelData(faccess, mem_alloc);
+        assertTrue(pix.has_more());
+    end
+
+    function test_has_more_rets_false_if_all_data_in_page(~)
+        data = rand(9, 11);
+        pix_in_page = 11;
+        mem_alloc = pix_in_page*8*9;  % 11 pixels held in memory at a time
+        faccess = FakeFAccess(data);
+        pix = PixelData(faccess, mem_alloc);
+        assertFalse(pix.has_more());
+    end
+
+    function test_has_more_rets_false_if_all_data_created_in_memory(~)
+        data = rand(9, 30);
+        pix = PixelData(data);
+        assertFalse(pix.has_more());
+    end
+
 end
 
 end

--- a/_test/test_sqw_file/test_dnd_binfile_common.m
+++ b/_test/test_sqw_file/test_dnd_binfile_common.m
@@ -2,11 +2,11 @@ classdef test_dnd_binfile_common <  TestCase %WithSave
     %Testing common part of the code used to access binary sqw files
     % and various auxiliary methods, available on this class
     %
-    
+
     properties
         test_folder
     end
-    
+
     methods
         function obj = test_dnd_binfile_common(varargin)
             if nargin > 0
@@ -23,82 +23,82 @@ classdef test_dnd_binfile_common <  TestCase %WithSave
             to = dnd_binfile_common_tester();
             source = fullfile(fileparts(obj.test_folder),'test_symmetrisation','w1d_d1d.sqw');
             wrong_source = fullfile(fileparts(obj.test_folder),'common_data','96dets.par');
-            
-            
+
+
             f = @()(to.get_file_header('non-existing_file.sqw'));
             assertExceptionThrown(f,'SQW_FILE_IO:io_error');
-            
+
             f = @()to.get_file_header(wrong_source);
             assertExceptionThrown(f,'SQW_FILE_IO:runtime_error');
-            
-            
+
+
             [stream,fid1] = to.get_file_header(source);
             co1 = onCleanup(@()fclose(fid1));
-            
+
             assertTrue(fid1>0)
             assertTrue(isstruct(stream));
             assertEqual(stream.version,2);
             assertEqual(stream.name,'horace');
             assertEqual(stream.typestart,int32(18));
             assertEqual(stream.uncertain,false);
-            
+
             assertEqual(stream.sqw_type,false);
             assertEqual(stream.num_dim,int32(1));
         end
         %
         function obj = test_get_data_form(obj)
             tob = dnd_binfile_common_tester();
-            
+
             form = tob.get_dnd_form();
             fn = fieldnames(form);
-            
+
             assertEqual(numel(fn),19);
-            
+
             tob = tob.set_datatype('a');
             form = tob.get_dnd_form('-head');
             fn = fieldnames(form);
             assertEqual(numel(fn),16);
-            
+
             form = tob.get_dnd_form('-const');
             fn = fieldnames(form);
             assertEqual(numel(fn),16);
-            
+
             form = tob.get_dnd_form('-const','-head');
             fn = fieldnames(form);
             assertEqual(numel(fn),13);
-            
+
         end
         %
         function obj= test_extract_field_range(obj)
             range = 1:20;
             base_fields = arrayfun(@form_str,range,'UniformOutput',false);
-            
+
             base_str = struct(base_fields{:});
-            
+
             filter1 = struct('f1','','f2','','f3','');
-            
+
             [f1,f2,is_last] = dnd_binfile_common.extract_field_range(base_str,filter1);
             assertFalse(is_last)
             assertEqual(f1,'f1_pos_');
             assertEqual(f2,'f4_pos_');
-            
-            
+
+
             filter2 = struct('f3','','f4','','f7','');
-            
+
             [f1,f2,is_last] = dnd_binfile_common.extract_field_range(base_str,filter2);
             assertFalse(is_last)
             assertEqual(f1,'f3_pos_');
             assertEqual(f2,'f8_pos_');
-            
-            
+
+
             filter3 =struct('f4','','f7','','f10','');
-            
+
             [f1,f2,is_last] = dnd_binfile_common.extract_field_range(base_str,filter3);
             assertTrue(is_last)
             assertEqual(f1,'f4_pos_');
             assertEqual(f2,'f10_pos_');
-            
-            
+
+
             function str = form_str(x)
                 if mod(x+1,2) == 0
                     str = ['f',num2str((x+1)/2),'_pos_'];
@@ -110,68 +110,68 @@ classdef test_dnd_binfile_common <  TestCase %WithSave
         %
         function obj = test_change_file_to_write(obj)
             tob = dnd_binfile_common();
-            
+
             samp = fullfile(fileparts(obj.test_folder),...
                 'test_symmetrisation','w1d_sqw.sqw');
             f=@()(tob.set_file_to_update(samp));
             assertExceptionThrown(f,'SQW_FILE_IO:invalid_argument');
-            
+
             tob=tob.set_file_to_update(samp);
-            
+
             assertTrue(tob.sqw_type)
             assertEqual(tob.num_dim,1)
             assertTrue(isa(tob,'faccess_sqw_v2'));
-            
-            
+
+
             test_f = fullfile(tmp_dir,'test_change_file_to_write.sqw');
             clob = onCleanup(@()delete(test_f));
-            
+
             tob=tob.set_file_to_update(test_f);
             assertTrue(exist(test_f,'file')==2);
-            
+
             tob=tob.delete();
             assertTrue(tob.sqw_type) % its still sqw reader, you know...
             assertEqual(tob.num_dim,'undefined')
-            
+
         end
         %
         function obj = test_copy_constructor(obj)
-            
+
             samp = fullfile(fileparts(obj.test_folder),...
                 'test_symmetrisation','w1d_d1d.sqw');
             tob = dnd_binfile_common_tester(samp);
-            
-            
+
+
             cob = dnd_binfile_common_tester(tob);
-            
+
             d0 = tob.get_sqw();
             d1 = cob.get_sqw();
-            
+
             assertEqual(d0,d1);
-            
+
         end
         function obj = test_copy_constructor_write_perm(obj)
-            
+
             samp = fullfile(fileparts(obj.test_folder),...
                 'test_symmetrisation','w1d_d1d.sqw');
             ttob = dnd_binfile_common_tester(samp);
             sq_obj = ttob.get_sqw();
             assertTrue(isa(sq_obj,'d1d'));
-            
+
             test_f = fullfile(tmp_dir,'test_dnd_copy_constructor_write_perm.sqw');
             clob = onCleanup(@()delete(test_f));
-            
+
             tob =  dnd_binfile_common_tester(sq_obj,test_f);
             cob = dnd_binfile_common_tester(tob);
-            
+
             cob  = cob.put_sqw();
             cob.delete();
-            
+
             chob = dnd_binfile_common_tester(test_f);
-            
+
             tsq_obj = chob.get_sqw();
             tsq0_obj = tob.get_sqw();
-            
+
             [ok,mess]=equal_to_tol(sq_obj,tsq_obj,'ignore_str',true);
             assertTrue(ok,mess)
             [ok,mess]=equal_to_tol(tsq0_obj,tsq_obj,'ignore_str',true);
@@ -180,40 +180,79 @@ classdef test_dnd_binfile_common <  TestCase %WithSave
             tob.delete();
         end
         %
-        function obj = test_reopen_to_wrire(obj)
-            
+        function obj = test_reopen_to_write(obj)
+
             samp = fullfile(fileparts(obj.test_folder),...
                 'test_symmetrisation','w1d_d1d.sqw');
             ttob = dnd_binfile_common_tester(samp);
-            % important! -verbatim is critical here! without it we should 
+            % important! -verbatim is critical here! without it we should
             % reinitialize object to write!
             sq_obj = ttob.get_sqw('-verbatim');
             assertTrue(isa(sq_obj,'d1d'));
-            
+
             test_f = fullfile(tmp_dir,'test_dnd_reopen_to_wrire.sqw');
             clob = onCleanup(@()delete(test_f));
-            
+
             % using already initialized object to write new data.
             % its better to initialize object again as with this form
             % object bas to be exactly the same as the one read before.
             ttob =  ttob.reopen_to_write(test_f);
             ttob = ttob.put_sqw(sq_obj);
             ttob.delete();
-            
+
             assertEqual(exist(test_f,'file'),2);
-            
+
             chob = dnd_binfile_common_tester(test_f);
-            
+
             tsq_obj = chob.get_sqw();
             chob.delete();
-            
+
             [ok,mess]=equal_to_tol(sq_obj,tsq_obj,'ignore_str',true);
             assertTrue(ok,mess)
-            
-        end
-        
-        
-    end
-    
-end
 
+        end
+
+        function test_activate_reopens_file_in_rb_if_read_given(obj)
+            file_path = fullfile( ...
+                    fileparts(obj.test_folder), 'test_symmetrisation', 'w1d_d1d.sqw');
+            bin_file = dnd_binfile_common_tester(file_path);
+            cleanup = onCleanup(@() bin_file.delete());
+            bin_file.deactivate();
+            assertFalse(bin_file.is_activated('read'));
+            assertFalse(bin_file.is_activated('write'));
+
+            bin_file.activate('read');
+
+            assertTrue(bin_file.is_activated('read'));
+            assertFalse(bin_file.is_activated('write'));
+        end
+
+        function test_activate_reopens_file_in_rbplus_if_write_given(obj)
+            file_path = fullfile( ...
+                    fileparts(obj.test_folder), 'test_symmetrisation', 'w1d_d1d.sqw');
+            bin_file = dnd_binfile_common_tester(file_path);
+            cleanup = onCleanup(@() bin_file.delete());
+            bin_file.deactivate();
+            assertFalse(bin_file.is_activated('read'));
+            assertFalse(bin_file.is_activated('write'));
+
+            bin_file.activate('write');
+
+            assertTrue(bin_file.is_activated('read'));
+            assertTrue(bin_file.is_activated('write'));
+        end
+
+        function test_error_raised_if_activating_file_with_bad_permission(obj)
+            file_path = fullfile( ...
+                    fileparts(obj.test_folder), 'test_symmetrisation', 'w1d_d1d.sqw');
+            bin_file = dnd_binfile_common_tester(file_path);
+            cleanup = onCleanup(@() bin_file.delete());
+            bin_file.deactivate();
+
+            f = @() bin_file.activate('not-a-permission');
+            assertExceptionThrown(f, 'DNDBINFILECOMMON:get_fopen_permission_');
+        end
+
+    end
+
+end

--- a/_test/test_sqw_file/test_dnd_binfile_common.m
+++ b/_test/test_sqw_file/test_dnd_binfile_common.m
@@ -226,7 +226,7 @@ classdef test_dnd_binfile_common <  TestCase %WithSave
             assertTrue(bin_file.is_activated('read'));
             assertFalse(bin_file.is_activated('write'));
 
-            [~, permission] = obj.get_file_id_from_path(file_path);
+            permission = obj.get_opened_file_permission(file_path);
             assertEqual(permission, 'rb');
         end
 
@@ -244,7 +244,7 @@ classdef test_dnd_binfile_common <  TestCase %WithSave
             assertTrue(bin_file.is_activated('read'));
             assertTrue(bin_file.is_activated('write'));
 
-            [~, permission] = obj.get_file_id_from_path(file_path);
+            permission = obj.get_opened_file_permission(file_path);
             assertEqual(permission, 'rb+');
 
         end
@@ -264,16 +264,14 @@ classdef test_dnd_binfile_common <  TestCase %WithSave
 
     methods (Static)
 
-        function [fid, permission] = get_file_id_from_path(file_path)
-            % Get the fileID and permission of an open file from its path
-            %   If the file is not open the fileID and permission will be empty
-            fid = [];
+        function permission = get_opened_file_permission(file_path)
+            % Get the permission of an open file from its path
+            %   If the file is not open the permission will be empty
             permission = '';
             file_ids = fopen('all');
             for i = 1:numel(file_ids)
                 [open_file_path, open_permission] = fopen(file_ids(i));
                 if strcmp(open_file_path, file_path)
-                    fid = file_ids(i);
                     permission = open_permission;
                     return;
                 end

--- a/_test/test_sqw_file/test_dnd_binfile_common.m
+++ b/_test/test_sqw_file/test_dnd_binfile_common.m
@@ -225,6 +225,9 @@ classdef test_dnd_binfile_common <  TestCase %WithSave
 
             assertTrue(bin_file.is_activated('read'));
             assertFalse(bin_file.is_activated('write'));
+
+            [~, permission] = obj.get_file_id_from_path(file_path);
+            assertEqual(permission, 'rb');
         end
 
         function test_activate_reopens_file_in_rbplus_if_write_given(obj)
@@ -240,6 +243,10 @@ classdef test_dnd_binfile_common <  TestCase %WithSave
 
             assertTrue(bin_file.is_activated('read'));
             assertTrue(bin_file.is_activated('write'));
+
+            [~, permission] = obj.get_file_id_from_path(file_path);
+            assertEqual(permission, 'rb+');
+
         end
 
         function test_error_raised_if_activating_file_with_bad_permission(obj)
@@ -251,6 +258,26 @@ classdef test_dnd_binfile_common <  TestCase %WithSave
 
             f = @() bin_file.activate('not-a-permission');
             assertExceptionThrown(f, 'DNDBINFILECOMMON:get_fopen_permission_');
+        end
+
+    end
+
+    methods (Static)
+
+        function [fid, permission] = get_file_id_from_path(file_path)
+            % Get the fileID and permission of an open file from its path
+            %   If the file is not open the fileID and permission will be empty
+            fid = [];
+            permission = '';
+            file_ids = fopen('all');
+            for i = 1:numel(file_ids)
+                [open_file_path, open_permission] = fopen(file_ids(i));
+                if strcmp(open_file_path, file_path)
+                    fid = file_ids(i);
+                    permission = open_permission;
+                    return;
+                end
+            end
         end
 
     end

--- a/_test/test_sqw_file/test_faccess_sqw_prototype.m
+++ b/_test/test_sqw_file/test_faccess_sqw_prototype.m
@@ -5,16 +5,16 @@ classdef test_faccess_sqw_prototype< TestCase
     %
     % $Revision:: 1753 ($Date:: 2019-10-24 20:46:14 +0100 (Thu, 24 Oct 2019) $)
     %
-    
-    
+
+
     properties
         sample_dir;
         sample_file;
         clob = []
     end
-    
+
     methods
-        
+
         %The above can now be read into the test routine directly.
         function this=test_faccess_sqw_prototype(varargin)
             if nargin > 0
@@ -23,104 +23,104 @@ classdef test_faccess_sqw_prototype< TestCase
                 name= mfilename('class');
             end
             this=this@TestCase(name);
-            
+
             this.sample_dir = fullfile(fileparts(mfilename('fullpath')));
             this.sample_file = fullfile(this.sample_dir,'test_sqw_read_write_v0_t.sqw');
         end
-        
+
         % tests
         function obj = test_should_load_stream(obj)
             to = faccess_sqw_prototype();
             co = onCleanup(@()to.delete());
             assertEqual(to.file_version,'-v0');
-            
+
             [stream,fid] = to.get_file_header(obj.sample_file);
             co1 = onCleanup(@()(fclose(fid)));
-            
+
             warning('off','SQW_FILE_IO:legacy_data')
             this.clob = onCleanup(@()(warning('on','SQW_FILE_IO:legacy_data')));
-            
+
             [ok,initob] = to.should_load_stream(stream,fid);
-            
+
             assertTrue(ok);
             assertTrue(initob.file_id>0);
-            
-            
+
+
         end
         function obj = test_should_load_file(obj)
             to = faccess_sqw_prototype();
             assertEqual(to.file_version,'-v0');
             co = onCleanup(@()to.delete());
-            
+
             warning('off','SQW_FILE_IO:legacy_data')
             this.clob = onCleanup(@()(warning('on','SQW_FILE_IO:legacy_data')));
-            
+
             [ok,inob] = to.should_load(obj.sample_file);
             co1 = onCleanup(@()(fclose(inob.file_id)));
-            
+
             assertTrue(ok);
             assertTrue(inob.file_id>0);
-            
+
         end
-        
+
         function obj = test_init(obj)
             to = faccess_sqw_prototype();
             assertEqual(to.file_version,'-v0');
-            
+
             %access to incorrect object
             f = @()(to.init());
             assertExceptionThrown(f,'SQW_FILE_IO:invalid_argument');
-            
+
             warning('off','SQW_FILE_IO:legacy_data')
             this.clob = onCleanup(@()(warning('on','SQW_FILE_IO:legacy_data')));
-            
+
             [ok,inob] = to.should_load(obj.sample_file);
-            
+
             assertTrue(ok);
             assertTrue(inob.file_id>0);
-            
+
             to = to.init(inob);
             assertEqual(to.npixels,16);
-            
+
             header = to.get_header();
             assertEqual(header.filename,'map11014.spe')
             assertEqual(header.ulabel{4},'E')
             assertEqual(header.ulabel{3},'Q_\eta')
-            
+
             det = to.get_detpar();
             assertEqual(det.filename,'demo_par.PAR')
             assertEqual(det.filepath,'d:\users\abuts\SVN\ISIS\HoraceV1.0final\documentation\')
             assertEqual(numel(det.group),28160)
-            
+
             data = to.get_data();
             assertEqual(size(data.pix),[9,16])
             assertEqual(size(data.s,1),numel(data.p{1})-1)
             assertEqual(size(data.e,2),numel(data.p{2})-1)
             assertEqual(size(data.npix,3),numel(data.p{3})-1)
-            
+
         end
         function obj = test_get_data(obj)
             %spath = fileparts(obj.sample_file);
             warning('off','SQW_FILE_IO:legacy_data')
             this.clob = onCleanup(@()(warning('on','SQW_FILE_IO:legacy_data')));
-            
+
             to = faccess_sqw_prototype(obj.sample_file);
-            
+
             data_h = to.get_data('-he');
             assertTrue(isstruct(data_h))
             assertEqual(data_h.filename,to.filename)
             assertEqual(data_h.filepath,to.filepath)
-            
+
             data_dnd = to.get_data('-ver','-nopix');
             assertTrue(isa(data_dnd,'data_sqw_dnd'));
             assertEqual(data_dnd.filename,'test_sqw_read_write_v0_t.sqw');
-            
-            data = to.get_data('-ver',1,10);
+
+            data = to.get_data('-ver');
             assertEqual(data.filename,data_dnd.filename)
             assertEqual(data.filepath,data_dnd.filepath)
-            assertEqual(size(data.pix),[9,10]);
+            assertTrue(isa(data.pix, 'PixelData'));
         end
-        
+
     end
 end
 

--- a/_test/test_sqw_file/test_faccess_sqw_prototype.m
+++ b/_test/test_sqw_file/test_faccess_sqw_prototype.m
@@ -119,6 +119,8 @@ classdef test_faccess_sqw_prototype< TestCase
             assertEqual(data.filename,data_dnd.filename)
             assertEqual(data.filepath,data_dnd.filepath)
             assertTrue(isa(data.pix, 'PixelData'));
+            assertEqual(data.pix.file_path, obj.sample_file);
+            assertEqual(data.pix.num_pixels, 16);
         end
 
     end

--- a/_test/test_sqw_file/test_faccess_sqw_v2.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v2.m
@@ -5,8 +5,8 @@ classdef test_faccess_sqw_v2< TestCase
     %
     % $Revision:: 1753 ($Date:: 2019-10-24 20:46:14 +0100 (Thu, 24 Oct 2019) $)
     %
-    
-    
+
+
     properties
         sample_dir;
         sample_file;
@@ -21,12 +21,12 @@ classdef test_faccess_sqw_v2< TestCase
             sz = p1-p0;
             fclose(fh);
         end
-        
+
     end
-    
-    
+
+
     methods
-        
+
         %The above can now be read into the test routine directly.
         function this=test_faccess_sqw_v2(varargin)
             if nargin > 0
@@ -35,155 +35,155 @@ classdef test_faccess_sqw_v2< TestCase
                 name= mfilename('class');
             end
             this=this@TestCase(name);
-            
+
             this.sample_dir = fullfile(fileparts(fileparts(mfilename('fullpath'))),'test_symmetrisation');
             this.sample_file = fullfile(this.sample_dir,'w3d_sqw.sqw');
             this.test_folder=fileparts(mfilename('fullpath'));
         end
-        
+
         % tests
         function obj = test_should_load_stream(obj)
             to = faccess_sqw_v2();
             co = onCleanup(@()to.delete());
-            
-            
+
+
             [stream,fid] = to.get_file_header(obj.sample_file);
             [ok,initob] = to.should_load_stream(stream,fid);
             co1 = onCleanup(@()fclose(initob.file_id));
             assertTrue(ok);
             assertTrue(initob.file_id> 0);
-            
-            
-            
+
+
+
         end
         function obj = test_should_load_file(obj)
             to = faccess_sqw_v2();
             co = onCleanup(@()to.delete());
-            
+
             [ok,initob] = to.should_load(obj.sample_file);
             co1 = onCleanup(@()fclose(initob.file_id));
-            
+
             assertTrue(ok);
             assertTrue(initob.file_id>0);
         end
-        
+
         function obj = test_init(obj)
             to = faccess_sqw_v2();
             assertEqual(to.file_version,'-v2');
-            
-            
+
+
             % access to incorrect object
             f = @()(to.init());
             assertExceptionThrown(f,'SQW_FILE_IO:invalid_argument');
-            
-            
+
+
             [ok,initob] = to.should_load(obj.sample_file);
-            
+
             assertTrue(ok);
             assertTrue(initob.file_id > 0);
-            
+
             to = to.init(initob);
             assertEqual(to.npixels,1164180);
-            
+
             header = to.get_header();
             assertEqual(header.filename,'slice_n_c_m1_ei140')
             assertEqual(header.ulabel{4},'E')
             assertEqual(header.ulabel{3},'Q_\eta')
-            
+
             det = to.get_detpar();
             assertEqual(det.filename,'slice_n_c_m1_ei140.par')
             assertEqual(det.filepath,'C:\Russell\PCMO\ARCS_Oct10\Data\')
             assertEqual(numel(det.group),58880)
-            
+
             data = to.get_data();
             assertEqual(size(data.pix),[9,1164180])
             assertEqual(size(data.s,1),numel(data.p{1})-1)
             assertEqual(size(data.e,2),numel(data.p{2})-1)
             assertEqual(size(data.npix,3),numel(data.p{3})-1)
-            
+
         end
         function obj = test_read_v1(obj)
             to = faccess_sqw_v2();
             assertEqual(to.file_version,'-v2');
-            
-            
+
+
             [ok,initob] = to.should_load(fullfile(obj.test_folder,'w2_small_v1.sqw'));
-            
+
             assertTrue(ok);
             assertTrue(initob.file_id > 0);
-            
+
             to = to.init(initob);
             assertEqual(to.npixels,179024);
-            
+
             header = to.get_header();
             assertEqual(header.filename,'map11014.spe;1')
             assertEqual(header.ulabel{4},'E')
             assertEqual(header.ulabel{3},'Q_\eta')
-            
+
             det = to.get_detpar();
             assertEqual(det.filename,'9cards_4_4to1.par')
             assertEqual(det.filepath,'c:\data\Fe\')
             assertEqual(numel(det.group),36864)
-            
+
             data = to.get_data();
             assertEqual(size(data.pix),[9,179024])
             assertEqual(size(data.s,1),numel(data.p{1})-1)
             assertEqual(size(data.e,2),numel(data.p{2})-1)
             assertEqual(size(data.npix),size(data.e))
-            
+
             headers = to.get_header('-all');
             assertEqual(numel(headers),186)
-            
+
             header = headers{186};
             assertEqual(header.filename,'map11201.spe;1');
             assertEqual(header.filepath,'c:\data\Fe\data_nov06\const_ei\');
             assertEqual(header.ulabel{1},'Q_\zeta')
             assertEqual(header.ulabel{2},'Q_\xi')
             assertEqual(header.ulabel{4},'E')
-            
-            
+
+
             main_h = to.get_main_header('-verbatim');
             assertEqual(main_h.nfiles,186);
             assertEqual(main_h.filename,'Fe_ei787.sqw');
             assertEqual(main_h.filepath,'c:\data\Fe\sqw\');
-            
-            
+
+
         end
-        
+
         function obj = test_get_data(obj)
             spath = fileparts(obj.sample_file);
             sample  = fullfile(spath,'w1d_sqw.sqw');
-            
+
             to = faccess_sqw_v2(sample);
-            
+
             data_h = to.get_data('-he');
             assertTrue(isstruct(data_h))
             assertEqual(data_h.filename,to.filename)
             assertEqual(data_h.filepath,to.filepath)
-            
+
             data_dnd = to.get_data('-ver','-nopix');
             assertTrue(isa(data_dnd,'data_sqw_dnd'));
             assertEqual(data_dnd.filename,'ei140.sqw');
-            
-            data = to.get_data('-ver',1,20);
+
+            data = to.get_data('-ver');
             assertEqual(data.filename,data_dnd.filename)
             assertEqual(data.filepath,data_dnd.filepath)
-            assertEqual(size(data.pix),[9,20]);
+            assertTrue(isa(data.pix, 'PixelData'));
         end
-        
+
         function obj = test_get_sqw(obj)
             spath = fileparts(obj.sample_file);
             samplef  = fullfile(spath,'w2d_qq_small_sqw.sqw');
-            
+
             fo = faccess_sqw_v2();
             fo = fo.init(samplef);
-            
+
             sqw_obj = fo.get_sqw();
-            
+
             assertTrue(isa(sqw_obj,'sqw'));
             assertEqual(sqw_obj.main_header.filename,fo.filename)
             assertEqual(sqw_obj.main_header.filepath,fo.filepath)
-            
+
             sqw_obj1 = fo.get_sqw('-hverbatim');
             assertTrue(isa(sqw_obj1,'sqw'));
             assertEqual(sqw_obj1.main_header.filename,'ei140.sqw')
@@ -194,20 +194,20 @@ classdef test_faccess_sqw_v2< TestCase
         function obj = test_put_sqw(obj)
             spath = fileparts(obj.sample_file);
             samplef  = fullfile(spath,'w2d_qq_small_sqw.sqw');
-            
-            
+
+
             ts = faccess_sqw_v2(samplef);
             tob_sqw = ts.get_sqw('-verbatim');
-            
+
             tt = faccess_sqw_v2();
-            
+
             tf = fullfile(tmp_dir,'test_put_sqw_v2.sqw');
             clob = onCleanup(@()delete(tf));
-            
+
             tt = tt.init(tob_sqw);
             tt = tt.set_file_to_update(tf);
-            
-            
+
+
             tt=tt.put_sqw();
             assertTrue(exist(tf,'file')==2)
             tt.delete();
@@ -228,26 +228,26 @@ classdef test_faccess_sqw_v2< TestCase
         function obj = test_upgrade_sqw(obj)
             spath = fileparts(obj.sample_file);
             samplef  = fullfile(spath,'w2d_qq_small_sqw.sqw');
-            
-            
+
+
             tf = fullfile(tmp_dir,'test_upgrade_sqwV2.sqw');
             clob = onCleanup(@()delete(tf));
             copyfile(samplef,tf);
-            
+
             tob = faccess_sqw_v2(tf);
             tob = tob.upgrade_file_format();
             assertTrue(isa(tob,'faccess_sqw_v3'));
-            
-            
+
+
             sqw1 = tob.get_sqw();
-            
+
             tob.delete();
-            
+
             to = sqw_formats_factory.instance().get_loader(tf);
             assertTrue(isa(to,'faccess_sqw_v3'));
-            
+
             sqw2 = to.get_sqw();
-            
+
             assertEqual(sqw1,sqw2);
             to.delete();
             %
@@ -256,63 +256,63 @@ classdef test_faccess_sqw_v2< TestCase
         function obj = test_upgrade_sqw_multiheader(obj)
             spath = fileparts(fileparts(obj.sample_file));
             samplef  = fullfile(spath,'test_sqw_file','w2_small_v1.sqw');
-            
-            
+
+
             tf = fullfile(tmp_dir,'test_upgrade_sqwV2_multiheader.sqw');
             clob = onCleanup(@()delete(tf));
             copyfile(samplef,tf);
-            
+
             tob = faccess_sqw_v2(tf);
             tob = tob.upgrade_file_format();
             assertTrue(isa(tob,'faccess_sqw_v3'));
-            
-            
+
+
             sqw1 = tob.get_sqw();
-            
+
             tob.delete();
-            
+
             to = sqw_formats_factory.instance().get_loader(tf);
             assertTrue(isa(to,'faccess_sqw_v3'));
-            
+
             sqw2 = to.get_sqw();
-            
+
             assertEqual(sqw1,sqw2);
             to.delete();
             %
         end
-        
+
         %
         function obj = test_upgrade_sqw_wac(obj)
             %
             spath = fileparts(obj.sample_file);
             samplef  = fullfile(spath,'w2d_qq_small_sqw.sqw');
-            
+
             sqwob = read_sqw(samplef);
-            
+
             tf = fullfile(tmp_dir,'test_upgrade_sqwV2_wac.sqw');
             clob = onCleanup(@()delete(tf));
             tob = faccess_sqw_v2(sqwob,tf);
             tob = tob.put_sqw();
-            
+
             tobV3 = tob.upgrade_file_format();
             assertTrue(isa(tobV3,'faccess_sqw_v3'));
-            
-            
+
+
             sqw1 = tobV3.get_sqw();
-            
+
             tob.delete();
             tobV3.delete();
-            
+
             to = sqw_formats_factory.instance().get_loader(tf);
             assertTrue(isa(to,'faccess_sqw_v3'));
-            
+
             sqw2 = to.get_sqw();
             to.delete();
-            
+
             assertEqual(sqw1,sqw2);
             [ok,mess]=equal_to_tol(sqwob,sqw2,'ignore_str',true);
             assertTrue(ok,mess)
-            
+
             %
         end
         %
@@ -320,22 +320,22 @@ classdef test_faccess_sqw_v2< TestCase
             %
             spath = fileparts(obj.sample_file);
             samplef  = fullfile(spath,'w2d_qq_small_sqw.sqw');
-            
+
             sqwob = read_sqw(samplef);
-            
+
             tf = fullfile(tmp_dir,'test_put_dnd_from_sqw.sqw');
             clob = onCleanup(@()delete(tf));
             tob = faccess_sqw_v2(sqwob,tf);
             tob = tob.put_dnd();
             tob.delete();
-            
+
             to = sqw_formats_factory.instance().get_loader(tf);
             assertTrue(isa(to,'faccess_dnd_v2'));
-            
+
             sqw2 = to.get_sqw();
             to.delete();
             assertTrue(isa(sqw2,'d2d'));
-            
+
             [ok,mess]=equal_to_tol(d2d(sqwob),sqw2,'ignore_str',true);
             assertTrue(ok,mess)
             %
@@ -345,30 +345,30 @@ classdef test_faccess_sqw_v2< TestCase
             %
             spath = fileparts(obj.sample_file);
             samplef  = fullfile(spath,'w2d_qq_small_sqw.sqw');
-            
+
             dnob = read_dnd(samplef);
-            
+
             tf = fullfile(tmp_dir,'test_put_dnd_from_sqw.sqw');
             clob = onCleanup(@()delete(tf));
-            
+
             tob = faccess_dnd_v2(dnob,tf);
             tob = tob.put_sqw();
             tob.delete();
-            
+
             to = sqw_formats_factory.instance().get_loader(tf);
             assertTrue(isa(to,'faccess_dnd_v2'));
-            
+
             dn2 = to.get_sqw();
             to.delete();
             assertTrue(isa(dn2,'d2d'));
-            
+
             [ok,mess]=equal_to_tol(dn2,dnob,'ignore_str',true);
             assertTrue(ok,mess)
             %
         end
         %
         function obj = test_sqw_reopen_to_write(obj)
-            
+
             samp = fullfile(fileparts(obj.test_folder),...
                 'test_symmetrisation','w1d_sqw.sqw');
             ttob = faccess_sqw_v2(samp);
@@ -376,31 +376,31 @@ classdef test_faccess_sqw_v2< TestCase
             % reinitialize object to write!
             sq_obj = ttob.get_sqw('-verbatim');
             assertTrue(isa(sq_obj,'sqw'));
-            
+
             test_f = fullfile(tmp_dir,'test_sqw_reopen_to_wrire.sqw');
             clob = onCleanup(@()delete(test_f));
-            
+
             % using already initialized object to write new data.
             % its better to initialize object again as with this form
             % object bas to be exactly the same as the one read before.
             ttob =  ttob.reopen_to_write(test_f);
             ttob = ttob.put_sqw(sq_obj);
             ttob.delete();
-            
+
             assertEqual(exist(test_f,'file'),2);
-            
+
             chob = faccess_sqw_v2(test_f);
-            
+
             tsq_obj = chob.get_sqw();
             chob.delete();
-            
+
             [ok,mess]=equal_to_tol(sq_obj,tsq_obj,'ignore_str',true);
             assertTrue(ok,mess)
-            
+
         end
-        
-        
-        
+
+
+
     end
 end
 

--- a/_test/test_sqw_file/test_faccess_sqw_v2.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v2.m
@@ -106,7 +106,6 @@ classdef test_faccess_sqw_v2< TestCase
             to = faccess_sqw_v2();
             assertEqual(to.file_version,'-v2');
 
-
             [ok,initob] = to.should_load(fullfile(obj.test_folder,'w2_small_v1.sqw'));
 
             assertTrue(ok);
@@ -147,7 +146,6 @@ classdef test_faccess_sqw_v2< TestCase
             assertEqual(main_h.filename,'Fe_ei787.sqw');
             assertEqual(main_h.filepath,'c:\data\Fe\sqw\');
 
-
         end
 
         function obj = test_get_data(obj)
@@ -169,6 +167,8 @@ classdef test_faccess_sqw_v2< TestCase
             assertEqual(data.filename,data_dnd.filename)
             assertEqual(data.filepath,data_dnd.filepath)
             assertTrue(isa(data.pix, 'PixelData'));
+            assertEqual(data.pix.file_path, sample);
+            assertEqual(data.pix.num_pixels, 8031);
         end
 
         function obj = test_get_sqw(obj)

--- a/_test/test_sqw_file/test_faccess_sqw_v3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3.m
@@ -116,7 +116,7 @@ classdef test_faccess_sqw_v3< TestCase
             assertTrue(isa(data.pix, 'PixelData'));
 
             raw_pix = to.get_pix(1,20);
-            assertEqual(data.pix.data, raw_pix);
+            assertEqual(data.pix.get_pixels(1:20).data, raw_pix);
         end
         %
         function obj = test_get_inst_or_sample(obj)

--- a/_test/test_sqw_file/test_faccess_sqw_v3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3.m
@@ -110,10 +110,10 @@ classdef test_faccess_sqw_v3< TestCase
             assertTrue(isa(data_dnd,'data_sqw_dnd'));
             assertEqual(data_dnd.filename,'test_sqw_file_read_write_v3.sqw');
 
-            data = to.get_data('-ver',1,20);
+            data = to.get_data('-ver');
             assertEqual(data.filename,data_dnd.filename)
             assertEqual(data.filepath,data_dnd.filepath)
-            assertEqual(size(data.pix),[9,20]);
+            assertTrue(isa(data.pix, 'PixelData'));
 
             pix = to.get_pix(1,20);
             assertEqual(data.pix.data,pix.data);

--- a/_test/test_sqw_file/test_faccess_sqw_v3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3.m
@@ -115,13 +115,8 @@ classdef test_faccess_sqw_v3< TestCase
             assertEqual(data.filepath,data_dnd.filepath)
             assertTrue(isa(data.pix, 'PixelData'));
 
-            pix = to.get_pix(1,20);
-            assertEqual(data.pix.data,pix.data);
-        end
-        %
-        function test_get_pix_returns_a_PixelData_object(obj)
-            to = faccess_sqw_v3(obj.sample_file);
-            assertTrue(isa(to.get_pix(1, 20), 'PixelData'))
+            raw_pix = to.get_pix(1,20);
+            assertEqual(data.pix.data, raw_pix);
         end
         %
         function obj = test_get_inst_or_sample(obj)

--- a/_test/test_sqw_file/test_faccess_sqw_v3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3.m
@@ -114,6 +114,8 @@ classdef test_faccess_sqw_v3< TestCase
             assertEqual(data.filename,data_dnd.filename)
             assertEqual(data.filepath,data_dnd.filepath)
             assertTrue(isa(data.pix, 'PixelData'));
+            assertEqual(data.pix.file_path, obj.sample_file);
+            assertEqual(data.pix.num_pixels, 7680);
 
             raw_pix = to.get_pix(1,20);
             assertEqual(data.pix.get_pixels(1:20).data, raw_pix);

--- a/_test/test_sqw_file/test_sqw_file_read_write.m
+++ b/_test/test_sqw_file/test_sqw_file_read_write.m
@@ -16,7 +16,7 @@ for i=1:numel(existing_objects)
     % @axis_name
     cur_sqw=sqw(struct(ds.(existing_objects{i})));
     var_name = existing_objects{i};
-    
+
     eval(sprintf('%s = cur_sqw;', var_name));
 end
 
@@ -44,12 +44,15 @@ clob1 = onCleanup(@()delete(tmpsqwfile));
 
 % Write out to sqw files, read back in, and test they are the same
 % ----------------------------------------------------------------
-save(f1_1,tmpsqwfile); tmp=read(sqw,tmpsqwfile);
+save(f1_1,tmpsqwfile);
+tmp=read(sqw,tmpsqwfile);
 [ok,mess]=equal_to_tol(f1_1,tmp,'ignore_str',1);
 assertTrue(ok,mess);
 
-save(f1_3,tmpsqwfile); tmp=read(sqw,tmpsqwfile);
-[ok,mess]=equal_to_tol(f1_3,tmp,'ignore_str',1); assertTrue(ok,mess)
+save(f1_3,tmpsqwfile);
+tmp=read(sqw,tmpsqwfile);
+[ok,mess]=equal_to_tol(f1_3,tmp,'ignore_str',1);
+assertTrue(ok,mess)
 
 
 % Reference sqw objects with different samples

--- a/_test/test_utilities/test_fix_magnetic_ff.m
+++ b/_test/test_utilities/test_fix_magnetic_ff.m
@@ -4,33 +4,31 @@ classdef test_fix_magnetic_ff< TestCase
     %
 
     properties
-        tests_folder
+        tests_folder = fileparts(fileparts(mfilename('fullpath')));
         sample_sqw;
+        sample_sqw_const;
     end
     methods
         %
         function this=test_fix_magnetic_ff(varargin)
-
             if nargin>0
                 name = varargin{1};
             else
                 name = 'test_correct_magnetif_ff';
             end
             this = this@TestCase(name);
-            this.tests_folder = fileparts(fileparts(mfilename('fullpath')));
 
-            persistent sample_sqw_;
-            if isempty(sample_sqw_)
-                en = -1:1:50;
-                par_file = fullfile(this.tests_folder,'common_data','gen_sqw_96dets.nxspe');
-
-                fsqw = fake_sqw (en, par_file, '', 51, 1,[2.8,3.86,4.86], [120,80,90],...
-                    [1,0,0],[0,1,0], 10, 1.,0.1, -0.1, 0.1, [50,50,50,50]);
-                sample_sqw_ = fsqw{1};
-
-            end
-            this.sample_sqw = sample_sqw_;
+            en = -1:1:50;
+            par_file = fullfile(this.tests_folder,'common_data','gen_sqw_96dets.nxspe');
+            fsqw = fake_sqw (en, par_file, '', 51, 1,[2.8,3.86,4.86], [120,80,90],...
+                             [1,0,0],[0,1,0], 10, 1.,0.1, -0.1, 0.1, [50,50,50,50]);
+            this.sample_sqw_const = copy(fsqw{1});
         end
+        %
+        function obj = setUp(obj)
+            obj.sample_sqw = copy(obj.sample_sqw_const);
+        end
+
         % tests themself
         function test_magnetic_Ions(this)
             mi = MagneticIons();

--- a/_work/RAE_work/mask_runs.m
+++ b/_work/RAE_work/mask_runs.m
@@ -30,7 +30,7 @@ if numel(win)~=1
 end
 
 % Initialise output argument
-wout = win;
+wout = copy(win);
 % Trivial case of empty or no mask arguments
 if nargin==1 || isempty(runno)
     return

--- a/_work/RAE_work/symmetrise_replicate_sqw.m
+++ b/_work/RAE_work/symmetrise_replicate_sqw.m
@@ -32,7 +32,7 @@ function wout=symmetrise_replicate_sqw(win,v1,v2,v3)
 %==============================
 %Some checks on the inputs:
 win=sqw(win);
-wout=win;
+wout = copy(win);
 
 %New code (problem spotted by Matt Mena for case when using a single
 %contributing spe file):

--- a/_work/RAE_work/symmetrise_sqw_StephenGaw.m
+++ b/_work/RAE_work/symmetrise_sqw_StephenGaw.m
@@ -28,7 +28,7 @@ function wout=symmetrise_sqw_corrected_2(win,v1,v2,v3)
 %==============================
 %Some checks on the inputs:
 win=sqw(win);
-wout=win;
+wout = copy(win);
 
 if numel(win)~=1
     error('Horace error: symmetrisation only implemented for single sqw object, not arrays of objects. Use a for-loop to deal with arrays');

--- a/_work/RAE_work/symmetrise_sqw_multi.m
+++ b/_work/RAE_work/symmetrise_sqw_multi.m
@@ -25,7 +25,7 @@ function wout=symmetrise_sqw_multi(win,v1,v2,v3)
 %==============================
 %Some checks on the inputs:
 win=sqw(win);
-wout=win;
+wout = copy(win);
 
 %New code (problem spotted by Matt Mena for case when using a single
 %contributing spe file):

--- a/_work/RAE_work/symmetrise_sqw_pikulski_code.m
+++ b/_work/RAE_work/symmetrise_sqw_pikulski_code.m
@@ -60,7 +60,7 @@ function wout=symmetrise_sqw_pikulski_code(win,v1,v2,v3)
 %==============================
 %Some checks on the inputs:
 win=sqw(win);
-wout=win;
+wout = copy(win);
 
 % MP: Old code would fail the checks done at check_sqw_header.m:56 if
 % called from outside the class.

--- a/_work/TGP_work/archive/horace_convert_legacy_sqw.m
+++ b/_work/TGP_work/archive/horace_convert_legacy_sqw.m
@@ -5,7 +5,7 @@ function wout=horace_convert_legacy_sqw(win)
 %
 % If not an sqw object, leave unchanged
 
-wout=win;
+wout = copy(win);
 for i=1:numel(win)
     if isa(win,'sqw') && is_sqw_type(win(i))
         hnew=win(i).header;

--- a/horace_core/Tobyfit/Tobyfit/@sqw/tobyfit_DGdisk_resconv.m
+++ b/horace_core/Tobyfit/Tobyfit/@sqw/tobyfit_DGdisk_resconv.m
@@ -120,7 +120,7 @@ end
 
 % Initialise output arguments
 % ---------------------------
-wout = win;
+wout = copy(win);
 state_out = cell(size(win));    % create output argument
 store_out = [];
 

--- a/horace_core/Tobyfit/Tobyfit/@sqw/tobyfit_DGfermi_resconv.m
+++ b/horace_core/Tobyfit/Tobyfit/@sqw/tobyfit_DGfermi_resconv.m
@@ -120,7 +120,7 @@ end
 
 % Initialise output arguments
 % ---------------------------
-wout = win;
+wout = copy(win);
 state_out = cell(size(win));    % create output argument
 store_out = [];
 

--- a/horace_core/Tobyfit/Tobyfit_legacy/@sqw/resol_conv_tobyfit_mc.m
+++ b/horace_core/Tobyfit/Tobyfit_legacy/@sqw/resol_conv_tobyfit_mc.m
@@ -71,7 +71,7 @@ function wout=resol_conv_tobyfit_mc(win,sqwfunc,pars,mc_contrib,mc_npoints,xtal,
 %   yvec(10,...):  z_d      z-coordinate of point of detection in detector frame
 %   yvec(11,...):  t_d      deviation in detection time of neutron
 
-wout = win;
+wout = copy(win);
 if ~iscell(pars), pars={pars}; end  % package parameters as a cell for convenience
 
 % Unpack lookup tables and other pre-computed parameters

--- a/horace_core/sqw/@PixelData/PixelData.m
+++ b/horace_core/sqw/@PixelData/PixelData.m
@@ -198,7 +198,7 @@ methods
 
     function is_empty = isempty(obj)
         % Return true if the PixelData object holds no pixel data
-        is_empty = isempty(obj.data);
+        is_empty = obj.num_pixels == 0;
     end
 
     function s = size(obj, varargin)
@@ -224,7 +224,9 @@ methods
 
     function nel = numel(obj)
         % Return the number of data points in the pixel data block
-        nel = numel(obj.data);
+        %   If the data is file backed, this returns the number of values in
+        %   the file
+        nel = obj.PIXEL_BLOCK_COLS_*obj.num_pixels;
     end
 
     function data = get_data(obj, fields, pix_indices)

--- a/horace_core/sqw/@PixelData/PixelData.m
+++ b/horace_core/sqw/@PixelData/PixelData.m
@@ -1,4 +1,4 @@
-classdef PixelData
+classdef PixelData < matlab.mixin.Copyable
 % PixelData Provides an interface for access to pixel data
 %
 %   This class provides getters and setters for each data column in an SQW

--- a/horace_core/sqw/@PixelData/PixelData.m
+++ b/horace_core/sqw/@PixelData/PixelData.m
@@ -221,8 +221,14 @@ methods
         end
         % In memory construction
         if isa(arg, 'PixelData')  % TODO make sure this works with file-backed
-            obj.data = arg.data;
-            obj.file_path_ = arg.file_path;
+            if ~isempty(arg.file_path) && exist(arg.file_path, 'file')
+                % if the file exists we can create a file-backed instance
+                obj = PixelData(arg.file_path, arg.page_memory_size_);
+                obj.pix_position_ = arg.pix_position_;
+            else
+                % if no file exists, just copy the data
+                obj.data = arg.data;
+            end
             return;
         end
         if numel(arg) == 1 && isnumeric(arg) && floor(arg) == arg
@@ -248,7 +254,7 @@ methods
             return;
         end
 
-        % input sets underlying data
+        % Input sets underlying data
         obj.data = arg;
     end
 

--- a/horace_core/sqw/@PixelData/PixelData.m
+++ b/horace_core/sqw/@PixelData/PixelData.m
@@ -198,16 +198,22 @@ methods
     function s = size(obj, varargin)
         % Return the size of the PixelData
         %   Axis 1 gives the number of columns, axis 2 gives the number of
-        %   pixels
-
-        % For the time being, the number of columns is equal to the number of
-        % columns in the underlying pix data block. When we start allowing
-        % additional columns to be added, the number of columns of a PixelData
-        % object may not equal the number in the main underlying data
-        % structure.
-        % This overload should always return the number of columns in the
-        % underlying structure + the number of additional columns
-        s = size(obj.data, varargin{:});
+        %   pixels. Along with Matlab convention, any other axis returns 1.
+        if nargin == 1
+            s = [obj.PIXEL_BLOCK_COLS_, obj.num_pixels];
+        else
+            s = ones(1, numel(varargin));
+            for i = 1:numel(varargin)
+                dim = varargin{i};
+                if dim == 1
+                    s(i) = obj.PIXEL_BLOCK_COLS_;
+                elseif dim == 2
+                    s(i) = obj.num_pixels;
+                else
+                    s(i) = size(obj.data, dim);
+                end
+            end
+        end
     end
 
     function nel = numel(obj)

--- a/horace_core/sqw/@PixelData/PixelData.m
+++ b/horace_core/sqw/@PixelData/PixelData.m
@@ -369,6 +369,7 @@ methods
 
     % --- Getters / Setters ---
     function pixel_data = get.data(obj)
+        obj = obj.load_first_page_if_data_empty_();
         pixel_data = obj.data_;
     end
 
@@ -499,7 +500,6 @@ methods
 
     function page_size = get.page_size(obj)
         % The number of pixels that are held in the current page.
-        %
         if isempty(obj.data)
             page_size = obj.max_page_size_;
         else
@@ -532,14 +532,15 @@ methods (Access = private)
         end
         obj.data = obj.f_accessor_.get_pix(pix_idx_start, pix_idx_end);
         obj.pix_position_ = pix_idx_start;
-        if pix_idx_start == 1 && obj.num_pixels <= obj.max_page_size_
-            % close the sqw file if all the data has been read into memory
+        if pix_idx_start == 1 && (obj.page_size >= obj.num_pixels)
+            % close the sqw file if all the data has been read into memory on
+            % first read
             obj.f_accessor_.deactivate();
         end
     end
 
     function obj = load_first_page_if_data_empty_(obj)
-        if isempty(obj.data) && ~isempty(obj.f_accessor_)
+        if isempty(obj.data_) && ~isempty(obj.f_accessor_)
             obj = obj.load_page_(1);
         end
     end

--- a/horace_core/sqw/@PixelData/PixelData.m
+++ b/horace_core/sqw/@PixelData/PixelData.m
@@ -322,12 +322,20 @@ methods
         %    >> has_more = pix.has_more();
         %
         has_more = false;
-        if ~isempty(obj.f_accessor_)
-            has_more = obj.pix_position_ + obj.page_size- 1 < obj.num_pixels;
+        if isempty(obj.f_accessor_)
+            return;
+        end
+        if obj.page_size == 0 && obj.num_pixels > obj.max_page_size_
+            % If nothing has been loaded into the cache yet (page_size == 0),
+            % the object acts as though the first page has been loaded. So
+            % return true if there's more than one page worth of pixels
+            has_more = true;
+        else
+            has_more = obj.pix_position_ + obj.page_size  <= obj.num_pixels;
         end
     end
 
-    function advance(obj)
+    function obj = advance(obj)
         % Load the next page of pixel data from the file backing the object
         %
         % An example of using this to loop over and sum all signal data in an
@@ -492,9 +500,11 @@ methods
     function page_size = get.page_size(obj)
         % The number of pixels that are held in the current page.
         %
-        % If "num_pixels in file" < "number of pixels that can fit in memory size",
-        % return num_pixels - this avoids ever reading past end of file
-        page_size = size(obj.data, 2);
+        if isempty(obj.data)
+            page_size = obj.max_page_size_;
+        else
+            page_size = size(obj.data, 2);
+        end
     end
 
 end

--- a/horace_core/sqw/@PixelData/PixelData.m
+++ b/horace_core/sqw/@PixelData/PixelData.m
@@ -41,7 +41,6 @@ classdef PixelData
 
 properties (Access=private)
     PIXEL_BLOCK_COLS_ = 9;
-    data_ = zeros(9, 0);
     FIELD_INDEX_MAP_ = containers.Map(...
         {'u1', 'u2', 'u3', 'dE', ...
          'coordinates', ...
@@ -52,6 +51,12 @@ properties (Access=private)
          'signal', ...
          'variance'}, ...
         {1, 2, 3, 4, 1:4, 1:3, 5, 6, 7, 8, 9})
+
+    data_ = zeros(9, 0);
+    f_accessor_;  % instance of faccess object to access pixel data from file
+end
+properties
+   file_path = '';
 end
 properties (Dependent)
     % Return the 1st, 2nd and 3rd dimension of the crystal cartestian orientation (1 x n arrays) [A^-1]
@@ -130,7 +135,7 @@ end
 
 methods
 
-    function obj = PixelData(arg)
+    function obj = PixelData(varargin)
         % Construct a PixelData object from the given data. Default
         % construction initialises the underlying data as an empty (9 x 0)
         % array.
@@ -138,6 +143,8 @@ methods
         %   >> obj = PixelData(ones(9, 200))
         %
         %   >> obj = PixelData(200)  % intialise 200 pixels with underlying data set to zero
+        %
+        %   >> obj = PixelData(file_path)  % initialise pixel data from an sqw file
         %
         % Input:
         % ------
@@ -156,12 +163,17 @@ methods
         %  arg    An integer specifying the desired number of pixels. The underlying
         %         data will be filled with zeros
         %
+        %  arg    A path to an SQW file.
+        %
         if nargin == 1
-            if isa(arg, 'PixelData')
+            arg = varargin{1};
+            if isa(arg, 'PixelData')  %  TODO make sure this works with file-backed
                 obj.data = arg.data;
             elseif numel(arg) == 1 && isnumeric(arg) && floor(arg) == arg
                 % input is integer
                 obj.data = zeros(obj.PIXEL_BLOCK_COLS_, arg);
+            elseif ischar(arg)
+                obj.file_path = arg;
             else
                 obj.data = arg;
             end

--- a/horace_core/sqw/@PixelData/PixelData.m
+++ b/horace_core/sqw/@PixelData/PixelData.m
@@ -170,11 +170,15 @@ methods
             if isa(arg, 'PixelData')  %  TODO make sure this works with file-backed
                 obj.data = arg.data;
             elseif numel(arg) == 1 && isnumeric(arg) && floor(arg) == arg
-                % input is integer
+                % input is an integer
                 obj.data = zeros(obj.PIXEL_BLOCK_COLS_, arg);
             elseif ischar(arg)
+                % input is a file path
                 obj.file_path = arg;
+                obj.f_accessor_ = sqw_formats_factory.instance().get_loader(arg);
+                obj.data = obj.f_accessor_.get_pix(1, obj.num_pixels).data;
             else
+                % input sets underlying data
                 obj.data = arg;
             end
         end
@@ -371,7 +375,11 @@ methods
      end
 
     function num_pix = get.num_pixels(obj)
-        num_pix = size(obj.data, 2);
+        if isempty(obj.f_accessor_)
+            num_pix = size(obj.data, 2);
+        else
+            num_pix = obj.f_accessor_.npixels;
+        end
     end
 
 end

--- a/horace_core/sqw/@PixelData/PixelData.m
+++ b/horace_core/sqw/@PixelData/PixelData.m
@@ -331,7 +331,7 @@ methods
             % return true if there's more than one page worth of pixels
             has_more = true;
         else
-            has_more = obj.pix_position_ + obj.page_size  <= obj.num_pixels;
+            has_more = obj.pix_position_ + obj.max_page_size_  <= obj.num_pixels;
         end
     end
 
@@ -500,11 +500,7 @@ methods
 
     function page_size = get.page_size(obj)
         % The number of pixels that are held in the current page.
-        if isempty(obj.data)
-            page_size = obj.max_page_size_;
-        else
-            page_size = size(obj.data, 2);
-        end
+        page_size = size(obj.data_, 2);
     end
 
 end
@@ -526,17 +522,12 @@ methods (Access = private)
         if pix_idx_end > obj.num_pixels
             pix_idx_end = obj.num_pixels;
         end
-        if ~obj.f_accessor_.is_activated()
-            % open the sqw file if it's not open
-            obj.f_accessor_.activate();
-        end
         obj.data = obj.f_accessor_.get_pix(pix_idx_start, pix_idx_end);
-        obj.pix_position_ = pix_idx_start;
-        if pix_idx_start == 1 && (obj.page_size >= obj.num_pixels)
-            % close the sqw file if all the data has been read into memory on
-            % first read
+        if obj.page_size == obj.num_pixels && obj.f_accessor_.is_activated()
+            % close the file if all pixels have been read
             obj.f_accessor_.deactivate();
         end
+        obj.pix_position_ = pix_idx_start;
     end
 
     function obj = load_first_page_if_data_empty_(obj)

--- a/horace_core/sqw/@sqw/compact.m
+++ b/horace_core/sqw/@sqw/compact.m
@@ -6,7 +6,7 @@ function wout = compact (win)
 %
 % Input:
 % ------
-%   win         Input object 
+%   win         Input object
 %
 % Output:
 % -------
@@ -19,11 +19,11 @@ function wout = compact (win)
 % $Revision:: 1759 ($Date:: 2020-02-10 16:06:00 +0000 (Mon, 10 Feb 2020) $)
 
 % Initialise output argument
-wout = win;
+wout = copy(win);
 
 %Loop over the number of inputs objects:
 for n=1:numel(win)
-    
+
     % Dimension of input data structure
     ndim=length(win(n).data.p);
     if ndim==0  % no compacting needs to be done

--- a/horace_core/sqw/@sqw/copy.m
+++ b/horace_core/sqw/@sqw/copy.m
@@ -1,0 +1,11 @@
+function new_sqw = copy(obj)
+% Copy this SQW object or an array of sqw objects
+%
+% As PixelData is a handle class, we must call the copy operator on the pixels
+% so the two SQW objects do not point to the same pixel data
+new_sqw = obj;
+for i = 1:numel(obj)
+    if is_sqw_type(obj(i))
+        new_sqw(i).data.pix = copy(obj(i).data.pix);
+    end
+end

--- a/horace_core/sqw/@sqw/disp2sqw_eval.m
+++ b/horace_core/sqw/@sqw/disp2sqw_eval.m
@@ -15,7 +15,7 @@ function wout=disp2sqw_eval(win,dispreln,pars,fwhh,opt)
 %               where
 %                   qh,qk,ql    Arrays containing the coordinates of a set of points
 %                              in reciprocal lattice units
-%                   p           Vector of parameters needed by dispersion function 
+%                   p           Vector of parameters needed by dispersion function
 %                              e.g. [A,js,gam] as intensity, exchange, lifetime
 %                   w           Array of corresponding energies, or, if more than
 %                              one dispersion relation, a cell array of arrays.
@@ -25,7 +25,7 @@ function wout=disp2sqw_eval(win,dispreln,pars,fwhh,opt)
 %              More general form is:
 %                   [w,s] = dispreln (qh,qk,ql,p,c1,c2,..)
 %                 where
-%                   p           Typically a vector of parameters that we might want 
+%                   p           Typically a vector of parameters that we might want
 %                              to fit in a least-squares algorithm
 %                   c1,c2,...   Other constant parameters e.g. file name for look-up
 %                              table.
@@ -39,7 +39,7 @@ function wout=disp2sqw_eval(win,dispreln,pars,fwhh,opt)
 %   fwhh       Parametrizes the resolution function. There are three
 %              possible input values of fwhh:
 %
-%       double              A single FWHM value determines the FWHM of the 
+%       double              A single FWHM value determines the FWHM of the
 %                           Gaussian resolution function
 %       function_handle     A function that produces the FWHM value as a
 %                           function of energy transfer, it has to have the
@@ -71,7 +71,7 @@ function wout=disp2sqw_eval(win,dispreln,pars,fwhh,opt)
 %
 % Output:
 % -------
-%   wout        Output dataset or array of datasets 
+%   wout        Output dataset or array of datasets
 
 
 % Check optional argument
@@ -86,8 +86,8 @@ if exist('opt','var')  % no option given
         error('Unrecognised option')
     end
 end
-    
-wout = win;
+
+wout = copy(win);
 if ~iscell(pars), pars={pars}; end  % package parameters as a cell for convenience
 
 for i=1:numel(win)

--- a/horace_core/sqw/@sqw/equal_to_tol.m
+++ b/horace_core/sqw/@sqw/equal_to_tol.m
@@ -140,8 +140,10 @@ else
     % if required
 
     % Test all fields except pix array
-    tmp1=struct(w1); tmp1.data.pix=PixelData();
-    tmp2=struct(w2); tmp2.data.pix=PixelData();
+    tmp1=struct(w1);
+    tmp1.data.pix=PixelData();
+    tmp2=struct(w2);
+    tmp2.data.pix=PixelData();
     [ok,mess]=equal_to_tol(tmp1,tmp2,args{:},'name_a',name_a,'name_b',name_b);
     if ~ok, return, end
 

--- a/horace_core/sqw/@sqw/fit_legacy_func.m
+++ b/horace_core/sqw/@sqw/fit_legacy_func.m
@@ -423,7 +423,7 @@ args=multifit_gateway_wrap_functions (varargin,pos,func,plist,bpos,bfunc,bplist,
                                                     @func_eval,{},@func_eval,{});
 
 % Evaluate function for each element of the array of objects
-wout=win;
+wout = copy(win);
 fitdata=repmat(struct,size(wout));  % array of empty structures
 ok=false(size(wout));
 mess=cell(size(wout));

--- a/horace_core/sqw/@sqw/fit_legacy_sqw.m
+++ b/horace_core/sqw/@sqw/fit_legacy_sqw.m
@@ -442,7 +442,7 @@ args=multifit_gateway_wrap_functions (varargin,pos,func,plist,bpos,bfunc,bplist,
                                                     @sqw_eval,wrap_plist,@func_eval,{});
 
 % Evaluate function for each element of the array of objects
-wout=win;
+wout = copy(win);
 fitdata=repmat(struct,size(wout));  % array of empty structures
 ok=false(size(wout));
 mess=cell(size(wout));

--- a/horace_core/sqw/@sqw/fit_legacy_sqw_sqw.m
+++ b/horace_core/sqw/@sqw/fit_legacy_sqw_sqw.m
@@ -443,7 +443,8 @@ args=multifit_gateway_wrap_functions (varargin,pos,func,plist,bpos,bfunc,bplist,
                                                     @sqw_eval,wrap_plist,@sqw_eval,wrap_plist);
 
 % Evaluate function for each element of the array of objects
-wout=win;
+wout=copy(win);
+
 fitdata=repmat(struct,size(wout));  % array of empty structures
 ok=false(size(wout));
 mess=cell(size(wout));

--- a/horace_core/sqw/@sqw/func_eval.m
+++ b/horace_core/sqw/@sqw/func_eval.m
@@ -77,7 +77,7 @@ else
     error('Unrecognised option')
 end
 
-wout = win;
+wout = copy(win);
 if ~iscell(pars), pars={pars}; end  % package parameters as a cell for convenience
 
 % Check if any objects are zero dimensional before evaluating fuction, to save on possible expensive computations

--- a/horace_core/sqw/@sqw/get_sqw.m
+++ b/horace_core/sqw/@sqw/get_sqw.m
@@ -8,7 +8,6 @@ function [mess,main_header,header,detpar,data,position,npixtot,data_type,file_fo
 %   >> [...] = get_sqw (sqw,infile, '-hverbatim')
 %   >> [...] = get_sqw (sqw,infile, '-hisverbatim')
 %   >> [...] = get_sqw (sqw,infile, '-nopix')
-%   >> [...] = get_sqw (sqw,infile, npix_lo, npix_hi)
 %
 % Input:
 % --------
@@ -30,9 +29,6 @@ function [mess,main_header,header,detpar,data,position,npixtot,data_type,file_fo
 %                   '-nopix'        Pixel information not read (only meaningful for sqw data type 'a')
 %
 %               Default: read all fields of whatever is the sqw data type contained in the file ('b','b+','a','a-')
-%
-%   npix_lo     -|- [optional] pixel number range to be read from the file
-%   npix_hi     -|
 %
 %
 % Output:
@@ -73,7 +69,7 @@ function [mess,main_header,header,detpar,data,position,npixtot,data_type,file_fo
 %
 %   npixtot     Total number of pixels written to file (=[] if pix not present in the file)
 %
-%   data_type   Type of sqw data written in the file 
+%   data_type   Type of sqw data written in the file
 %                   type 'b'    fields: filename,...,dax,s,e
 %                   type 'b+'   fields: filename,...,dax,s,e,npix
 %                   type 'a'    fields: filename,...,dax,s,e,npix,urange,pix
@@ -84,7 +80,7 @@ function [mess,main_header,header,detpar,data,position,npixtot,data_type,file_fo
 %   file_format     Format of file
 %                       Current formats:  '-v2', '-v3'
 %                       Obsolete formats: '-prototype'
-% 
+%
 %
 % NOTES:
 % ======

--- a/horace_core/sqw/@sqw/mask.m
+++ b/horace_core/sqw/@sqw/mask.m
@@ -26,7 +26,7 @@ function wout = mask (win, mask_array)
 
 
 % Initialise output argument
-wout = win;
+wout = copy(win);
 
 % Trivial case of empty or no mask arguments
 if nargin==1 || isempty(mask_array)

--- a/horace_core/sqw/@sqw/mask_detectors.m
+++ b/horace_core/sqw/@sqw/mask_detectors.m
@@ -32,7 +32,7 @@ end
 
 % Trivial case of empty or no mask arguments
 if nargin==1 || isempty(det_id)
-    wout=win;
+    wout = copy(win);
     return
 end
 

--- a/horace_core/sqw/@sqw/mask_pixels.m
+++ b/horace_core/sqw/@sqw/mask_pixels.m
@@ -42,7 +42,7 @@ if ~is_sqw_type(win)
 end
 
 % Initialise output argument
-wout = win;
+wout = copy(win);
 
 % Trivial case of empty or no mask arguments
 if nargin==1 || isempty(mask_array)

--- a/horace_core/sqw/@sqw/mask_random_fraction_pixels.m
+++ b/horace_core/sqw/@sqw/mask_random_fraction_pixels.m
@@ -29,7 +29,7 @@ if ~is_sqw_type(win);
 end
 
 % Initialise output argument
-wout = win;
+wout = copy(win);
 
 
 %Check size of input array:

--- a/horace_core/sqw/@sqw/mask_random_pixels.m
+++ b/horace_core/sqw/@sqw/mask_random_pixels.m
@@ -29,7 +29,7 @@ if ~is_sqw_type(win);
 end
 
 % Initialise output argument
-wout = win;
+wout = copy(win);
 
 
 %Check size of input array:

--- a/horace_core/sqw/@sqw/mask_runs.m
+++ b/horace_core/sqw/@sqw/mask_runs.m
@@ -35,7 +35,7 @@ end
 
 % Trivial case of empty or no mask arguments
 if nargin==1 || isempty(runno)
-    wout=win;
+    wout = copy(win);
     return
 end
 

--- a/horace_core/sqw/@sqw/permute.m
+++ b/horace_core/sqw/@sqw/permute.m
@@ -23,7 +23,7 @@ function wout = permute (win, order)
 %
 %
 % Example: if input object is 3D
-%   >> wout = permute (win, [3,1,2]) % the current 3rd, 1st and 2nd display axes 
+%   >> wout = permute (win, [3,1,2]) % the current 3rd, 1st and 2nd display axes
 %                                    % become the 1st, 2nd and 3rd of the output object
 %
 %   >> wout = permute (win)          % equivalent to permute(win,[2,3,1])
@@ -46,7 +46,7 @@ end
 
 if ~exist('order','var')
     if ndim<=1
-        wout = win;     % nothing to permute
+        wout = copy(win);     % nothing to permute
         return
     else
         order = [linspace(2,ndim,ndim-1),1];
@@ -63,9 +63,9 @@ end
 
 % Permute data array
 if isequal(order,(1:ndim))      % order is unchanged
-    wout = win;
+    wout = copy(win);
 else
-    wout = win;
+    wout = copy(win);
     for i=1:numel(win)
         wout(i).data.dax = win(i).data.dax(order);
     end

--- a/horace_core/sqw/@sqw/private/combine_sqw_same_bins.m
+++ b/horace_core/sqw/@sqw/private/combine_sqw_same_bins.m
@@ -5,7 +5,7 @@ function wout = combine_sqw_same_bins (varargin)
 %
 %   >> wout = combine_sqw_same_bins (w1,w2,w3...)
 
-wout = varargin{1};
+wout = copy(varargin{1});
 % Trivial case of just one input argument
 if numel(varargin)==1
     return
@@ -14,7 +14,7 @@ end
 % More than one sqw object
 % ------------------------
 nw = numel(varargin);   % number of sqw objects
-nbin = numel(varargin{1}.data.npix);     % number of bins in each sqw object
+nbin = numel(wout.data.npix);     % number of bins in each sqw object
 
 % Total number of pixels in each sqw object
 npixtot = cellfun (@(x) x.data.pix.num_pixels, varargin);
@@ -52,7 +52,7 @@ pix = PixelData(npixtot_all);
 for i=1:nw
     pix.data(:,nbeg(i):nend(i)) = varargin{i}.data.pix.data;
 end
-wout.data.pix.data = pix.data(:,ix_all);
+wout.data.pix = PixelData(pix.data(:,ix_all));
 
 % Recompute the singal and error arrays
 wout=recompute_bin_data(wout);

--- a/horace_core/sqw/@sqw/private/cut_data_from_array.m
+++ b/horace_core/sqw/@sqw/private/cut_data_from_array.m
@@ -75,7 +75,7 @@ cut_pix_data = PixelData(npix_read);
 ibeg = cumsum([1;range(1:end-1)]);
 iend = cumsum(range);
 for i=1:length(range)
-    cut_pix_data.data(:,ibeg(i):iend(i)) = pix_in.data(:,nstart(i):nend(i));
+    cut_pix_data.data(:,ibeg(i):iend(i)) = pix_in.get_pixels(nstart(i):nend(i)).data;
 end
 if hor_log_level>=1, t_read = bigtoc(1); end
 if hor_log_level>=2

--- a/horace_core/sqw/@sqw/rebunch.m
+++ b/horace_core/sqw/@sqw/rebunch.m
@@ -12,7 +12,7 @@ for i=1:numel(win)
     end
 end
 
-wout=win;   % initalise the output
+wout = copy(win);   % initalise the output
 for i=1:numel(win)
     wout(i).data = rebunch_dnd(win(i).data,varargin{:});
 end

--- a/horace_core/sqw/@sqw/section.m
+++ b/horace_core/sqw/@sqw/section.m
@@ -33,7 +33,7 @@ function wout = section (win,varargin)
 
 % Trivial case of no section arguments
 if nargin==1
-    wout = win;
+    wout = copy(win);
     return
 end
 
@@ -55,7 +55,7 @@ if nargs~=ndim
 end
 
 % Initialise output argument
-wout = win;
+wout = copy(win);
 
 tol=4*eps('single');    % acceptable tolerance: bin centres deemed contained in new boundaries
 

--- a/horace_core/sqw/@sqw/shift_energy_bins.m
+++ b/horace_core/sqw/@sqw/shift_energy_bins.m
@@ -60,7 +60,7 @@ for i=1:numel(win)
 end
 
 % Shift the energy bins
-wout = win;
+wout = copy(win);
 if ~iscell(pars), pars={pars}; end  % package parameters as a cell for convenience
 
 for i=1:numel(win)

--- a/horace_core/sqw/@sqw/shift_pixels.m
+++ b/horace_core/sqw/@sqw/shift_pixels.m
@@ -56,7 +56,7 @@ if exist('opt','var')  % no option given
     end
 end
 
-wout = win;
+wout = copy(win);
 if ~iscell(pars), pars={pars}; end  % package parameters as a cell for convenience
 
 for i=1:numel(win)

--- a/horace_core/sqw/@sqw/slim.m
+++ b/horace_core/sqw/@sqw/slim.m
@@ -25,7 +25,7 @@ if ~(isnumeric(reduce) && isscalar(reduce) && isfinite(reduce) && reduce>=1)
 end
 
 % Perform action using existing sqw methods for masking pixels
-wout = win;
+wout = copy(win);
 if reduce>1     % nothing to do if reduce==1
     for i=1:numel(wout)
         npix = wout.data.pix.num_pixels;

--- a/horace_core/sqw/@sqw/smooth.m
+++ b/horace_core/sqw/@sqw/smooth.m
@@ -12,7 +12,7 @@ for i=1:numel(win)
     end
 end
 
-wout=win;   % initalise the output
+wout = copy(win);   % initalise the output
 for i=1:numel(win)
     wout(i).data = smooth_dnd(win(i).data,false,varargin{:});
 end

--- a/horace_core/sqw/@sqw/smooth_units.m
+++ b/horace_core/sqw/@sqw/smooth_units.m
@@ -12,7 +12,7 @@ for i=1:numel(win)
     end
 end
 
-wout=win;   % initalise the output
+wout = copy(win);   % initalise the output
 for i=1:numel(win)
     wout(i).data = smooth_dnd(win(i).data,true,varargin{:});
 end

--- a/horace_core/sqw/@sqw/sqw_eval.m
+++ b/horace_core/sqw/@sqw/sqw_eval.m
@@ -62,7 +62,7 @@ if exist('opt','var')  % no option given
     end
 end
 
-wout = win;
+wout = copy(win);
 if ~iscell(pars), pars={pars}; end  % package parameters as a cell for convenience
 
 for i=1:numel(win)

--- a/horace_core/sqw/coord_transform/@projaxes/private/check_and_set_opt_fields_.m
+++ b/horace_core/sqw/coord_transform/@projaxes/private/check_and_set_opt_fields_.m
@@ -10,7 +10,7 @@ function [message, obj] = check_and_set_opt_fields_(obj,p)
 %           wout can be an altered version of the input structure or object that must
 %           have the same fields. For example, if a column array is provided for a field
 %           value, but one wants the array to be a row, then checkfields could take the
-%           transpose. If the facility is not wanted, simply include the line wout=win.
+%           transpose. If the facility is not wanted, simply include the line wout = copy(win).
 %
 %     Because checkfields must be in the folder defining the class, it
 %     can change fields of an object without calling set.m, which means
@@ -78,7 +78,7 @@ if isfield(p,'lab')
     obj.lab = p.lab;
 else
     obj.lab={'\zeta','\xi','\eta','E'};
-    
+
     if isfield(p,'lab1')
         if ischar(p.lab1) && size(p.lab1,1)==1
             obj.lab{1}=p.lab1;
@@ -87,7 +87,7 @@ else
             return
         end
     end
-    
+
     if isfield(p,'lab2')
         if ischar(p.lab2) && size(p.lab2,1)==1
             obj.lab{2}=p.lab2;
@@ -96,7 +96,7 @@ else
             return
         end
     end
-    
+
     if isfield(p,'lab3')
         if ischar(p.lab3) && size(p.lab3,1)==1
             obj.lab{3}=p.lab3;
@@ -105,7 +105,7 @@ else
             return
         end
     end
-    
+
     if isfield(p,'lab4')
         if ischar(p.lab4) && size(p.lab4,1)==1
             obj.lab{4}=p.lab4;

--- a/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
+++ b/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
@@ -471,12 +471,12 @@ classdef dnd_binfile_common < dnd_file_interface
 
             if is && nargin == 2
                 if strcmp(read_or_write, 'read')
-                    read_mode_regex = '([ra]b\+?)|(wb\+)';
-                    open_for_reading = regexp(permission, read_mode_regex);
+                    READ_MODE_REGEX = '([ra]b\+?)|(wb\+)';
+                    open_for_reading = regexp(permission, READ_MODE_REGEX);
                     is = open_for_reading;
                 elseif strcmp(read_or_write, 'write')
-                    write_mode_regex = '([WAaw]b\+?)|(rb\+)';
-                    open_for_writing = regexp(permission, write_mode_regex);
+                    WRITE_MODE_REGEX = '([WAaw]b\+?)|(rb\+)';
+                    open_for_writing = regexp(permission, WRITE_MODE_REGEX);
                     is = open_for_writing;
                 else
                     error('DNDBINFILECOMMON:is_activated', ...

--- a/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
+++ b/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
@@ -467,17 +467,17 @@ classdef dnd_binfile_common < dnd_file_interface
             %
             full_file_path = fullfile(obj.filepath, obj.filename);
             [file_id_path, permission] = fopen(obj.file_id_);
-            is = ~isempty(obj.file_closer_) && strcmp(full_file_path, file_id_path);
+            is = strcmp(full_file_path, file_id_path);
 
             if is && nargin == 2
-                if strcmp(read_or_write, 'read')
+                if strcmpi(read_or_write, 'read')
                     READ_MODE_REGEX = '([ra]b\+?)|(wb\+)';
-                    open_for_reading = regexp(permission, READ_MODE_REGEX);
-                    is = open_for_reading;
-                elseif strcmp(read_or_write, 'write')
+                    open_for_reading = regexp(permission, READ_MODE_REGEX, 'once');
+                    is = ~isempty(open_for_reading);
+                elseif strcmpi(read_or_write, 'write')
                     WRITE_MODE_REGEX = '([WAaw]b\+?)|(rb\+)';
-                    open_for_writing = regexp(permission, WRITE_MODE_REGEX);
-                    is = open_for_writing;
+                    open_for_writing = regexp(permission, WRITE_MODE_REGEX, 'once');
+                    is = ~isempty(open_for_writing);
                 else
                     error('DNDBINFILECOMMON:is_activated', ...
                           ['Invalid input for read_or_write. Must be ''read'' ', ...
@@ -515,10 +515,9 @@ classdef dnd_binfile_common < dnd_file_interface
             %                 Default is 'read'.
             %
             if nargin == 1
-                permission = 'rb';
-            else
-                permission = get_fopen_permission_(read_or_write);
+                read_or_write = 'read';
             end
+            permission = get_fopen_permission_(read_or_write);
 
             if ~isempty(obj.file_closer_)
                 obj.file_closer_ = [];

--- a/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
+++ b/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
@@ -237,7 +237,7 @@ classdef dnd_binfile_common < dnd_file_interface
                     obj.(flds{i}) = obj_structure_from_saveobj.(flds{i});
                 end
             end
-            if ~isempty(obj.file_closer_) && obj.file_id_ > 0;
+            if ~isempty(obj.file_closer_) && obj.file_id_ > 0
                 return;
             end
             if ~ischar(obj.num_dim_) && ~isempty(obj.filename_)
@@ -499,23 +499,27 @@ classdef dnd_binfile_common < dnd_file_interface
             obj.file_id_ = 0;
         end
         %
-        function obj = activate(obj, permission)
-            % open respective file for reading without reading any
-            % supplementary file information. Assume that this information
-            % is correct.
+        function obj = activate(obj, read_or_write)
+            % Open respective file in read or write mode without reading any
+            % supplementary file information. Assume that header information
+            % stored on this object is correct.
             %
-            % To use for MPI transfers between workers when open file can
+            % Can be used for MPI transfers between workers when open file can
             % not be transferred between workers but everything else can
             %
             % Input
             % -----
             %
-            % permission  The permissions with which to open the file.
-            %             Default is 'rb'.
+            % read_or_write   Char array. If 'read' open the file in read-only
+            %                 mode If 'write' open the file in read/write mode.
+            %                 Default is 'read'.
             %
             if nargin == 1
                 permission = 'rb';
+            else
+                permission = get_fopen_permission_(read_or_write);
             end
+
             if ~isempty(obj.file_closer_)
                 obj.file_closer_ = [];
             end

--- a/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
+++ b/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
@@ -54,14 +54,14 @@ classdef dnd_binfile_common < dnd_file_interface
         % of Horace data information and the size of this part.
         % 26 is standard position in modern sqw file format.
         data_pos_=26;
-        
+
         % signal information location (in bytes)
         s_pos_=0;
         % error information location (in bytes)
         e_pos_=0;
         % position of the npix field
         npix_pos_='undefined';
-        
+
         % end of dnd info position
         dnd_eof_pos_=0;
         % contains structure with accurate positions of all data fields
@@ -88,7 +88,7 @@ classdef dnd_binfile_common < dnd_file_interface
         % all substantial parts of appropriate sqw file
         fields_to_save_ = {'data_pos_';'s_pos_';'e_pos_';'npix_pos_';'dnd_eof_pos_';...
             'data_fields_locations_'};
-        
+
     end
     %
     properties(Dependent)
@@ -99,7 +99,7 @@ classdef dnd_binfile_common < dnd_file_interface
         data_position;
         % initial location of npix fields
         npix_position;
-        
+
     end
     %
     methods(Access = protected,Hidden=true)
@@ -225,7 +225,7 @@ classdef dnd_binfile_common < dnd_file_interface
             flds = fields_to_save@dnd_file_interface(obj);
             flds = [flds(:);obj.fields_to_save_(:)];
         end
-        
+
         %
         function obj=init_from_structure(obj,obj_structure_from_saveobj)
             % init file accessors using structure, obtained for object
@@ -257,11 +257,11 @@ classdef dnd_binfile_common < dnd_file_interface
         %
         % Check if this loader should deal with selected data stream
         [should,objinit,mess]= should_load_stream(obj,stream,fid)
-        
+
         % set filename to save sqw data and open file for write/append
         % operations
         [obj,file_exist] = set_file_to_update(obj,filename)
-        
+
         % Reopen existing file to overwrite or write new data to it
         % or open new target file to save data.
         obj = reopen_to_write(obj,filename)
@@ -269,7 +269,7 @@ classdef dnd_binfile_common < dnd_file_interface
         % initialize loader, to be ready to read or write dnd data.
         obj = init(obj,varargin);
         % ----------------------------------------------------------------
-        
+
         % read main dnd data  from properly initialized binary file.
         [dnd_data,obj] = get_data(obj,varargin);
         %
@@ -299,8 +299,8 @@ classdef dnd_binfile_common < dnd_file_interface
         % retrieve full dnd object from sqw file containing dnd or dnd and
         % sqw information
         [dnd_obj,varargout] = get_dnd(obj,varargin);
-        
-        
+
+
         %------   Mutators:
         % Save new or fully overwrite existing sqw file
         obj = put_sqw(obj,varargin);
@@ -315,12 +315,12 @@ classdef dnd_binfile_common < dnd_file_interface
         obj = put_dnd_data(obj,varargin);
         %
         obj = put_dnd(obj,varargin)
-        
+
         %------   Auxiliary methods
         % build header, which contains information on sqw/dnd object and
         % informs clients on the contents of a binary file
         header = build_app_header(obj,sqw_obj)
-        
+
         %------- Used in upgrade
         function type = get.upgrade_mode(obj)
             % return true if object is set up for upgrade
@@ -441,7 +441,7 @@ classdef dnd_binfile_common < dnd_file_interface
             if strcmp(obj.data_type,'un') % we want full data if datatype is undefined
                 argi={};
             end
-            
+
             data_form = process_format_fields_(argi{:});
         end
         %
@@ -458,7 +458,9 @@ classdef dnd_binfile_common < dnd_file_interface
         function is = is_activated(obj)
             % Check if the file-accessor is bind with open binary file
             %
-            is =  ~isempty(obj.file_closer_) && obj.file_id_ >0;
+            open_file_ids = fopen('all');
+            is =  ~isempty(obj.file_closer_) && obj.file_id_ > 0;
+            is = is && ismember(obj.file_id_, open_file_ids);
         end
         %
         function obj = deactivate(obj)
@@ -484,7 +486,7 @@ classdef dnd_binfile_common < dnd_file_interface
             if ~isempty(obj.file_closer_)
                 obj.file_closer_ = [];
             end
-            
+
             obj.file_id_ = fopen(fullfile(obj.filepath,obj.filename));
             if obj.file_id_ <=0
                 error('FILE_IO:runtime_error',...
@@ -510,7 +512,7 @@ classdef dnd_binfile_common < dnd_file_interface
         % correspondent to the structure form_fields
         [fn_start,fn_end,is_last] = extract_field_range(pos_fields,form_fields);
     end
-    
+
 end
 
 

--- a/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
+++ b/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
@@ -506,6 +506,13 @@ classdef dnd_binfile_common < dnd_file_interface
             %
             % To use for MPI transfers between workers when open file can
             % not be transferred between workers but everything else can
+            %
+            % Input
+            % -----
+            %
+            % permission  The permissions with which to open the file.
+            %             Default is 'rb'.
+            %
             if nargin == 1
                 permission = 'rb';
             end

--- a/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
+++ b/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
@@ -237,7 +237,7 @@ classdef dnd_binfile_common < dnd_file_interface
                     obj.(flds{i}) = obj_structure_from_saveobj.(flds{i});
                 end
             end
-            if obj.is_activated()
+            if ~isempty(obj.file_closer_) && obj.file_id_ > 0;
                 return;
             end
             if ~ischar(obj.num_dim_) && ~isempty(obj.filename_)

--- a/horace_core/sqw/file_io/@dnd_binfile_common/private/get_fopen_permission_.m
+++ b/horace_core/sqw/file_io/@dnd_binfile_common/private/get_fopen_permission_.m
@@ -1,0 +1,12 @@
+function permission = get_fopen_permission_(permission)
+    % Convert char arrays 'read' or 'write' into fopen file permissions
+    if strcmpi(permission, 'read')
+        permission = 'rb';
+    elseif strcmpi(permission, 'write')
+        permission = 'rb+';
+    else
+        error('DNDBINFILECOMMON:get_fopen_permission_', ...
+              ['Invalid input for read_or_write. Must be ''read'' or ''write''. ' ...
+               'Found ''%s'''], read_or_write);
+    end
+end

--- a/horace_core/sqw/file_io/@dnd_binfile_common/private/get_fopen_permission_.m
+++ b/horace_core/sqw/file_io/@dnd_binfile_common/private/get_fopen_permission_.m
@@ -7,6 +7,6 @@ function permission = get_fopen_permission_(permission)
     else
         error('DNDBINFILECOMMON:get_fopen_permission_', ...
               ['Invalid input for read_or_write. Must be ''read'' or ''write''. ' ...
-               'Found ''%s'''], read_or_write);
+               'Found ''%s'''], permission);
     end
 end

--- a/horace_core/sqw/file_io/@faccess_sqw_prototype/faccess_sqw_prototype.m
+++ b/horace_core/sqw/file_io/@faccess_sqw_prototype/faccess_sqw_prototype.m
@@ -173,7 +173,6 @@ classdef faccess_sqw_prototype < sqw_binfile_common
             %
             %   >> data = obj.get_sqw_data()
             %   >> data = obj.get_sqw_data(opt)
-            %   >> data = obj.get_sqw_data(npix_lo, npix_hi)
             %
             % Input:
             % ------
@@ -191,14 +190,9 @@ classdef faccess_sqw_prototype < sqw_binfile_common
             %
             %               Default: read all fields of whatever is the sqw data type contained in the file ('b','b+','a','a-')
             %
-            %   npix_lo     -|- [optional] pixel number range to be read from the file (only applies to type 'a')
-            %   npix_hi     -|
-            %
-
-            %
             % Output:
             % -------
-
+            %
             %   data        Output data structure actually read from the file. Will be one of:
             %                   type 'h'    fields: fields: uoffset,...,dax[,urange]
             %                   type 'b'    fields: filename,...,dax,s,e

--- a/horace_core/sqw/file_io/@sqw_binfile_common/get_data.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/get_data.m
@@ -161,6 +161,7 @@ if ~nopix
     if ~exist('npix_hi','var')
         npix_hi = obj.npixels;
     end
-    data.pix = obj.get_pix(npix_lo,npix_hi);
+    % TODO: add constructor that takes npix_lo and npix_hi and loads that range
+    data.pix = PixelData(obj);
 end
 

--- a/horace_core/sqw/file_io/@sqw_binfile_common/get_data.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/get_data.m
@@ -9,7 +9,6 @@ function [data,obj] = get_data (obj,varargin)
 %
 %   >> data = obj.get_data()
 %   >> data = obj.get_data(opt)
-%   >> data = obj.get_data(npix_lo, npix_hi)
 %
 % Input:
 % ------
@@ -29,11 +28,6 @@ function [data,obj] = get_data (obj,varargin)
 %                            going to be created. May be removed in a future.
 %
 %               Default: read all fields of whatever is the sqw data type contained in the file ('b','b+','a','a-')
-%
-%   npix_lo     -|- [optional] pixel number range to be read from the file (only applies to type 'a')
-%   npix_hi     -|
-%
-
 %
 % Output:
 % -------
@@ -137,31 +131,6 @@ if header_only || noclass
 end
 data = data_sqw_dnd(data_str);
 
-if numel(argi)>0
-    if ~isnumeric(argi{1})
-        error('SQW_BINFILE_COMMON:invalid_argument',...
-            'get_data: invalid argument %s',argi{1})
-    end
-    npix_lo = argi{1};
-    if numel(argi)>1
-        if ~isnumeric(argi{2})
-            error('SQW_BINFILE_COMMON:invalid_argument',...
-                'get_data: invalid argument %s',argi{1})
-        end
-        npix_hi = argi{2};
-    end
-end
-
-
-
 if ~nopix
-    if ~exist('npix_lo','var')
-        npix_lo = 1;
-    end
-    if ~exist('npix_hi','var')
-        npix_hi = obj.npixels;
-    end
-    % TODO: add constructor that takes npix_lo and npix_hi and loads that range
     data.pix = PixelData(obj);
 end
-

--- a/horace_core/sqw/file_io/@sqw_binfile_common/get_pix.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/get_pix.m
@@ -55,7 +55,7 @@ if res ~= 0
 end
 
 if size>0
-    pix = PixelData(fread(obj.file_id_,[9,size],'float32'));
+    pix = fread(obj.file_id_,[9,size],'float32');
     [mess,res] = ferror(obj.file_id_);
     if res ~= 0
         error('SQW_BINFILE_COMMON:io_error',...
@@ -63,5 +63,5 @@ if size>0
     end
 else
     % *** T.G.Perring 5 Sep 2018: allow for size=0
-    pix = PixelData();
+    pix = [];
 end

--- a/horace_core/sqw/file_io/@sqw_binfile_common/get_pix.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/get_pix.m
@@ -10,6 +10,10 @@ if ischar(obj.num_contrib_files)
         'get_pix method called from un-initialized loader')
 end
 
+if ~obj.is_activated('read')
+    obj = obj.activate('rb+');
+end
+
 npix_tot = obj.npixels;
 if isempty(npix_tot) % dnd object
     pix = PixelData();

--- a/horace_core/sqw/file_io/@sqw_binfile_common/get_pix.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/get_pix.m
@@ -11,7 +11,7 @@ if ischar(obj.num_contrib_files)
 end
 
 if ~obj.is_activated('read')
-    obj = obj.activate('rb+');
+    obj = obj.activate('read');
 end
 
 npix_tot = obj.npixels;

--- a/horace_core/sqw/file_io/@sqw_binfile_common/get_sqw.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/get_sqw.m
@@ -7,7 +7,6 @@ function [sqw_object,varargout] = get_sqw (obj,varargin)
 %   >> sqw_object = obj.get_sqw('-hverbatim')
 %   >> sqw_object = obj.get_sqw('-hisverbatim')
 %   >> sqw_object = obj.get_sqw('-nopix')
-%   >> sqw_object = obj.get_sqw(npix_lo, npix_hi)
 %
 % Input:
 % --------
@@ -32,10 +31,6 @@ function [sqw_object,varargout] = get_sqw (obj,varargin)
 %                                   detpar and data
 %
 %               Default: read all fields of whatever is the sqw data type contained in the file ('b','b+','a','a-')
-%
-%   npix_lo     -|- [optional] pixel number range to be read from the file
-%   npix_hi     -|
-%
 %
 % Output:
 % --------
@@ -66,15 +61,8 @@ if ~ok
 end
 verbatim = verbatim||hverbatim;
 if numel(argi)>0
-    numer = cellfun(@isnumeric,argi);
-    if any(~numer)
-        error('SQW_BINFILE_COMMON:invalid_argument',...
-            'Unrecognised options %s to get_sqw',argi{:});
-    end
-    num_arg = argi{numer};
-    pix_range  = true;
-else
-    pix_range = false;
+    error('SQW_BINFILE_COMMON:invalid_argument',...
+        'Unrecognised options %s to get_sqw',argi{:});
 end
 
 
@@ -119,20 +107,7 @@ else
 end
 
 data_opt={opt1{:},opt2{:},opt3{:}};
-if pix_range
-    if numel(num_arg) == 2
-        npix_lo = num_arg{1};
-        npix_hi = num_arg{2};
-        
-    elseif numel(num_arg) == 1
-        npix_lo = num_arg{1};
-        npix_hi = obj.npixels;
-    end
-    sqw_struc.data = obj.get_data(data_opt{:},npix_lo,npix_hi);
-else
-    sqw_struc.data = obj.get_data(data_opt{:});
-end
-
+sqw_struc.data = obj.get_data(data_opt{:});
 
 sqw_struc.header = headers;
 if legacy

--- a/horace_core/sqw/file_io/@sqw_binfile_common/put_pix.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/put_pix.m
@@ -22,6 +22,9 @@ if ~ok
         'SQW_BINFILE_COMMON::put_pix: %s',mess);
 end
 
+if ~obj.is_activated('write')
+    obj = obj.activate('rb+');
+end
 
 obj.check_obj_initated_properly();
 

--- a/horace_core/sqw/file_io/@sqw_binfile_common/put_pix.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/put_pix.m
@@ -23,7 +23,7 @@ if ~ok
 end
 
 if ~obj.is_activated('write')
-    obj = obj.activate('rb+');
+    obj = obj.activate('write');
 end
 
 obj.check_obj_initated_properly();

--- a/horace_core/sqw/file_io/@sqw_binfile_common/put_pix.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/put_pix.m
@@ -168,6 +168,10 @@ else % write pixels directly
     if npix_to_write <=block_size
         if write_all
             fwrite(obj.file_id_,input_obj.pix.data,'float32');
+            while input_obj.pix.has_more()
+                input_obj.pix.advance();
+                fwrite(obj.file_id_,input_obj.pix.data,'float32');
+            end
         else
             fwrite(obj.file_id_,input_obj.pix.get_pixels(npix_lo:npix_hi).data,'float32');
         end

--- a/horace_core/utilities/@MagneticIons/correct_mag_ff.m
+++ b/horace_core/utilities/@MagneticIons/correct_mag_ff.m
@@ -32,5 +32,3 @@ function wout=correct_mag_ff(self,win)
 sqw_magFF = self.calc_mag_ff(win);
 %
 wout=mrdivide(win,sqw_magFF);
-
-

--- a/horace_core/utilities/@sqw/symmetrise_sqw.m
+++ b/horace_core/utilities/@sqw/symmetrise_sqw.m
@@ -27,7 +27,7 @@ function wout=symmetrise_sqw(win,v1,v2,v3)
 %==============================
 %Some checks on the inputs:
 win=sqw(win);
-wout=win;
+wout = copy(win);
 
 %New code (problem spotted by Matt Mena for case when using a single
 %contributing spe file):


### PR DESCRIPTION
This PR adds file-backed data access to the `PixelData` class. 

- `PixelData` can now take a file path or `faccess` object as a constructor argument. 
- A "page" of data that fills a given memory allocation is read into memory _when a getter is called_, no data is loaded on construction
- The getters now pull only from what is in the current "page" of data
- An `advance` method will read in the next "page" of data
- `PixelData` is now a handle class
    - this means `sqw` and `PixelData` objects must be explicitly copied (i.e. with the `copy()` function) if they are to be independent
- The new `PixelData.has_more()` method will return true if there is a subsequent page of data in the file that can be loaded

### Follow-up tasks
Issues should be raised for the following:
- Update algorithm usages of PixelData so that they iterate over PixelData with a `while pix.has_more()` loop
- Add methods `get_data_at_index(fields, indices)` and `get_pix_at_index(indices)` that will pull data from the file according to real pixel index, rather than pixel index in the current page #270

Fixes #246 