### PR TITLE
Always return PixelData.num_pixels as double

### DIFF
--- a/_test/test_sqw/FakeFAccess.m
+++ b/_test/test_sqw/FakeFAccess.m
@@ -48,6 +48,10 @@ methods
         is = ~obj.closed;
     end
 
+    function obj = set_npixels(obj, npix)
+        obj.npixels_ = npix;
+    end
+
 end
 
 end

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -545,6 +545,16 @@ methods
         assertTrue(new_pix.has_more());
     end
 
+    function test_num_pixels_is_a_double_if_faccess_returns_uint(obj)
+        npix = 30;
+        data = rand(9, npix);
+        faccess = FakeFAccess(data);
+        faccess = faccess.set_npixels(uint64(npix));
+
+        pix = PixelData(faccess);
+        assertEqual(class(pix.num_pixels), 'double');
+    end
+
     % -- Helpers --
     function do_pixel_data_loop_with_f(obj, func, data)
         % func should be a function handle, it is evaluated within a

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -555,6 +555,14 @@ methods
         assertEqual(class(pix.num_pixels), 'double');
     end
 
+    function test_num_pixels_is_a_double_if_data_in_memory(obj)
+        assertEqual(class(obj.pixel_data_obj.num_pixels), 'double');
+    end
+
+    function test_num_pixels_is_a_double_if_more_than_one_page_of_data(obj)
+        assertEqual(class(obj.pix_data_small_page.num_pixels), 'double');
+    end
+
     % -- Helpers --
     function do_pixel_data_loop_with_f(obj, func, data)
         % func should be a function handle, it is evaluated within a

--- a/horace_core/sqw/@PixelData/PixelData.m
+++ b/horace_core/sqw/@PixelData/PixelData.m
@@ -517,7 +517,7 @@ methods
         if isempty(obj.f_accessor_)
             num_pix = size(obj.data, 2);
         else
-            num_pix = obj.f_accessor_.npixels;
+            num_pix = double(obj.f_accessor_.npixels);
         end
     end
 


### PR DESCRIPTION
This PR ensures that `PixelData.num_pixels` always returns a double. See the corresponding issue (#272) for bug description and reasoning behind the decision.

Fixes #272 