### PR TITLE
Handle copying PixelData instances with tmp files

### DIFF
--- a/_test/test_sqw/FakeFAccess.m
+++ b/_test/test_sqw/FakeFAccess.m
@@ -52,6 +52,11 @@ methods
         obj.npixels_ = npix;
     end
 
+    function obj = set_filepath(obj, file_path)
+        [obj.filepath_, file_name, ext] = fileparts(file_path);
+        obj.filename_ = [file_name, ext];
+    end
+
 end
 
 end

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -675,6 +675,8 @@ methods
     % -- Helpers --
     function pix = get_pix_with_fake_faccess(obj, data, npix_in_page)
         faccess = FakeFAccess(data);
+        % give it a real file path to trick code into thinking it exists
+        faccess = faccess.set_filepath(obj.test_sqw_file_full_path);
         mem_alloc = npix_in_page*obj.NUM_BYTES_IN_VALUE*obj.NUM_COLS_IN_PIX_BLOCK;
         pix = PixelData(faccess, mem_alloc);
     end

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -691,6 +691,20 @@ methods
         assertEqual(pix_copy.data, pix_original.data);
     end
 
+    function test_copy_on_same_pg_as_original_when_more_than_1_pg_no_advance(obj)
+        pix_original = PixelData(obj.test_sqw_file_path, 1e6);
+        pix_original.signal = 1;
+
+        pix_copy = copy(pix_original);
+
+        assertEqual(pix_copy.data, pix_original.data);
+        while pix_original.has_more()
+            pix_original.advance();
+            pix_copy.advance();
+            assertEqual(pix_copy.data, pix_original.data);
+        end
+    end
+
     function test_changes_to_original_persistent_in_copy_if_1_page_in_file(obj)
         pix_original = PixelData(obj.test_sqw_file_path, 1e9);
         pix_original.signal = 1;
@@ -712,6 +726,22 @@ methods
         assertEqual(pix_copy.data, pix_original.data);
     end
 
+    function test_changes_to_orig_persistent_in_copy_if_1_pg_in_file_no_adv(obj)
+        pix_original = PixelData(obj.test_sqw_file_path, 1e9);
+        pix_original.signal = 1;
+
+        pix_copy = copy(pix_original);
+
+        assertEqual(pix_copy.data, pix_original.data);
+        while pix_original.has_more()
+            % we shouldn't enter here, but we should check the same API for
+            % data with > 1 page works for single page
+            pix_original.advance();
+            pix_copy.advance();
+            assertEqual(pix_copy.data, pix_original.data);
+        end
+    end
+
     function test_changes_to_copy_have_no_affect_on_original_after_advance(obj)
         data = zeros(9, 30);
         npix_in_page = 11;
@@ -729,7 +759,20 @@ methods
 
         pix_copy.move_to_first_page();
         assertEqual(pix_copy.signal, 2*ones(1, numel(pix_copy.signal)));
+    end
 
+    function test_changes_to_copy_have_no_affect_on_original_no_advance(obj)
+        data = zeros(9, 30);
+        npix_in_page = 11;
+        pix_original = obj.get_pix_with_fake_faccess(data, npix_in_page);
+        pix_original.signal = 1;
+
+        pix_copy = copy(pix_original);
+        pix_copy.move_to_first_page();
+        pix_copy.signal = 2;
+
+        assertEqual(pix_original.signal, ones(1, numel(pix_original.signal)));
+        assertEqual(pix_copy.signal, 2*ones(1, numel(pix_copy.signal)));
     end
 
     function test_changes_to_original_before_copy_are_reflected_in_copies(obj)
@@ -742,6 +785,17 @@ methods
         pix_copy = copy(pix_original);
         pix_copy.move_to_first_page();
 
+        assertEqual(pix_copy.signal, ones(1, numel(pix_copy.signal)));
+    end
+
+    function test_changes_to_original_kept_in_copy_after_advance(obj)
+        pix_original = PixelData(obj.test_sqw_file_path, 1e2);
+        pix_original.signal = 1;
+
+        pix_copy = copy(pix_original);
+        pix_copy.advance();
+
+        pix_copy.move_to_first_page();
         assertEqual(pix_copy.signal, ones(1, numel(pix_copy.signal)));
     end
 

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -672,6 +672,77 @@ methods
         assertEqual(class(obj.pix_data_small_page.num_pixels), 'double');
     end
 
