### PR TITLE
Add tests for SQW binary operations

### DIFF
--- a/_test/test_sqw/test_binary_ops.m
+++ b/_test/test_sqw/test_binary_ops.m
@@ -1,0 +1,123 @@
+classdef test_binary_ops < TestCase
+
+properties (Constant)
+    DOUBLE_REL_TOLERANCE = 5e-7;
+end
+
+properties
+    test_sqw_file_path = '../test_sqw_file/sqw_2d_1.sqw';
+    base_sqw_obj;
+    sqw_obj;
+    dnd_obj;
+end
+
+methods
+
+    function obj = test_binary_ops(varargin)
+        obj = obj@TestCase('test_binary_ops');
+
+        obj.base_sqw_obj = sqw(obj.test_sqw_file_path);
+        obj.dnd_obj = d2d(obj.base_sqw_obj);
+    end
+
+    function obj = setUp(obj)
+        obj.sqw_obj = copy(obj.base_sqw_obj);
+    end
+
+    function test_SQW_error_if_first_input_is_int64(obj)
+        f = @() int64(ones(size(obj.sqw_obj.data.npix))) + obj.sqw_obj;
+        assertExceptionThrown(f, 'SQW:binary_op_manager_single');
+    end
+
+    function test_SQW_error_if_first_input_is_char(obj)
+        f = @() 'some char' + obj.sqw_obj;
+        assertExceptionThrown(f, 'SQW:binary_op_manager_single');
+    end
+
+    function test_SQW_error_if_second_input_not_supported_type(obj)
+        f = @() obj.sqw_obj + int64(ones(size(obj.sqw_obj.data.npix)));
+        assertExceptionThrown(f, 'SQW:binary_op_manager_single');
+    end
+
+    function test_adding_sqw_and_dnd_objects_1st_operand_is_sqw_returns_sqw(obj)
+        out = obj.sqw_obj + obj.dnd_obj;
+
+        assertTrue(isa(out, 'sqw'));
+
+        expected_signal = obj.sqw_obj.data.s + obj.dnd_obj.s;
+        assertElementsAlmostEqual(out.data.s, expected_signal, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+    end
+
+    function test_adding_sqw_and_dnd_objects_2nd_operand_is_sqw_returns_sqw(obj)
+        out = obj.dnd_obj + obj.sqw_obj;
+
+        assertTrue(isa(out, 'sqw'));
+
+        expected_signal = obj.sqw_obj.data.s + obj.dnd_obj.s;
+        assertElementsAlmostEqual(out.data.s, expected_signal, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+    end
+
+    function test_subtracting_scalar_from_sqw_returns_sqw(obj)
+        scalar_operand = 1.3;
+        out = obj.sqw_obj - scalar_operand;
+
+        assertTrue(isa(out, 'sqw'));
+
+        expected_signal = obj.sqw_obj.data.s - scalar_operand;
+        expected_signal(obj.sqw_obj.data.npix == 0) = 0;
+        assertElementsAlmostEqual(out.data.s, expected_signal, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+    end
+
+    function test_subtracting_sqw_from_scalar_returns_sqw(obj)
+        scalar_operand = 0.3;
+        out = scalar_operand - obj.sqw_obj;
+
+        assertTrue(isa(out, 'sqw'));
+
+        expected_signal = scalar_operand - obj.sqw_obj.data.s;
+        expected_signal(obj.sqw_obj.data.npix == 0) = 0;
+        assertElementsAlmostEqual(out.data.s, expected_signal, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+    end
+
+    function test_subtracting_two_sqw_objects_returns_sqw(obj)
+        out = obj.sqw_obj - obj.sqw_obj;
+
+        assertTrue(isa(out, 'sqw'));
+        assertElementsAlmostEqual(out.data.s, zeros(size(out.data.s)));
+    end
+
+    function test_adding_sqw_and_sigvar_with_sqw_1st_operand_returns_sqw(obj)
+        signal = 1e5 * (1 + rand(size(obj.sqw_obj.data.s)));
+        variance = 1e5 * (1 + rand(size(obj.sqw_obj.data.s)));
+        out = obj.sqw_obj + sigvar(signal, variance);
+
+        assertTrue(isa(out, 'sqw'));
+
+        expected_signal = obj.sqw_obj.data.s + signal;
+        expected_signal(obj.sqw_obj.data.npix == 0) = 0;
+        assertElementsAlmostEqual(out.data.s, expected_signal, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+    end
+
+    function test_adding_sqw_and_sigvar_with_sqw_2nd_operand_returns_sigvar(obj)
+        signal = 1e5 * (1 + rand(size(obj.sqw_obj.data.s)));
+        variance = 1e5 * (1 + rand(size(obj.sqw_obj.data.s)));
+        out = sigvar(signal, variance) + obj.sqw_obj;
+
+        assertTrue(isa(out, 'sigvar'));
+
+        expected_sigvar = sigvar(obj.sqw_obj.data.s + signal, ...
+                                 obj.sqw_obj.data.e + variance);
+        assertElementsAlmostEqual(out.s, expected_sigvar.s, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+        assertElementsAlmostEqual(out.e, expected_sigvar.e, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+    end
+
+end
+
+end

--- a/_test/test_sqw/test_binary_ops.m
+++ b/_test/test_sqw/test_binary_ops.m
@@ -74,7 +74,7 @@ methods
                                   obj.DOUBLE_REL_TOLERANCE);
     end
 
-    function test_subtracting_sqw_from_dnd_returns_sqw_equal_image_data(obj)
+    function test_dnd_minus_equivalent_sqw_returns_sqw_with_zero_image_data(obj)
         out = obj.dnd_obj - obj.sqw_obj;
 
         assertTrue(isa(out, 'sqw'));
@@ -88,7 +88,7 @@ methods
                                   1e-7);
     end
 
-    function test_subtracting_dnd_from_sqw_returns_sqw_equal_image_data(obj)
+    function test_sqw_minus_equivalent_dnd_returns_sqw_with_zero_image_data(obj)
         out = obj.sqw_obj - obj.dnd_obj;
 
         assertTrue(isa(out, 'sqw'));
@@ -102,7 +102,7 @@ methods
                                   1e-7);
     end
 
-    function test_subtracting_dnd_from_sqw_returns_sqw_non_equal_image_data(obj)
+    function test_subtracting_dnd_from_sqw_returns_sqw(obj)
         obj.dnd_obj.s = ones(size(obj.dnd_obj.npix));
         out = obj.sqw_obj - obj.dnd_obj;
 

--- a/_test/test_sqw/test_binary_ops.m
+++ b/_test/test_sqw/test_binary_ops.m
@@ -26,19 +26,32 @@ methods
         obj.dnd_obj = d2d(obj.base_sqw_obj);
     end
 
-    function test_SQW_error_if_first_input_is_int64(obj)
-        f = @() int64(ones(size(obj.sqw_obj.data.npix))) + obj.sqw_obj;
-        assertExceptionThrown(f, 'SQW:binary_op_manager_single');
-    end
-
-    function test_SQW_error_if_first_input_is_char(obj)
+    function test_SQW_error_if_operand_is_char(obj)
         f = @() 'some char' + obj.sqw_obj;
+        ff = @()  obj.sqw_obj + 'some char';
         assertExceptionThrown(f, 'SQW:binary_op_manager_single');
+        assertExceptionThrown(ff, 'SQW:binary_op_manager_single');
     end
 
-    function test_SQW_error_if_second_input_not_supported_type(obj)
-        f = @() obj.sqw_obj + int64(ones(size(obj.sqw_obj.data.npix)));
+    function test_SQW_error_if_operand_is_cell_array(obj)
+        f = @() {1, 2, 3} + obj.sqw_obj;
+        ff = @() obj.sqw_obj + {0};
         assertExceptionThrown(f, 'SQW:binary_op_manager_single');
+        assertExceptionThrown(ff, 'SQW:binary_op_manager_single');
+    end
+
+    function test_SQW_error_if_operand_is_numeric_but_not_double(obj)
+        unsupported_types = {@single, @int8, @int16, @int32, @int64, ...
+                             @uint8, @uint16, @uint32, @uint64};
+
+        for i = 1:numel(unsupported_types)
+            type_func = unsupported_types{i};
+            numeric_array = type_func(ones(size(obj.sqw_obj.data.npix)));
+            f = @() obj.sqw_obj + numeric_array;
+            ff = @() numeric_array + obj.sqw_obj;
+            assertExceptionThrown(f, 'SQW:binary_op_manager_single');
+            assertExceptionThrown(ff, 'SQW:binary_op_manager_single');
+        end
     end
 
     function test_adding_sqw_and_dnd_objects_1st_operand_is_sqw_returns_sqw(obj)

--- a/horace_core/sqw/@sqw/private/binary_op_manager_single.m
+++ b/horace_core/sqw/@sqw/private/binary_op_manager_single.m
@@ -10,6 +10,13 @@ function wout = binary_op_manager_single(w1,w2,binary_op)
 %           >> nd = dimensions(obj)
 %   (3) have private function that returns class name
 %           >> name = classname     % no argument - gets called by its association with the class
+%
+allowed_types = {'double', 'd0d', 'd1d', 'd2d', 'd3d', 'd4d', 'sqw', 'sigvar'};
+if ~ismember(class(w1), allowed_types) || ~ismember(class(w2), allowed_types)
+    error('SQW:binary_op_manager_single', ...
+          ['Cannot perform binary operation between types ' ...
+           '''%s'' and ''%s''.'], class(w1), class(w2));
+end
 
 if ~isa(w1,'double') && ~isa(w2,'double')
     if (isa(w1,classname) && is_sqw_type(w1)) && (isa(w2,classname) && is_sqw_type(w2))


### PR DESCRIPTION
Adds a suite of tests for SQW binary operations. 

The tests written are not meant to test that the individual binary operation implementations are correct e.g. `plus`, `minus`. The point of the tests is to ensure that performing binary operations with SQW objects behaves as it should, i.e. correct type returned, no errors raised, errors raised where they should be.

Fixes #304 