### PR TITLE
Add help to build scripts

### DIFF
--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -1,29 +1,73 @@
-param (
-  [switch][Alias("b")]$build,
-  [switch][Alias("t")]$test,
-  [switch][Alias("p")]$package,
-  [switch][Alias("v")]$print_versions,
+<#
+.SYNOPSIS
+  This script is used to build, test and package Horace on Windows.
 
+.DESCRIPTION
+  This script requires Matlab, Visual Studio, CMake>=3.7 and CTest be installed
+  on your system and available on the path.
+
+  This script also requires that Herbert be findable by CMake. CMake will search
+  in common places for Herbert e.g. in the same directory as Horace.
+
+  Use "Get-Help ./build.ps1 -Detailed" for parameter descriptions.
+
+.EXAMPLE
+  ./build.ps1 -build
+  # Builds Horace
+.EXAMPLE
+  ./build.ps1 -test
+  # Runs all Horace tests
+.EXAMPLE
+  ./build.ps1 -package
+  # Packages Horace
+.EXAMPLE
+  ./build.ps1 -build -package -vs_version 2017 -matlab_release "R2019a"
+  # Builds and packages Horace using Visual Studio 2017 and Matlab R2019a
+
+.LINK
+  https://github.com/pace-neutrons/Horace
+#>
+param (
+  # Run the Horace build commands.
+  [switch][Alias("b")]$build,
+  # Run all Horace tests.
+  [switch][Alias("t")]$test,
+  # Pacakge Horace into a .zip file.
+  [switch][Alias("p")]$package,
+  # Print the versions of libraries being used e.g. Matlab.
+  [switch][Alias("v")]$print_versions,
+  # Call Get-Help on this script and exit.
+  [switch][Alias("h")]$help,
+
+  # The version of Visual Studio to build with. Other Windows compilers are
+  # not supported by this script. {2015, 2017, 2019}
   [int][ValidateSet(2015, 2017, 2019)]
   [Alias("VS")]
   $vs_version = 2017,
 
+  # Whether to build the Horace C++ tests and enable testing via CTest.
+  # This must be "ON" in order to run tests with this script. {"ON", "OFF"}
   [string][ValidateSet("ON", "OFF")]
   [Alias("X")]
   $build_tests = "ON",
 
+  # The configuration to build with. {Release, Debug}
   [string][ValidateSet("Release", "Debug")]
   [Alias("C")]
   $build_config = 'Release',
 
+  # The directory to write build files into. If the directory does not exist it
+  # will be created.
   [string]
   [Alias("O")]
   $build_dir = "",
 
+  # Flags to pass to the CMake configure step.
   [string]
   [Alias("F")]
   $cmake_flags = "",
 
+  # The release of Matlab to build and run tests against e.g. R2018b.
   [string][ValidatePattern("R[0-9]{4}[ab]")]
   [Alias("M")]
   $matlab_release = ""
@@ -35,6 +79,11 @@ if ($args) {
     $error_msg += "`n    $arg"
   }
   throw "$error_msg"
+}
+
+if ($help -or $PSBoundParameters.Values.Count -eq 0) {
+  Get-Help "$PSCommandPath"
+  exit 0
 }
 
 <# Import:

--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -40,24 +40,24 @@ param (
   [switch][Alias("h")]$help,
 
   # The version of Visual Studio to build with. Other Windows compilers are
-  # not supported by this script. {2015, 2017, 2019}
+  # not supported by this script. {2015, 2017, 2019} [default: 2017]
   [int][ValidateSet(2015, 2017, 2019)]
   [Alias("VS")]
   $vs_version = 2017,
 
   # Whether to build the Horace C++ tests and enable testing via CTest.
-  # This must be "ON" in order to run tests with this script. {"ON", "OFF"}
+  # This must be "ON" in order to run tests with this script. {ON, OFF} [default: ON]
   [string][ValidateSet("ON", "OFF")]
   [Alias("X")]
   $build_tests = "ON",
 
-  # The configuration to build with. {Release, Debug}
+  # The configuration to build with. {Release, Debug} [default: Release]
   [string][ValidateSet("Release", "Debug")]
   [Alias("C")]
   $build_config = 'Release',
 
   # The directory to write build files into. If the directory does not exist it
-  # will be created.
+  # will be created. [default: build]
   [string]
   [Alias("O")]
   $build_dir = "",

--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -21,7 +21,7 @@
   ./build.ps1 -package
   # Packages Horace
 .EXAMPLE
-  ./build.ps1 -build -package -vs_version 2017 -matlab_release "R2019a"
+  ./build.ps1 -build -package -vs_version 2017 -matlab_release R2019a
   # Builds and packages Horace using Visual Studio 2017 and Matlab R2019a
 
 .LINK

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -88,6 +88,12 @@ function run_package() {
 function print_help() {
   readonly local help_msg="Script to build, run static analysis, test and package Horace.
 
+This script requires Matlab, GCC, CMake>=3.7 and CTest be installed on your
+system and available on the path.
+
+This script also requires that Herbert be findable by CMake. CMake will search
+in common places for Herbert e.g. in the same directory as Horace.
+
 https://github.com/pace-neutrons/Horace
 
 usage:

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -85,6 +85,46 @@ function run_package() {
   echo_and_run "cpack -G TGZ"
 }
 
+function print_help() {
+  readonly local help_msg="Script to build, run static analysis, test and package Horace.
+
+https://github.com/pace-neutrons/Horace
+
+usage:
+  ./build.sh flag1 [flag2 [flag3]...] [option1 argument1 [option2 argument2]...]
+flags:
+  -b, --build
+      Run the Horace build commands.
+  -t, --test
+      Run all Horace tests.
+  -a, --analyze
+      Run static analysis on Horace C++ code.
+  -p, --package
+      Pacakge Horace into a .tar.gz file.
+  -v, --print_versions
+      Print the versions of libraries being used e.g. Matlab.
+  -h, --help
+      Print help message and exit.
+options:
+  -X, --build_tests {\"ON\", \"OFF\"}
+      Whether to build the Horace C++ tests and enable testing via CTest.
+      This must be \"ON\" in order to run tests with this script. [default: ON]
+  -C, --build_config {\"Release\", \"Debug\"}
+      The build configuration passed to CMake [default: Release]
+  -O, --build_dir
+      The directory to write build files into. If the directory does not exist
+      it will be created. [default: build]
+  -F, --cmake_flags
+      Flags to pass to the CMake configure step.
+  -M, --matlab_release
+      The release of Matlab to build and run tests against e.g. R2018b. This
+      Matlab release should also be on your path.
+example:
+  ./build.sh --build --test --build_config Debug
+"
+  echo -e "${help_msg}"
+}
+
 function main() {
   # set default parameter values
   local build=$FALSE
@@ -108,6 +148,7 @@ function main() {
         -a|--analyze) analyze=$TRUE; shift ;;
         -p|--package) package=$TRUE; shift ;;
         -v|--print_versions) print_versions=$TRUE; shift ;;
+        -h|--help) print_help; exit 0 ;;
         # options
         -X|--build_tests) build_tests="$2"; shift; shift ;;
         -C|--build_config) build_config="$2"; shift; shift ;;


### PR DESCRIPTION
This adds `-h|-help` and `-h|--help` flags to the `build.ps1` and `build.sh` scripts respectively.

refs: https://github.com/pace-neutrons/Herbert/pull/180

Fixes #257 