+    function test_copy_creates_new_version_on_same_page_as_previous(obj)
+        data = rand(9, 30);
+        npix_in_page = 11;
+        pix_original = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        pix_original.signal = 1;
+        pix_original.advance();
+
+        pix_copy = copy(pix_original);
+
+        assertEqual(pix_copy.data, pix_original.data);
+        while pix_original.has_more()
+            pix_original.advance();
+            pix_copy.advance();
+            assertEqual(pix_copy.data, pix_original.data);
+        end
+
+        pix_copy.move_to_first_page();
+        pix_original.move_to_first_page();
+        assertEqual(pix_copy.data, pix_original.data);
+    end
+
+    function test_changes_to_copy_have_no_affect_on_original_after_advance(obj)
+        data = zeros(9, 30);
+        npix_in_page = 11;
+        pix_original = obj.get_pix_with_fake_faccess(data, npix_in_page);
+        pix_original.signal = 1;
+        pix_original.advance();
+
+        pix_copy = copy(pix_original);
+        pix_copy.move_to_first_page();
+        pix_copy.signal = 2;
+        pix_copy.advance();
+
+        pix_original.move_to_first_page();
+        assertEqual(pix_original.signal, ones(1, numel(pix_original.signal)));
+
+        pix_copy.move_to_first_page();
+        assertEqual(pix_copy.signal, 2*ones(1, numel(pix_copy.signal)));
+
+    end
+
+    function test_changes_to_original_before_copy_are_reflected_in_copies(obj)
+        data = zeros(9, 30);
+        npix_in_page = 11;
+        pix_original = obj.get_pix_with_fake_faccess(data, npix_in_page);
+        pix_original.signal = 1;
+        pix_original.advance();
+
+        pix_copy = copy(pix_original);
+        pix_copy.move_to_first_page();
+
+        assertEqual(pix_copy.signal, ones(1, numel(pix_copy.signal)));
+    end
+
+    function test_change_to_orig_post_copy_does_not_affect_copy_post_advance(obj)
+        data = zeros(9, 30);
+        npix_in_page = 11;
+        pix_original = obj.get_pix_with_fake_faccess(data, npix_in_page);
+        pix_copy = copy(pix_original);
+
+        pix_copy.signal = 1;
+        pix_copy.advance();
+
+        pix_original.signal = 2;
+        pix_original.advance();
+
+        pix_copy.move_to_first_page();
+        assertEqual(pix_copy.signal, ones(1, numel(pix_copy.signal)));
+    end
+
     % -- Helpers --
     function pix = get_pix_with_fake_faccess(obj, data, npix_in_page)
         faccess = FakeFAccess(data);

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -815,6 +815,32 @@ methods
         assertEqual(pix_copy.signal, ones(1, numel(pix_copy.signal)));
     end
 
+    function test_page_written_correctly_when_page_size_gt_mem_chunk_size(obj)
+        warning('off', 'HOR_CONFIG:set_mem_chunk_size');
+        hc = hor_config;
+        old_config = hc.get_data_to_store();
+        npix_to_write = 28;
+        size_of_float = 4;
+        hc.mem_chunk_size = npix_to_write*size_of_float;
+
+        function clean_up_func(conf_to_restore)
+            set(hor_config, conf_to_restore);
+            warning('on', 'HOR_CONFIG:set_mem_chunk_size');
+        end
+
+        clean_up = onCleanup(@() clean_up_func(old_config));
+
+        npix_in_page = 90;
+        data = zeros(obj.NUM_COLS_IN_PIX_BLOCK, npix_in_page + 10);
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        pix.data = ones(obj.NUM_COLS_IN_PIX_BLOCK, npix_in_page);
+        pix.advance();
+        pix.move_to_first_page();
+
+        assertEqual(pix.data, ones(obj.NUM_COLS_IN_PIX_BLOCK, npix_in_page));
+    end
+
     % -- Helpers --
     function pix = get_pix_with_fake_faccess(obj, data, npix_in_page)
         faccess = FakeFAccess(data);

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -672,11 +672,8 @@ methods
         assertEqual(class(obj.pix_data_small_page.num_pixels), 'double');
     end
 
