### PR TITLE
Fix missing return in Jenkinsfile

### DIFF
--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -68,7 +68,7 @@ def get_default_herbert_branch(String job_name) {
           return ''
 
       case 'Nightly':
-        'None'
+        return 'None'
 
       default:
           return 'master'


### PR DESCRIPTION
This was causing a null value to be set as the default Herbert branch for the nightly builds.