### PR TITLE
paging for noisify

### DIFF
--- a/_test/test_sqw/test_PixelData_operations.m
+++ b/_test/test_sqw/test_PixelData_operations.m
@@ -66,6 +66,21 @@ methods
     function tearDown(obj)
         set(hor_config, obj.old_config);
     end
+    
+    function test_noisify_with_paging_draft(obj)
+        % Test function to compare the output between 2 noisify
+        % implementations.
+        % This one is hard wired to use the test below.
+        % The random number generator is re-seeded before each call
+        % of noisify to ensure that nosify uses the same random sequence
+        % for both calls.
+        s = sqw('_test\test_sqw_file\sqw_1d_1.sqw');
+        rng(0);
+        s1 = noisify(s);
+        rng(0);
+        s2 = noisify(s);
+        assertEqual(s1, s2, '', 5e-4);
+    end
 
     function test_compute_bin_data_correct_output_in_memory_mex_1_thread(obj)
         obj.config.use_mex = true;

--- a/horace_core/sqw/@sqw/noisify.m
+++ b/horace_core/sqw/@sqw/noisify.m
@@ -14,13 +14,17 @@ function wout = noisify (w,varargin)
 %           Add noise with Poisson distribution, where the mean value at
 %           a point is the value of pixel signal.
 %
+% Modified to use the object paging functionality. The "noisify" overload
+% required here is the one in Herbert taking separate signal and error
+% arguments before varargin. I *think* this overload is resolved at call
+% time and consequently further specification at this point is not needed.
 wout=w;
 for i=1:numel(w)
     if is_sqw_type(w(i))   % determine if sqw or dnd type
-        [wout(i).data.pix.signal,wout(i).data.pix.variance] = ...
-                noisify(w(i).data.pix.signal,w(i).data.pix.variance,varargin{:});
+        wout(i).data.pix = w(i).data.pix.do_sigvar_pair_va_op(noisify, varargin{:})
         wout(i)=recompute_bin_data(wout(i));
     else
         [wout(i).data.s,wout(i).data.e]=noisify(w(i).data.s,w(i).data.e,varargin{:});
     end
 end
+

--- a/horace_core/sqw/@sqw/noisify.m
+++ b/horace_core/sqw/@sqw/noisify.m
@@ -21,7 +21,7 @@ function wout = noisify (w,varargin)
 wout=w;
 for i=1:numel(w)
     if is_sqw_type(w(i))   % determine if sqw or dnd type
-        wout(i).data.pix = w(i).data.pix.do_sigvar_pair_va_op(noisify, varargin{:})
+        wout(i).data.pix = w(i).data.pix.do_sigvar_pair_va_op(@noisify, varargin{:});
         wout(i)=recompute_bin_data(wout(i));
     else
         [wout(i).data.s,wout(i).data.e]=noisify(w(i).data.s,w(i).data.e,varargin{:});

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -222,6 +222,7 @@ methods
     pix_out = do_unary_op(obj, unary_op);
     pix_out = append(obj, pix);
     pix_out = mask(obj, mask_array, npix);
+    pix_out = do_sigvar_pair_va_op(obj, op, varargin);
 
     function obj = PixelData(arg, mem_alloc)
         % Construct a PixelData object from the given data. Default

--- a/horace_core/sqw/PixelData/@PixelData/do_sigvar_pair_va_op.m
+++ b/horace_core/sqw/PixelData/@PixelData/do_sigvar_pair_va_op.m
@@ -18,9 +18,9 @@ end
 
 pix_out.move_to_first_page();
 while true
-    pg_result = svpair_op(pix_out.signal, pix_out.variance, varargin{:});
-    pix_out.signal = pg_result.s;
-    pix_out.variance = pg_result.e;
+    [pg_result_s, pg_result_e] = svpair_op(pix_out.signal, pix_out.variance, varargin{:});
+    pix_out.signal = pg_result_s;
+    pix_out.variance = pg_result_e;
 
     if pix_out.has_more()
         pix_out = pix_out.advance();

--- a/horace_core/sqw/PixelData/@PixelData/do_sigvar_pair_va_op.m
+++ b/horace_core/sqw/PixelData/@PixelData/do_sigvar_pair_va_op.m
@@ -1,0 +1,30 @@
+function pix_out = do_sigvar_pair_va_op(obj, svpair_op, varargin)
+% Perform a "sigvarpair" operation on this object's signal and variance
+% arrays, input separately and with additional input varargs
+%
+% Input:
+% -----
+% svpair_op   Function handle pointing to the operation to perform. This
+%             operation should take a sigvar object as an argument.
+% varargs     Variable final arguments according to svpair_op needs.
+%
+if nargout == 1
+    % Only do a copy if a return argument exists, otherwise perform the
+    % operation on obj
+    pix_out = copy(obj);
+else
+    pix_out = obj;
+end
+
+pix_out.move_to_first_page();
+while true
+    pg_result = svpair_op(pix_out.signal, pix_out.variance, varargin{:});
+    pix_out.signal = pg_result.s;
+    pix_out.variance = pg_result.e;
+
+    if pix_out.has_more()
+        pix_out = pix_out.advance();
+    else
+        break;
+    end
+end


### PR DESCRIPTION
Comparing the existing commit for unitary operators in https://github.com/pace-neutrons/Horace/pull/299/commits/2c7af694929dc8cafb2fee648cff35685a10173c, this PR attempts to do the same thing with noisify.m in sqw\@sqw.

noisify.m is modified in line with unary_op_manager.m to replace the call within the loop over elements of w to noisify (this is the Herbert overload of noisify with separate arguments for signal and variance and additional varargin.) As unary_op and do_unary_op do not currently support varargin and as unary_op currently works by using the parent object for signal and variance as their source, these cannot presently be used without modification.

Options appear to be : 
- add varargin to the above unary_op functions; modify the Herbert noisify to accept a single whole object argument while providing a mechanism to disambiguate the overload from the other (arg, varargin) overloads of noisify.
- make an alternative to do_unary_op which does support the current Herbert 3-arg version of noisify.
I have chosen the second option for simplicity - I do not want to start digging into Herbert or finding out how to manage the overload.

The present commit is draft and for review; please could you comment on whether this is a good idea and what misunderstanding there might be in it.

I note I have left off a semi-colon in noisify.m.