-    function test_copy_creates_new_version_on_same_page_as_previous(obj)
-        data = rand(9, 30);
-        npix_in_page = 11;
-        pix_original = obj.get_pix_with_fake_faccess(data, npix_in_page);
-
+    function test_copy_on_same_page_as_original_when_more_than_1_page(obj)
+        pix_original = PixelData(obj.test_sqw_file_path, 1e6);
         pix_original.signal = 1;
         pix_original.advance();
 
@@ -684,6 +681,27 @@ methods
 
         assertEqual(pix_copy.data, pix_original.data);
         while pix_original.has_more()
+            pix_original.advance();
+            pix_copy.advance();
+            assertEqual(pix_copy.data, pix_original.data);
+        end
+
+        pix_copy.move_to_first_page();
+        pix_original.move_to_first_page();
+        assertEqual(pix_copy.data, pix_original.data);
+    end
+
+    function test_changes_to_original_persistent_in_copy_if_1_page_in_file(obj)
+        pix_original = PixelData(obj.test_sqw_file_path, 1e9);
+        pix_original.signal = 1;
+        pix_original.advance();
+
+        pix_copy = copy(pix_original);
+
+        assertEqual(pix_copy.data, pix_original.data);
+        while pix_original.has_more()
+            % we shouldn't enter here, but we should check the same API for
+            % data with > 1 page works for single page
             pix_original.advance();
             pix_copy.advance();
             assertEqual(pix_copy.data, pix_original.data);
@@ -727,7 +745,7 @@ methods
         assertEqual(pix_copy.signal, ones(1, numel(pix_copy.signal)));
     end
 
-    function test_change_to_orig_post_copy_does_not_affect_copy_post_advance(obj)
+    function test_change_to_original_after_copy_does_not_affect_copy(obj)
         data = zeros(9, 30);
         npix_in_page = 11;
         pix_original = obj.get_pix_with_fake_faccess(data, npix_in_page);

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -236,7 +236,7 @@ methods
         end
         % In memory construction
         if isa(arg, 'PixelData')  % TODO make sure this works with file-backed
-            if ~isempty(arg.file_path) && exist(arg.file_path, 'file')
+            if arg.is_file_backed_() && exist(arg.file_path, 'file')
                 % if the file exists we can create a file-backed instance
                 obj = PixelData(arg.file_path, arg.page_memory_size_);
                 obj.page_number_ = arg.page_number_;
@@ -343,7 +343,7 @@ methods
         if ~isa(fields, 'cell')
             fields = {fields};
         end
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         try
             field_indices = cell2mat(obj.FIELD_INDEX_MAP_.values(fields));
         catch ME
@@ -376,7 +376,7 @@ methods
         % -------
         %   pixels      PixelData object containing a subset of pixels
         %
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         pixels = PixelData(obj.data(:, pix_indices));
     end
 
