### PR TITLE
Ensure tests seeded with mersenne twister

### DIFF
--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -567,7 +567,7 @@ methods
     function test_dirty_pix_tmp_files_are_deleted_when_pix_out_of_scope(obj)
         old_rng_state = rng();
         fixed_seed = 774015;
-        rng(fixed_seed);  % this seed gives an expected object_id_ = 54452
+        rng(fixed_seed, 'twister');  % this seed gives an expected object_id_ = 54452
         expected_tmp_dir = fullfile(tempdir(), 'sqw_pix54452');
         clean_up = onCleanup(@() rng(old_rng_state));
 

--- a/_test/test_tobyfit/seed_rng.m
+++ b/_test/test_tobyfit/seed_rng.m
@@ -7,5 +7,5 @@ old_state = rng();
 if nargin < 1
     seed = mod(posixtime(datetime('now'))*1e3, 1e6);
 end
-rng(seed);
+rng(seed, 'twister');
 state = rng();

--- a/_test/test_tobyfit/test_let/test_tobyfit_let_1.m
+++ b/_test/test_tobyfit/test_let/test_tobyfit_let_1.m
@@ -44,6 +44,11 @@ test_tobyfit_dir = fullfile(horace_root(), '_test', 'test_tobyfit');
 addpath(test_tobyfit_dir)
 cleanup = onCleanup(@() rmpath(test_tobyfit_dir));
 
+% This seed provides a passing test at time of writing
+fixed_seed = 0;
+[old_rng_state, rng_state] = seed_rng(fixed_seed);
+clean_up = onCleanup(@() rng(old_rng_state));
+fprintf('RNG seed: %i\n', rng_state.Seed);
 
 %% --------------------------------------------------------------------------------------
 % Read cuts
@@ -107,7 +112,7 @@ end
 % %% --------------------------------------------------------------------------------------
 % % Collect results together as a structure
 % % ---------------------------------------------------------------------------------------
-% 
+%
 % % Cuts
 % res.wdata_1 = wdata_1;
 % res.wfit_1 = wfit_1;


### PR DESCRIPTION
When setting the seed for a `test_PixelData` and `test_tobyfit_let`, make sure the RNG is set to use the `twister` algorithm. This ensures we get the values we expect.

Fixes #282 