### PR TITLE
Build mex libraries directly into DLL directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,10 @@ list(APPEND CMAKE_MODULE_PATH
 )
 
 # Set some useful global variables
-# this will hold herbert/horace_on.m and worker_v2.m
+# This will hold herbert/horace_on.m and worker_v2.m
 set(LOCAL_INIT_DIR "${CMAKE_BINARY_DIR}/local_init")
+# This sets the destination for mex build artifacts (used in PACE_AddMex)
+set(Horace_DLL_DIRECTORY "${CMAKE_SOURCE_DIR}/horace_core/DLL")
 
 # Set our options
 option(BUILD_TESTS "Build the C++ tests" ON)
@@ -41,10 +43,6 @@ if(${BUILD_TESTS})
     include(PACE_FindGTest)
     enable_testing()
 endif()
-
-# Set the destination of our build artifacts
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 add_subdirectory("_LowLevelCode")
 if(${BUILD_TESTS})

--- a/_LowLevelCode/cpp/accumulate_cut_c/CMakeLists.txt
+++ b/_LowLevelCode/cpp/accumulate_cut_c/CMakeLists.txt
@@ -13,5 +13,4 @@ set(MEX_NAME "accumulate_cut_c")
 pace_add_mex(
     NAME "${MEX_NAME}"
     SRC "${SRC_FILES}" "${HDR_FILES}"
-    COPY_TO "${CMAKE_SOURCE_DIR}/horace_core/DLL"
 )

--- a/_LowLevelCode/cpp/bin_pixels_c/CMakeLists.txt
+++ b/_LowLevelCode/cpp/bin_pixels_c/CMakeLists.txt
@@ -12,5 +12,4 @@ set(MEX_NAME "bin_pixels_c")
 pace_add_mex(
     NAME "${MEX_NAME}"
     SRC "${SRC_FILES}" "${HDR_FILES}"
-    COPY_TO "${CMAKE_SOURCE_DIR}/horace_core/DLL"
 )

--- a/_LowLevelCode/cpp/calc_projections_c/CMakeLists.txt
+++ b/_LowLevelCode/cpp/calc_projections_c/CMakeLists.txt
@@ -13,7 +13,6 @@ set(MEX_NAME "calc_projections_c")
 pace_add_mex(
     NAME "${MEX_NAME}"
     SRC "${SRC_FILES}" "${HDR_FILES}"
-    COPY_TO "${CMAKE_SOURCE_DIR}/horace_core/DLL"
 )
 if(OpenMP_CXX_FOUND)
     target_link_libraries("${MEX_NAME}" OpenMP::OpenMP_CXX)

--- a/_LowLevelCode/cpp/combine_sqw/CMakeLists.txt
+++ b/_LowLevelCode/cpp/combine_sqw/CMakeLists.txt
@@ -25,6 +25,5 @@ set(MEX_NAME "combine_sqw")
 pace_add_mex(
     NAME "${MEX_NAME}"
     SRC "${SRC_FILES}" "${HDR_FILES}"
-    COPY_TO "${CMAKE_SOURCE_DIR}/horace_core/DLL"
 )
 target_link_libraries("${MEX_NAME}" "${Matlab_UT_LIBRARY}")

--- a/_LowLevelCode/cpp/hdf_mex_reader/CMakeLists.txt
+++ b/_LowLevelCode/cpp/hdf_mex_reader/CMakeLists.txt
@@ -19,7 +19,6 @@ set(MEX_NAME "hdf_mex_reader")
 pace_add_mex(
     NAME "${MEX_NAME}"
     SRC "${SRC_FILES}" "${HDR_FILES}"
-    COPY_TO "${CMAKE_SOURCE_DIR}/horace_core/DLL"
 )
 target_include_directories("${MEX_NAME}" PUBLIC "${HDF5_INCLUDE_DIRS}")
 target_link_libraries("${MEX_NAME}" "${HDF5_LIBRARIES}")

--- a/_LowLevelCode/cpp/mtimesx_horace/CMakeLists.txt
+++ b/_LowLevelCode/cpp/mtimesx_horace/CMakeLists.txt
@@ -13,7 +13,6 @@ set(MEX_NAME "mtimesx_mex")
 pace_add_mex(
     NAME "${MEX_NAME}"
     SRC "${SRC_FILES}" "${HDR_FILES}"
-    COPY_TO "${CMAKE_SOURCE_DIR}/horace_core/DLL"
 )
 if(OpenMP_CXX_FOUND)
     target_link_libraries("${MEX_NAME}" OpenMP::OpenMP_CXX)

--- a/_LowLevelCode/cpp/recompute_bin_data/CMakeLists.txt
+++ b/_LowLevelCode/cpp/recompute_bin_data/CMakeLists.txt
@@ -13,7 +13,6 @@ set(MEX_NAME "recompute_bin_data_c")
 pace_add_mex(
     NAME "${MEX_NAME}"
     SRC "${SRC_FILES}" "${HDR_FILES}"
-    COPY_TO "${CMAKE_SOURCE_DIR}/horace_core/DLL"
 )
 if(OpenMP_CXX_FOUND)
     target_link_libraries("${MEX_NAME}" OpenMP::OpenMP_CXX)

--- a/_LowLevelCode/cpp/sort_pixels_by_bins/CMakeLists.txt
+++ b/_LowLevelCode/cpp/sort_pixels_by_bins/CMakeLists.txt
@@ -13,5 +13,4 @@ set(MEX_NAME "sort_pixels_by_bins")
 pace_add_mex(
     NAME "${MEX_NAME}"
     SRC "${SRC_FILES}" "${HDR_FILES}"
-    COPY_TO "${CMAKE_SOURCE_DIR}/horace_core/DLL"
 )


### PR DESCRIPTION
Update to make things consistent with https://github.com/pace-neutrons/Herbert/pull/201.

This is a less disruptive change than in Herbert and should be merged first.

Fixes #294 