@@ -443,7 +443,7 @@ methods
 
     % --- Getters / Setters ---
     function pixel_data = get.data(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         pixel_data = obj.data_;
     end
 
@@ -483,122 +483,122 @@ methods
     end
 
     function u1 = get.u1(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         u1 = obj.data(obj.FIELD_INDEX_MAP_('u1'), :);
     end
 
     function obj = set.u1(obj, u1)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         obj.data(obj.FIELD_INDEX_MAP_('u1'), :) = u1;
         obj.set_page_dirty_(true);
     end
 
     function u2 = get.u2(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         u2 = obj.data(obj.FIELD_INDEX_MAP_('u2'), :);
     end
 
     function obj = set.u2(obj, u2)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         obj.data(obj.FIELD_INDEX_MAP_('u2'), :) = u2;
         obj.set_page_dirty_(true);
     end
 
     function u3 = get.u3(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         u3 = obj.data(obj.FIELD_INDEX_MAP_('u3'), :);
     end
 
     function obj = set.u3(obj, u3)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         obj.data(obj.FIELD_INDEX_MAP_('u3'), :) = u3;
         obj.set_page_dirty_(true);
     end
 
     function dE = get.dE(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         dE = obj.data(obj.FIELD_INDEX_MAP_('dE'), :);
     end
 
     function obj = set.dE(obj, dE)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         obj.data(obj.FIELD_INDEX_MAP_('dE'), :) = dE;
         obj.set_page_dirty_(true);
     end
 
     function coord_data = get.coordinates(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         coord_data = obj.data(obj.FIELD_INDEX_MAP_('coordinates'), :);
     end
 
     function obj = set.coordinates(obj, coordinates)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         obj.data(obj.FIELD_INDEX_MAP_('coordinates'), :) = coordinates;
         obj.set_page_dirty_(true);
     end
 
     function coord_data = get.q_coordinates(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         coord_data = obj.data(obj.FIELD_INDEX_MAP_('q_coordinates'), :);
     end
 
     function obj = set.q_coordinates(obj, q_coordinates)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         obj.data(obj.FIELD_INDEX_MAP_('q_coordinates'), :) = q_coordinates;
         obj.set_page_dirty_(true);
     end
 
     function run_index = get.run_idx(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         run_index = obj.data(obj.FIELD_INDEX_MAP_('run_idx'), :);
     end
 
     function obj = set.run_idx(obj, iruns)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         obj.data(obj.FIELD_INDEX_MAP_('run_idx'), :) = iruns;
         obj.set_page_dirty_(true);
     end
 
     function detector_index = get.detector_idx(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         detector_index = obj.data(obj.FIELD_INDEX_MAP_('detector_idx'), :);
     end
 
     function obj = set.detector_idx(obj, detector_indices)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         obj.data(obj.FIELD_INDEX_MAP_('detector_idx'), :) = detector_indices;
         obj.set_page_dirty_(true);
     end
 
     function detector_index = get.energy_idx(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         detector_index = obj.data(obj.FIELD_INDEX_MAP_('energy_idx'), :);
     end
 
     function obj = set.energy_idx(obj, energies)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         obj.data(obj.FIELD_INDEX_MAP_('energy_idx'), :) = energies;
         obj.set_page_dirty_(true);
     end
 
     function signal = get.signal(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         signal = obj.data(obj.FIELD_INDEX_MAP_('signal'), :);
     end
 
     function obj = set.signal(obj, signal)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         obj.data(obj.FIELD_INDEX_MAP_('signal'), :) = signal;
         obj.set_page_dirty_(true);
     end
 
     function variance = get.variance(obj)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         variance = obj.data(obj.FIELD_INDEX_MAP_('variance'), :);
     end
 
     function obj = set.variance(obj, variance)
-        obj = obj.load_first_page_if_data_empty_();
+        obj = obj.load_current_page_if_data_empty_();
         obj.data(obj.FIELD_INDEX_MAP_('variance'), :) = variance;
         obj.set_page_dirty_(true);
     end
@@ -637,11 +637,11 @@ methods (Access=private)
         obj.page_number_ = 1;
     end
 
-    function obj = load_first_page_if_data_empty_(obj)
+    function obj = load_current_page_if_data_empty_(obj)
         % Check if there's any data in the current page and load a page if not
         %   This function does nothing if pixels are not file-backed
         if isempty(obj.data_) && obj.is_file_backed_()
-            obj = obj.load_page_(1);
+            obj = obj.load_page_(obj.page_number_);
         end
     end
 

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -242,10 +242,8 @@ methods
                 obj.page_number_ = arg.page_number_;
                 obj.page_dirty_ = arg.page_dirty_;
                 arg.tmp_io_handler_.copy_tmp_folder(obj.object_id_);
-            else
-                % if no file exists, just copy the data
-                obj.data_ = arg.data;
             end
+            obj.data_ = arg.data;
             return;
         end
         if numel(arg) == 1 && isnumeric(arg) && floor(arg) == arg

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -76,7 +76,6 @@ classdef PixelData < handle
 %
 properties (Access=private)
     DIRTY_PIX_DIR_NAME_ = 'sqw_pix%05d';
-    PIXEL_BLOCK_COLS_ = 9;
     FIELD_INDEX_MAP_ = containers.Map(...
         {'u1', 'u2', 'u3', 'dE', ...
          'coordinates', ...
@@ -86,16 +85,17 @@ properties (Access=private)
          'energy_idx', ...
          'signal', ...
          'variance'}, ...
-        {1, 2, 3, 4, 1:4, 1:3, 5, 6, 7, 8, 9})
+        {1, 2, 3, 4, 1:4, 1:3, 5, 6, 7, 8, 9});
+    PIXEL_BLOCK_COLS_ = 9;
 
-    raw_data_ = zeros(9, 0);  % the underlying data cached in the object
     f_accessor_;  % instance of faccess object to access pixel data from file
     file_path_ = '';  % the path to the file backing this object - empty string if all data in memory
-    page_memory_size_ = 3e9;  % 3Gb - the maximum amount of memory a page can use
     max_page_size_;  % the maximum number of pixels that can fie in the page memory size
-    page_dirty_ = false;  % array mapping from page_number to whether that page is dirty
     object_id_;  % random unique identifier for this object, used for tmp file names
+    page_dirty_ = false;  % array mapping from page_number to whether that page is dirty
+    page_memory_size_ = 3e9;  % 3Gb - the maximum amount of memory a page can use
     page_number_ = 1;  % the index of the currently loaded page
+    raw_data_ = zeros(9, 0);  % the underlying data cached in the object
     tmp_io_handler_;  % a PixelTmpFileHandler object that handles reading/writing of tmp files
 end
 

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -241,7 +241,7 @@ methods
                 obj = PixelData(arg.file_path, arg.page_memory_size_);
                 obj.page_number_ = arg.page_number_;
                 obj.page_dirty_ = arg.page_dirty_;
-                arg.tmp_io_handler_.copy_tmp_folder(obj.object_id_);
+                arg.tmp_io_handler_.copy_folder(obj.object_id_);
             end
             obj.data_ = arg.data;
             return;

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -314,6 +314,11 @@ methods
     end
 
     function pix_copy = copy(obj)
+        % Make an independent copy of this object
+        %  This method simply constructs a new PixelData instance by calling
+        %  the constructor with the input object as an argument. Because of
+        %  this, any properties that need to be explicitly copied must be
+        %  copied within this classes "copy-constructor".
         pix_copy = PixelData(obj);
     end
 

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -309,7 +309,7 @@ methods
     function nel = numel(obj)
         % Return the number of data points in the pixel data block
         %   If the data is file backed, this returns the number of values in
-        %   the file
+        %   the file.
         nel = obj.PIXEL_BLOCK_COLS_*obj.num_pixels;
     end
 
@@ -433,7 +433,7 @@ methods
     function obj = move_to_first_page(obj)
         % Reset the object to point to the first page of pixel data in the file
         % and clear the current cache
-        %  This function does nothing if pixels are not file-backed
+        %  This function does nothing if pixels are not file-backed.
         %
         if obj.is_file_backed_()
             if obj.page_is_dirty_(obj.page_number_)
@@ -471,7 +471,7 @@ methods
         %  This is the only method that should ever touch obj.raw_data_
 
         % The need for multiple layers of getters/setters for the raw data
-        % should be removed when the public facing getters/setters are removed
+        % should be removed when the public facing getters/setters are removed.
         if size(pixel_data, 1) ~= obj.PIXEL_BLOCK_COLS_
             msg = ['Cannot set pixel data, invalid dimensions. Axis 1 must '...
                    'have length %i, found ''%i''.'];
@@ -642,7 +642,7 @@ methods (Access=private)
 
     function obj = load_current_page_if_data_empty_(obj)
         % Check if there's any data in the current page and load a page if not
-        %   This function does nothing if pixels are not file-backed
+        %   This function does nothing if pixels are not file-backed.
         if isempty(obj.data_) && obj.is_file_backed_()
             obj = obj.load_page_(obj.page_number_);
         end

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -452,10 +452,17 @@ methods
 
     function obj = set.data(obj, pixel_data)
         % This setter provides rules for public facing edits to the cached data
-        if size(pixel_data, 2) ~= obj.page_size
+        if obj.page_size == 0
+            % no pixels loaded, get our expected page size
+            required_page_size = min(obj.max_page_size_, obj.num_pixels);
+        else
+            required_page_size = obj.page_size;
+        end
+
+        if size(pixel_data, 2) ~= required_page_size
             msg = ['Cannot set pixel data, invalid dimensions. Axis 2 ' ...
                    'must have dimensions matching current page size (%i), ' ...
-                   'found ''%i''.', obj.page_size, size(pixel_data, 2)];
+                   'found ''%i''.', required_page_size, size(pixel_data, 2)];
             error('PIXELDATA:data', msg, class(pixel_data));
         end
         obj.data_ = pixel_data;

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -1,4 +1,4 @@
-classdef PixelData < matlab.mixin.Copyable
+classdef PixelData < handle
 % PixelData Provides an interface for access to pixel data
 %
 %   This class provides getters and setters for each data column in an SQW
@@ -240,6 +240,8 @@ methods
                 % if the file exists we can create a file-backed instance
                 obj = PixelData(arg.file_path, arg.page_memory_size_);
                 obj.page_number_ = arg.page_number_;
+                obj.page_dirty_ = arg.page_dirty_;
+                arg.tmp_io_handler_.copy_tmp_folder(obj.object_id_);
             else
                 % if no file exists, just copy the data
                 obj.data_ = arg.data;
@@ -311,6 +313,10 @@ methods
         %   If the data is file backed, this returns the number of values in
         %   the file
         nel = obj.PIXEL_BLOCK_COLS_*obj.num_pixels;
+    end
+
+    function pix_copy = copy(obj)
+        pix_copy = PixelData(obj);
     end
 
     function data = get_data(obj, fields, pix_indices)

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -276,7 +276,7 @@ methods
     function delete(obj)
         % Class destructor to delete any temporary files
         if ~isempty(obj.tmp_io_handler_)
-            obj.tmp_io_handler_.delete_tmp_files();
+            obj.tmp_io_handler_.delete_files();
         end
     end
 

--- a/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
+++ b/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
@@ -22,8 +22,7 @@ methods
         %          This sets the tmp directory name
         %
         obj.pix_id_ = pix_id;
-        tmp_dir_name = sprintf(obj.TMP_DIR_BASE_NAME_, obj.pix_id_);
-        obj.tmp_dir_path_ = fullfile(tempdir(), tmp_dir_name);
+        obj.tmp_dir_path_ = obj.generate_tmp_dir_path_(obj.pix_id_);
     end
 
     function raw_pix = load_page(obj, page_number, ncols)
@@ -75,6 +74,26 @@ methods
         obj.write_float_data_(file_id, raw_pix);
     end
 
+    function copy_tmp_folder(obj, new_pix_id)
+        % Copy the temporary files managed by this class instance to a new folder
+        %
+        % Input
+        % -----
+        % new_pix_id   The ID of the PixelData instance the new tmp folder will
+        %              be linked to
+        %
+        if ~exist(obj.tmp_dir_path_, 'dir')
+            return;
+        end
+
+        new_dir_path = obj.generate_tmp_dir_path_(new_pix_id);
+        [status, err_msg] = copyfile(obj.tmp_dir_path_, new_dir_path);
+        if status == 0
+            error('Could not copy tmp files from ''%s'' to ''%s'':\n%s', ...
+                    obj.tmp_dir_path_, new_dir_path, err_msg);
+        end
+    end
+
     function delete_tmp_files(obj)
         % Delete the directory containing the tmp files
         if exist(obj.tmp_dir_path_, 'dir')
@@ -111,6 +130,11 @@ methods (Access=private)
         % Generate the file path to the tmp directory for this object instance
         file_name = sprintf(obj.TMP_FILE_BASE_NAME_, page_number);
         tmp_file_path = fullfile(obj.tmp_dir_path_, file_name);
+    end
+
+    function tmp_dir_path = generate_tmp_dir_path_(obj, pix_id)
+        tmp_dir_name = sprintf(obj.TMP_DIR_BASE_NAME_, pix_id);
+        tmp_dir_path = fullfile(tempdir(), tmp_dir_name);
     end
 
 end

--- a/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
+++ b/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
@@ -94,7 +94,7 @@ methods
         end
     end
 
-    function delete_tmp_files(obj)
+    function delete_files(obj)
         % Delete the directory containing the tmp files
         if exist(obj.tmp_dir_path_, 'dir')
             rmdir(obj.tmp_dir_path_, 's');

--- a/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
+++ b/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
@@ -127,12 +127,13 @@ methods (Access=private)
     end
 
     function tmp_file_path = generate_tmp_pix_file_path_(obj, page_number)
-        % Generate the file path to the tmp directory for this object instance
+        % Generate the file path to a tmp file with the given page number
         file_name = sprintf(obj.TMP_FILE_BASE_NAME_, page_number);
         tmp_file_path = fullfile(obj.tmp_dir_path_, file_name);
     end
 
     function tmp_dir_path = generate_tmp_dir_path_(obj, pix_id)
+        % Generate the file path to the tmp directory for this object instance
         tmp_dir_name = sprintf(obj.TMP_DIR_BASE_NAME_, pix_id);
         tmp_dir_path = fullfile(tempdir(), tmp_dir_name);
     end

--- a/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
+++ b/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
@@ -109,27 +109,24 @@ methods (Access=private)
         % Write the given data to the file corresponding to the given file ID
         % in float32
         SIZE_OF_FLOAT = 4;
-        chunk_idx_length = hor_config().mem_chunk_size/SIZE_OF_FLOAT;
-        data_size = SIZE_OF_FLOAT*numel(pix_data);  % in bytes
-        num_chunks = ceil(data_size/hor_config().mem_chunk_size);
+        chunk_size = hor_config().mem_chunk_size/SIZE_OF_FLOAT;
 
-        for i = 1:num_chunks
-            start_idx = (i - 1)*chunk_idx_length + 1;
-            end_idx = min(i*chunk_idx_length, numel(pix_data));
-            try
+        try
+            for start_idx = 1:chunk_size:numel(pix_data)
+                end_idx = min(start_idx + chunk_size - 1, numel(pix_data));
                 fwrite(file_id, pix_data(start_idx:end_idx), obj.FILE_DATA_FORMAT_);
-            catch ME
-                switch ME.identifier
-                case 'MATLAB:badfid_mx'
-                    error('PIXELTMPFIELHANDLER:write_float_data_', ...
-                    'Could not write to file with ID ''%d'':\n The file is not open', ...
-                    file_id);
-                otherwise
-                    tmp_file_path = fopen(file_id);
-                    error('PIXELTMPFIELHANDLER:write_float_data_', ...
-                        'Could not write to file ''%s'':\n%s', ...
-                        tmp_file_path, ferror(file_id));
-                end
+            end
+        catch ME
+            switch ME.identifier
+            case 'MATLAB:badfid_mx'
+                error('PIXELTMPFIELHANDLER:write_float_data_', ...
+                      'Could not write to file with ID ''%d'':\n The file is not open', ...
+                      file_id);
+            otherwise
+                tmp_file_path = fopen(file_id);
+                error('PIXELTMPFIELHANDLER:write_float_data_', ...
+                      'Could not write to file ''%s'':\n%s', ...
+                      tmp_file_path, ferror(file_id));
             end
         end
     end

--- a/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
+++ b/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
@@ -74,19 +74,19 @@ methods
         obj.write_float_data_(file_id, raw_pix);
     end
 
-    function copy_folder(obj, new_pix_id)
+    function copy_folder(obj, target_pix_id)
         % Copy the temporary files managed by this class instance to a new folder
         %
         % Input
         % -----
-        % new_pix_id   The ID of the PixelData instance the new tmp folder will
-        %              be linked to
+        % target_pix_id   The ID of the PixelData instance the new tmp folder
+        %                 will be linked to
         %
         if ~exist(obj.tmp_dir_path_, 'dir')
             return;
         end
 
-        new_dir_path = obj.generate_tmp_dir_path_(new_pix_id);
+        new_dir_path = obj.generate_tmp_dir_path_(target_pix_id);
         [status, err_msg] = copyfile(obj.tmp_dir_path_, new_dir_path);
         if status == 0
             error('Could not copy tmp files from ''%s'' to ''%s'':\n%s', ...

--- a/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
+++ b/horace_core/sqw/PixelData/@PixelTmpFileHandler/PixelTmpFileHandler.m
@@ -74,7 +74,7 @@ methods
         obj.write_float_data_(file_id, raw_pix);
     end
 
-    function copy_tmp_folder(obj, new_pix_id)
+    function copy_folder(obj, new_pix_id)
         % Copy the temporary files managed by this class instance to a new folder
         %
         % Input


### PR DESCRIPTION
This PR implements a non-default `copy` method on `PixelData` that copies temporary files used to save edits to pages of data. This ensures `PixelData` copies are entirely independent of one another.

This PR does _not_ implement a similar thing for copies of `.sqw` files. Creating a copy of an `sqw` object will copy the `PixelData` instance as described above, however the two `PixelData` instances will both still point at the same `.sqw` file; changes to the `.sqw` file will affect both `PixelData` instances. This is a more complicated issue than the one this PR solves. 

Fixes #277 