### PR TITLE
Extend CI pipelines to build against Herbert branch or tag

### DIFF
--- a/documentation/smg/08_setting_up_jenkins_ci.md
+++ b/documentation/smg/08_setting_up_jenkins_ci.md
@@ -44,6 +44,54 @@ For all:
 - The `Jenkinsfile` script runs the platform specific build script and updates
 GitHub about the status of the build.
 
+## Naming conventions
+
+The pipelines are split into folders `Herbert` and `Horace`,
+each containing pipelines for their namesake's code.
+All pipelines should follow the stated naming convention
+and the majority of pipelines should exist in both Herbert and Horace folders.
+
+The convention is:
+
+```txt
+[pipeline-type]-[os/platform]-[matlab-year-release]
+```
+
+Examples of `pipeline-type`:
+
+- `PR` for pull requests
+- `Branch` for builds of a user specified branch
+- `Release` for pipelines creating Herbert/Horace releases
+- an empty string for nightly master builds
+
+The pipeline type defines the "type" of package that the pipeline will generate.
+For example, the `PR` type will create a package whose version number contains
+a Git SHA.
+The `Release` type will generate a package meant for public release and the
+version number will not contain a Git SHA.
+
+Examples of `os/platform`:
+
+- `Windows-10`
+- `Scientific-Linux-7`
+
+These names map to labels for ANVIL Jenkins agents.
+This mappings are defined using the
+[credentials plugin](https://www.jenkins.io/doc/book/using/using-credentials/).
+
+Examples of `matlab-year-release`:
+
+- 2018b
+- 2019b
+
+For example, a pipeline that builds PRs on Windows 10 using Matlab R2018b must
+be called `PR-Windows-10-2018b`
+
+It may also be useful to define _trigger_ pipelines.
+These pipelines can be used to trigger a set of pipelines.
+For example you may wish to trigger nightly builds for all platforms.
+The naming convention for these should be `[pipeline-type]-Trigger`.
+
 ## Managing Herbert Dependency
 
 In order to build and run, Horace requires that Herbert also be present in the
@@ -111,9 +159,8 @@ Allows GitHub to trigger builds
 ### Setting Up the Pipeline
 
 - Create a new "Pipeline" job.
-- The pipeline should follow the naming convention: `<operating-system>-<Matlab-release>`
-and should be prefixed with `PR-` if the pipeline is building pull requests, e.g.
-`PR-Scientific-Linux-7-2018b`.
+- The pipeline should follow the naming convention defined above.
+E.g. `PR-Scientific-Linux-7-2018b`.
 - Enter the GitHub project URL e.g. `http:/pace-neutrons.github.com/horace`
 (this creates a link to the GitHub from the pipeline).
 

--- a/documentation/smg/08_setting_up_jenkins_ci.md
+++ b/documentation/smg/08_setting_up_jenkins_ci.md
@@ -116,19 +116,6 @@ and should be prefixed with `PR-` if the pipeline is building pull requests, e.g
 `PR-Scientific-Linux-7-2018b`.
 - Enter the GitHub project URL e.g. `http:/pace-neutrons.github.com/horace`
 (this creates a link to the GitHub from the pipeline).
-- Select the `This project is parameterised` option:
-
-  - Create the following string parameters:
-
-    - `AGENT`: The label of the agent to run the job on
-    - `CMAKE_VERSION`: The version of CMake to load
-    - `MATLAB_VERSION`: The (release) version of Matlab to load
-    - `GCC_VERSION`: The version of GCC to use (Linux only)
-    - `CPPCHECK_VERSION`: The version of CppCheck to use (Linux only)
-
-    The list of required parameters are noted in the docstring for the pipeline
-    within the Jenkinsfile, and should be added with descriptions through the
-    Jenkins job GUI.
 
 #### Nightly builds
 
@@ -138,7 +125,10 @@ The nightly build should run if there have been any code changes to the `master`
 - Set the schedule to run overnight (e.g. between 1am and 2am `H 1 * * *`)
 - Add a `RELEASE_TYPE` string parameters and set to `nightly`
 
-Note: the Herbert build will trigger the downstream Horace build. To ensure the latest build artifacts are used the Horace build must be scheduled to trigger *after the Herbert build will have completed*.
+Note: the Herbert build will trigger the downstream Horace build.
+To ensure the latest build artifacts are used,
+the Horace build must be scheduled to trigger *after the Herbert build will
+have completed*.
 
 #### Pull requests
 
@@ -181,6 +171,14 @@ left and enter the name of the branch they want to build.
 The `Jenkinksfile` script is the entry point for Jenkins.
 This loads the required versions of libraries, calls the build scripts,
 and notifies GitHub of the build's status.
+
+The `Jenkinsfile` can be used to declare pipeline parameters,
+rather than needing to set them in the GUI.
+Be aware that these parameters will _not_ be set the first time you run the
+Jenkinsfile.
+However, the pipeline parameters will have been updated for the next time the
+pipeline is run.
+This moves more of the pipeline definition into code rather than in the GUI.
 
 There are two build scripts, one written in Bash and one in PowerShell. The
 scripts are named `build.<sh/ps1>` and have a similar API.

--- a/documentation/smg/08_setting_up_jenkins_ci.md
+++ b/documentation/smg/08_setting_up_jenkins_ci.md
@@ -52,8 +52,8 @@ So that Horace builds are run against an up-to-date Herbert,
 pull request and branch builds will checkout and build the latest Herbert master from GitHub.
 This means that Horace is run against Herbert source,
 instead of a Herbert package.
-There also exists a parameter that allows one to build a particular branch or
-tag of Herbert.
+There also exists a parameter `HERBERT_BRANCH_NAME` that allows one to build a
+particular branch or tag of Herbert.
 
 Nightly builds should be equivalent to production releases, so Horace will use a
 packaged version of Herbert. This will ensure that our Herbert and Horace packages

--- a/documentation/smg/08_setting_up_jenkins_ci.md
+++ b/documentation/smg/08_setting_up_jenkins_ci.md
@@ -1,12 +1,21 @@
 # Setting Up Jenkins CI
 
-Machines administered by [ANVIL](https://anvil.softeng-support.ac.uk/) are used to run the continuous integration (CI) jobs. These machines are running Jenkins v2.204.1 (at time of writing).
+Machines administered by [ANVIL](https://anvil.softeng-support.ac.uk/) are used
+to run the continuous integration (CI) jobs.
+These machines are running Jenkins v2.204.1 (at time of writing).
 
-As much of the CI configuration as possible should be scripted and committed to version control. This makes things re-creatable and locally testable. However, there is necessarily some set up that must be done within the GUI in Jenkins. It is therefore important that this document is kept up-to-date with the steps taken to reach the configuration we use.
+As much of the CI configuration as possible should be scripted and committed to
+version control. This makes things re-creatable and locally testable.
+However, there is necessarily some set up that must be done within the GUI in Jenkins.
+It is therefore important that this document is kept up-to-date with the steps
+taken to reach the configuration we use.
 
-Jenkins is used for building pull requests, when opened or edited, and building master every evening. Each build will create a Horace package that is shippable to users.
+Jenkins is used for building pull requests, when opened or edited,
+and building master every evening.
+Each build will create a Horace package that is shippable to users.
 
-A `pace-builder` GitHub account has been created to provide authentication between Jenkins and GitHub.
+A `pace-builder` GitHub account has been created to provide authentication
+between Jenkins and GitHub.
 
 ## Overview
 
@@ -14,30 +23,37 @@ The CI builds follow the following high-level process:
 
 For pull requests:
 
-  - Webhooks are created in GitHub that notify Jenkins when a pull request event
-    occurs.
-  - When Jenkins receives a notification from GitHub it will checkout out the
-    relevant pull request branch and merge it with master.
+- Webhooks are created in GitHub that notify Jenkins when a pull request event
+  occurs.
+- When Jenkins receives a notification from GitHub it will checkout out the
+  relevant pull request branch and merge it with master.
 
 For nightly builds:
 
-  - Jenkins will clone master at a specific time each evening if there have been any code changes.
+- Jenkins will clone master at a specific time each evening if there have been
+any code changes.
 
 For manual branch builds:
 
-  - A user manually triggers a build and enters a branch name that is then cloned.
+- A user manually triggers a build and enters a branch name that is then cloned.
 
 For all:
 
-  - Jenkins loads and runs the [`Jenkinsfile`](./../../tools/build_config/Jenkinsfile) located in `tools/build_config`.
-  - The `Jenkinsfile` script runs the platform specific build script and updates GitHub about the status of the build.
+- Jenkins loads and runs the
+[`Jenkinsfile`](./../../tools/build_config/Jenkinsfile) located in `tools/build_config`.
+- The `Jenkinsfile` script runs the platform specific build script and updates
+GitHub about the status of the build.
 
 ## Managing Herbert Dependency
 
-In order to build and run, Horace requires that Herbert also be present in the Jenkins
-workspace. So that Horace builds are run against an up-to-date Herbert,
+In order to build and run, Horace requires that Herbert also be present in the
+Jenkins workspace.
+So that Horace builds are run against an up-to-date Herbert,
 pull request and branch builds will checkout and build the latest Herbert master from GitHub.
-This means that Horace is run against Herbert source, instead of a Herbert package.
+This means that Horace is run against Herbert source,
+instead of a Herbert package.
+There also exists a parameter that allows one to build a particular branch or
+tag of Herbert.
 
 Nightly builds should be equivalent to production releases, so Horace will use a
 packaged version of Herbert. This will ensure that our Herbert and Horace packages
@@ -46,29 +62,42 @@ Herbert nightly build.
 
 ## GitHub
 
-The only job required on GitHub is to set up webhooks to notify Jenkins of pull requests. These can be created by GitHub repository admins by opening the settings tab in the [main repo](https://github.com/pace-neutrons/Horace).
+The only job required on GitHub is to set up webhooks to notify Jenkins of pull requests. These can be created by GitHub repository admins by opening the settings tab
+in the [main repo](https://github.com/pace-neutrons/Horace).
 
 <img src="./images/08_github_settings.png">
 
 Then selecting the `Webhooks` menu item on the left-hand side.
 
-The webhook should have payload URL
-```
+The webhook should have payload URL:
+
+```txt
 https://anvil.softeng-support.ac.uk/jenkins/generic-webhook-trigger/invoke?token=<my_secret_token>
 ```
-with content type `application/json` and only trigger on pull request events. This will send a json containing information about the pull request (including pull request number and the action taken in the pull request event) to Jenkins. Pull request events trigger when a pull request is:
+
+with content type `application/json` and only trigger on pull request events.
+This will send a json containing information about the pull request
+(including pull request number and the action taken in the pull request event)
+to Jenkins.
+Pull request events trigger when a pull request is:
 
 > *opened, closed, reopened, edited, assigned, unassigned, review requested,
 > review request removed, labeled, unlabeled, synchronized, ready for review,
 > locked, or unlocked.*
 
-This means that, from the webhook's JSON, it can be decided if a build is to be triggered. Usually, builds should only be triggered when a pull request is `opened` or `synchronized` (a new commit is pushed to an existing pull request).
+This means that, from the webhook's JSON, it can be decided if a build is to be
+triggered.
+Usually, builds should only be triggered when a pull request is `opened` or
+`synchronized` (a new commit is pushed to an existing pull request).
 
-Only one webhook should be required to trigger all the necessary build jobs. The webhook should have the format `<repo-name>-<secret>` so there is clear distinction between which webhooks are for which repository.
+Only one webhook should be required to trigger all the necessary build jobs,
+as long as the jobs share the same trigger token.
 
-From this page payloads can be re-delivered if required, for example, if the Jenkins servers were down and the payload was not received.
+From this page payloads can be re-delivered if required, for example,
+if the Jenkins servers were down and the payload was not received.
 
-Using webhooks is a more efficient method to automatically trigger builds than polling, as it does not require Jenkins to query GitHub on regular intervals.
+Using webhooks is a more efficient method to automatically trigger builds than
+polling, as it does not require Jenkins to query GitHub on regular intervals.
 
 ## Jenkins GUI
 
@@ -88,12 +117,14 @@ and should be prefixed with `PR-` if the pipeline is building pull requests, e.g
 - Enter the GitHub project URL e.g. `http:/pace-neutrons.github.com/horace`
 (this creates a link to the GitHub from the pipeline).
 - Select the `This project is parameterised` option:
-    - Create the following string parameters:
-        - `AGENT`: The label of the agent to run the job on
-        - `CMAKE_VERSION`: The version of CMake to load
-        - `MATLAB_VERSION`: The (release) version of Matlab to load
-        - `GCC_VERSION`: The version of GCC to use (Linux only)
-        - `CPPCHECK_VERSION`: The version of CppCheck to use (Linux only)
+
+  - Create the following string parameters:
+
+    - `AGENT`: The label of the agent to run the job on
+    - `CMAKE_VERSION`: The version of CMake to load
+    - `MATLAB_VERSION`: The (release) version of Matlab to load
+    - `GCC_VERSION`: The version of GCC to use (Linux only)
+    - `CPPCHECK_VERSION`: The version of CppCheck to use (Linux only)
 
     The list of required parameters are noted in the docstring for the pipeline
     within the Jenkinsfile, and should be added with descriptions through the
@@ -102,13 +133,15 @@ and should be prefixed with `PR-` if the pipeline is building pull requests, e.g
 #### Nightly builds
 
 The nightly build should run if there have been any code changes to the `master` branch.
-  - In the `Build Triggers` section select the `Poll SCM` option.
-  - Set the schedule to run overnight (e.g. between 1am and 2am `H 1 * * *`)
-  - Add a `RELEASE_TYPE` string parameters and set to `nightly`
+
+- In the `Build Triggers` section select the `Poll SCM` option.
+- Set the schedule to run overnight (e.g. between 1am and 2am `H 1 * * *`)
+- Add a `RELEASE_TYPE` string parameters and set to `nightly`
 
 Note: the Herbert build will trigger the downstream Horace build. To ensure the latest build artifacts are used the Horace build must be scheduled to trigger *after the Herbert build will have completed*.
 
 #### Pull requests
+
 - Select the `Generic Webhook Trigger` option and retrieve the json values:
   - `action`: The type of pull request event this is
   - `pull_request.number`: The pull request number on GitHub
@@ -124,7 +157,8 @@ action retrieved from GitHub matches the regex `(opened|synchronize)`.
 
   <img src="./images/08_action_trigger.png">
 
-- Set up the `Pipeline` section as shown below to have Jenkins pull the PR  branch and merge it into master before building.
+- Set up the `Pipeline` section as shown below to have Jenkins pull the PR
+branch and merge it into master before building.
 
   <img src="./images/08_git_pipeline.png">
 
@@ -138,15 +172,21 @@ action retrieved from GitHub matches the regex `(opened|synchronize)`.
 
   <img src="./images/08_branch_pipeline.png">
 
-When developers want to build a specific branch, they can navigate to the  `Branch-*` Jenkins job, choose `Build with Parameters` in the panel on the  left and enter the name of the branch they want to build.
+When developers want to build a specific branch, they can navigate to the
+`Branch-*` Jenkins job, choose `Build with Parameters` in the panel on the
+left and enter the name of the branch they want to build.
 
 ## Jenkinsfile and Build Scripts
 
-The `Jenkinksfile` script is the entry point for Jenkins. This loads the required versions of libraries, calls the build scripts, and notifies GitHub of the build's status.
+The `Jenkinksfile` script is the entry point for Jenkins.
+This loads the required versions of libraries, calls the build scripts,
+and notifies GitHub of the build's status.
 
-There are two build scripts, one written in Bash and one in PowerShell. The scripts are named `build.<sh/ps1>` and have a similar API.
+There are two build scripts, one written in Bash and one in PowerShell. The
+scripts are named `build.<sh/ps1>` and have a similar API.
 
-The build scripts are intended to work locally as well as on Jenkins, so any Jenkins specific tasks should *not* be in the build scripts.
+The build scripts are intended to work locally as well as on Jenkins,
+so any Jenkins specific tasks should *not* be in the build scripts.
 
 ### Actions
 
@@ -168,15 +208,27 @@ The build scripts are intended to work locally as well as on Jenkins, so any Jen
 | `-cmake_flags` | `--cmake_flags`, `-F` | | Custom parameters to pass to CMake configure step |
 | `-vs_version`, `VS` | | `2017` | Target Visual Studio version for CMake output (1) |
 
-Actions may be combined so to call the script and only build use the `--build` flag, to build and test use both flags `--build --test`.
+Actions may be combined.
+To call the script and only build use the `--build` flag,
+to build and test, use both flags `--build --test`.
 
 Notes:
 
-1. The Visual Studio version must match a configured Visual Studio release or an error will be thrown
+1. The Visual Studio version must match a configured Visual Studio release or
+an error will be thrown
 2. PowerShell uses *a single dash* for parameters, i.e. `-build -test -package`.
 
 ## Authentication
 
-In order to create merge commits and to post build statuses to GitHub some credentials must be provided within the Jenkins GUI. For this, the `pace.builder`. GitHub account has been created and given write permissions to the Horace and Herbert repository. The email for this account is `pace.buider.stfc@gmail.co.uk`.
+In order to create merge commits and to post build statuses to GitHub some
+credentials must be provided within the Jenkins GUI.
+For this, the `pace.builder` GitHub account has been created and given write
+permissions to the Horace and Herbert repository.
+The email for this account is `pace.buider.stfc@gmail.co.uk`.
 
-Credentials are saved in the Jenkins PACE area providing an API token linked to the account. These credentials can be accessed within the Jenkinsfile using a `withCredentials` block, this block will prevent the credentials being printed to the terminal. Jenkins logs are not private, be careful to never publish passwords or API tokens.
+Credentials are saved in the Jenkins PACE area providing an API token linked
+to the account.
+These credentials can be accessed within the Jenkinsfile using a
+`withCredentials` block,
+this block will prevent the credentials being printed to the terminal.
+Jenkins logs are not private, be careful to never publish passwords or API tokens.

--- a/tools/bash/clone_herbert_branch.sh
+++ b/tools/bash/clone_herbert_branch.sh
@@ -25,11 +25,11 @@ if [ "${herbert_branch}" = "" ]; then
 fi
 
 if [[ -d "${HERBERT_DIR}" ]]; then
-    echo_and_run "git -C ${HERBERT_DIR} fetch origin" &&
-    echo_and_run "git -C ${HERBERT_DIR} reset --hard origin/${herbert_branch}"
+    echo_and_run "git -C ${HERBERT_DIR} fetch -all --tags" &&
+    echo_and_run "git -C ${HERBERT_DIR} reset --hard \"${herbert_branch}\""
 else
     git_clone_cmd="git clone ${HERBERT_URL} --depth 1"
-    git_clone_cmd+=" --branch ${herbert_branch} ${HERBERT_DIR}"
+    git_clone_cmd+=" --branch \"${herbert_branch}\" ${HERBERT_DIR}"
     echo_and_run "${git_clone_cmd}"
 fi
 

--- a/tools/bash/clone_herbert_branch.sh
+++ b/tools/bash/clone_herbert_branch.sh
@@ -24,7 +24,6 @@ if [ "${herbert_branch}" = "" ]; then
     herbert_branch="${DEFAULT_BRANCH}"
 fi
 
-echo "Building Herbert branch '${herbert_branch}'..."
 if [[ -d "${HERBERT_DIR}" ]]; then
     echo_and_run "git -C ${HERBERT_DIR} fetch origin" &&
     echo_and_run "git -C ${HERBERT_DIR} reset --hard origin/${herbert_branch}"
@@ -34,6 +33,7 @@ else
     echo_and_run "${git_clone_cmd}"
 fi
 
+echo -e "\nBuilding Herbert revision $(git -C ${HERBERT_DIR} rev-parse HEAD)..."
 build_cmd="${HERBERT_DIR}/tools/build_config/build.sh --build"
 build_cmd+=" --build_tests OFF ${build_args}"
 echo_and_run "${build_cmd}"

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -5,11 +5,11 @@ def get_matlab_release(String job_name) {
 }
 
 def get_build_type(String job_name) {
-  if (env.JOB_BASE_NAME.startsWith('Release-')) {
+  if (job_name.startsWith('Release-')) {
     return 'Release'
-  } else if (env.JOB_BASE_NAME.startsWith('Branch-')) {
+  } else if (job_name.startsWith('Branch-')) {
     return 'Branch'
-  } else if(env.JOB_BASE_NAME.startsWith('PR-')) {
+  } else if(job_name.startsWith('PR-')) {
     return 'Pull-request'
   } else {
     return 'Nightly'
@@ -18,9 +18,9 @@ def get_build_type(String job_name) {
 
 def get_agent(String job_name) {
   def agent = ''
-  if (env.JOB_BASE_NAME.contains('Scientific-Linux-7')) {
+  if (job_name.contains('Scientific-Linux-7')) {
     return 'sl7'
-  } else if (env.JOB_BASE_NAME.contains('Windows-10')) {
+  } else if (job_name.contains('Windows-10')) {
     return 'PACE Windows (Private)'
   }
   return '';

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -221,9 +221,11 @@ pipeline {
        * master build.
        *
        * For PR and Branch builds, we clone and build the Herbert master
-       * source from GitHub
+       * source from GitHub.
+       *
+       * For release builds, we clone and build a manually specified Herbert
+       * branch.
       */
-
       steps {
         script {
           if (env.RELEASE_TYPE == "nightly") {
@@ -252,15 +254,19 @@ pipeline {
                 module load cmake/\$CMAKE_VERSION &&
                 module load matlab/\$MATLAB_VERSION &&
                 module load gcc/\$GCC_VERSION &&
-                ./tools/bash/clone_herbert_branch.sh --build_args \
+                ./tools/bash/clone_herbert_branch.sh\
+                  --branch \$HERBERT_BRANCH_NAME\
+                  --build_args \
                     \"--cmake_flags \\\"-DHerbert_RELEASE_TYPE=\$RELEASE_TYPE\\\" \
                     --matlab_release \$MATLAB_VERSION\"
               '''
             } else {
               powershell '''
-                ./tools/pwsh/clone_herbert_branch.ps1 -build_args \
-                  \"-cmake_flags \"\"-DHerbert_RELEASE_TYPE=\$env:RELEASE_TYPE\"\" \
-                  -matlab_release \$env:MATLAB_VERSION\"
+                ./tools/pwsh/clone_herbert_branch.ps1\
+                  -branch \$env:HERBERT_BRANCH_NAME\
+                  -build_args\
+                    \"-cmake_flags \"\"-DHerbert_RELEASE_TYPE=\$env:RELEASE_TYPE\"\" \
+                    -matlab_release \$env:MATLAB_VERSION\"
               '''
             }
           }

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -82,7 +82,7 @@ properties([
     ),
     string(
       defaultValue: get_default_herbert_branch(env.JOB_BASE_NAME),
-      description: 'The name of the branch of Herbert to use.',
+      description: 'The name of the branch or tag of Herbert to use.',
       name: 'HERBERT_BRANCH_NAME',
       trim: true
     ),

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -17,13 +17,18 @@ def get_build_type(String job_name) {
 }
 
 def get_agent(String job_name) {
-  def agent = ''
   if (job_name.contains('Scientific-Linux-7')) {
-    return 'sl7'
+    withCredentials([string(credentialsId: 'sl7_agent', variable: 'agent')]) {
+      return "${agent}"
+    }
   } else if (job_name.contains('Windows-10')) {
-    return 'PACE Windows (Private)'
+    withCredentials([string(credentialsId: 'win10_agent', variable: 'agent')]) {
+      return "${agent}"
+    }
+  } else {
+    // This else block is required or the below statement will always execute
+    return '';
   }
-  return '';
 }
 
 def get_release_type(String job_name) {

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -1,13 +1,136 @@
 #!groovy
-/**
- * The following parameters must be provided by the Jenkins build job and must match available application
- * on the build target machine
- *
- *  - CMAKE_VERSION: The version of CMake to run the build with
- *  - GCC_VERSION: The version of GCC to build with
- *  - MATLAB_VERSION: The release number of the Matlab to load
- *  - CPPCHECK_VERSION: The version of CppCheck tooling to load to provide the code-style checks
- */
+
+def get_matlab_release(String job_name) {
+  return 'R' + job_name[-5..-1]
+}
+
+def get_build_type(String job_name) {
+  if (env.JOB_BASE_NAME.startsWith('Release-')) {
+    return 'Release'
+  } else if (env.JOB_BASE_NAME.startsWith('Branch-')) {
+    return 'Branch'
+  } else if(env.JOB_BASE_NAME.startsWith('PR-')) {
+    return 'Pull-request'
+  } else {
+    return 'Nightly'
+  }
+}
+
+def get_agent(String job_name) {
+  def agent = ''
+  if (env.JOB_BASE_NAME.contains('Scientific-Linux-7')) {
+    return 'sl7'
+  } else if (env.JOB_BASE_NAME.contains('Windows-10')) {
+    return 'PACE Windows (Private)'
+  }
+  return '';
+}
+
+def get_release_type(String job_name) {
+  String build_type = get_build_type(job_name);
+
+  switch(build_type) {
+    case 'Release':
+      return 'release'
+
+    case 'Pull-request':
+      return 'pull_request'
+
+    case 'Nightly':
+      return 'nightly'
+
+    default:
+      return ''
+  }
+}
+
+def get_branch_name(String job_name) {
+  String build_type = get_build_type(job_name);
+
+  switch(build_type) {
+    case 'Nightly':
+      return 'master'
+
+    default:
+      return ''
+  }
+}
+
+def get_default_herbert_branch(String job_name) {
+  String build_type = get_build_type(job_name)
+
+  switch(build_type) {
+      case 'Release':
+          return ''
+
+      case 'Nightly':
+        'None'
+
+      default:
+          return 'master'
+  }
+}
+
+
+properties([
+  parameters([
+    string(
+      defaultValue: get_branch_name(env.JOB_BASE_NAME),
+      description: 'The name of the branch to build.',
+      name: 'BRANCH_NAME',
+      trim: true
+    ),
+    string(
+      defaultValue: get_default_herbert_branch(env.JOB_BASE_NAME),
+      description: 'The name of the branch of Herbert to use.',
+      name: 'HERBERT_BRANCH_NAME',
+      trim: true
+    ),
+    string(
+      defaultValue: get_matlab_release(env.JOB_BASE_NAME),
+      description: 'The release number of the Matlab to load e.g. R2019b.',
+      name: 'MATLAB_VERSION',
+      trim: true
+    ),
+    string(
+      defaultValue: get_release_type(env.JOB_BASE_NAME),
+      description: 'The type of the build e.g. "nightly", "release", "pull_request".',
+      name: 'RELEASE_TYPE',
+      trim: true
+    ),
+    string(
+      defaultValue: get_agent(env.JOB_BASE_NAME),
+      description: 'The agent to execute the pipeline on.',
+      name: 'AGENT',
+      trim: true
+    ),
+    string(
+      defaultValue: '3.7.2',
+      description: 'The version of CMake to run the build with.',
+      name: 'CMAKE_VERSION',
+      trim: true
+    ),
+    string(
+      defaultValue: '6.3.0',
+      description: 'The version of GCC to build with.',
+      name: 'GCC_VERSION',
+      trim: true
+    ),
+    string(
+      defaultValue: '2017',
+      description: 'The year of the version of Visual Studio to build with.',
+      name: 'VS_VERSION',
+      trim: true
+    ),
+    string(
+      defaultValue: '1.77',
+      description: 'The version of CppCheck tooling to load to provide the code-style checks.',
+      name: 'CPPCHECK_VERSION',
+      trim: true
+    )
+  ])
+])
+
 def post_github_status(String state, String message) {
   // Non-PR builds will not set PR_STATUSES_URL - in which case we do not
   // want to post any statuses to Git
@@ -49,18 +172,7 @@ def post_github_status(String state, String message) {
 
 def base_job_name = "${env.JOB_BASE_NAME}".replace("PR-", "").replace("Branch-", "")
 
-/* Pipeline parameters:
- *   All platforms:
- *     AGENT (e.g. 'sl7', 'PACE Windows (Private)', 'osx')
- *     MATLAB_VERSION (e.g R2018b)
- *     RELEASE_TYPE ('nightly', 'release' - optional)
- *   Unix only:
- *     CMAKE_VERSION (e.g. 3.7.2)
- *     GCC_VERSION (e.g. 6.3.0)
- *     CPPCHECK_VERSION (e.g. 1.77)
- *   Windows only:
- *     VS_VERSION (e.g. 2017)
- */
+
 pipeline {
   agent {
     label env.AGENT

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -17,18 +17,17 @@ def get_build_type(String job_name) {
 }
 
 def get_agent(String job_name) {
+  def agent = ''
   if (job_name.contains('Scientific-Linux-7')) {
     withCredentials([string(credentialsId: 'sl7_agent', variable: 'agent')]) {
-      return "${agent}"
+      agent = "${agent}"
     }
   } else if (job_name.contains('Windows-10')) {
     withCredentials([string(credentialsId: 'win10_agent', variable: 'agent')]) {
-      return "${agent}"
+      agent = "${agent}"
     }
-  } else {
-    // This else block is required or the below statement will always execute
-    return '';
   }
+  return agent
 }
 
 def get_release_type(String job_name) {
@@ -230,7 +229,7 @@ pipeline {
        *
        * For release builds, we clone and build a manually specified Herbert
        * branch.
-      */
+       */
       steps {
         script {
           if (env.RELEASE_TYPE == "nightly") {

--- a/tools/pwsh/clone_herbert_branch.ps1
+++ b/tools/pwsh/clone_herbert_branch.ps1
@@ -17,10 +17,10 @@ $HERBERT_URL = "https://github.com/pace-neutrons/Herbert.git"
 $HERBERT_DIR = "$($(Get-Location).Path)/Herbert"
 
 if (Test-Path -Path "$HERBERT_DIR") {
-  Write-And-Invoke "git -C $HERBERT_DIR fetch origin"
-  Write-And-Invoke "git -C $HERBERT_DIR reset --hard origin/$branch"
+  Write-And-Invoke "git -C $HERBERT_DIR fetch --all --tags"
+  Write-And-Invoke "git -C $HERBERT_DIR reset --hard ""$branch"""
 } else {
-  Write-And-Invoke "git clone $HERBERT_URL --depth 1 --branch $branch $HERBERT_DIR"
+  Write-And-Invoke "git clone $HERBERT_URL --depth 1 --branch ""$branch"" $HERBERT_DIR"
 }
 
 Write-Output "`nBuilding Herbert revision $(git -C $HERBERT_DIR rev-parse HEAD)..."

--- a/tools/pwsh/clone_herbert_branch.ps1
+++ b/tools/pwsh/clone_herbert_branch.ps1
@@ -16,7 +16,6 @@ param(
 $HERBERT_URL = "https://github.com/pace-neutrons/Herbert.git"
 $HERBERT_DIR = "$($(Get-Location).Path)/Herbert"
 
-Write-Output "Building Herbert branch '$branch'..."
 if (Test-Path -Path "$HERBERT_DIR") {
   Write-And-Invoke "git -C $HERBERT_DIR fetch origin"
   Write-And-Invoke "git -C $HERBERT_DIR reset --hard origin/$branch"
@@ -24,6 +23,7 @@ if (Test-Path -Path "$HERBERT_DIR") {
   Write-And-Invoke "git clone $HERBERT_URL --depth 1 --branch $branch $HERBERT_DIR"
 }
 
+Write-Output "`nBuilding Herbert revision $(git -C $HERBERT_DIR rev-parse HEAD)..."
 $build_cmd = "$HERBERT_DIR/tools/build_config/build.ps1 -build"
 $build_cmd += " -build_tests OFF"
 $build_cmd += " $build_args"


### PR DESCRIPTION
This PR adds a `HERBERT_BRANCH` parameter to our Jenkins pipelines. When triggering builds we now have the option to select a given Herbert branch or tag to clone from GitHub. *Nightly builds will still use the last successful Herbert nightly package*.

This PR also moves the parameter definitions in the Horace pipelines into the Jenkinsfile. This better documents what our parameters are and keeps our pipeline in sync with one another.

Fixes #332 