### PR TITLE
Do not default to Visual Studio 2017 in build.ps1

### DIFF
--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -41,7 +41,8 @@ param (
 
   # The version of Visual Studio to build with. Other Windows compilers are
   # not supported by this script. {2015, 2017, 2019}
-  # [default: 0 (use latest installed version)]
+  # [default: use latest installed version or, if rebuilding, the version used
+  # in the previous build]
   [int][ValidateSet(2015, 2017, 2019)]
   [Alias("VS")]
   $vs_version = 0,

--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -40,10 +40,11 @@ param (
   [switch][Alias("h")]$help,
 
   # The version of Visual Studio to build with. Other Windows compilers are
-  # not supported by this script. {2015, 2017, 2019} [default: 2017]
+  # not supported by this script. {2015, 2017, 2019}
+  # [default: 0 (use latest found version)]
   [int][ValidateSet(2015, 2017, 2019)]
   [Alias("VS")]
-  $vs_version = 2017,
+  $vs_version = 0,
 
   # Whether to build the Horace C++ tests and enable testing via CTest.
   # This must be "ON" in order to run tests with this script. {ON, OFF} [default: ON]
@@ -117,10 +118,11 @@ function New-Build-Directory {
 function New-CMake-Generator-Command {
   param([int]$vs_version)
   $cmake_generator = "$($VS_VERSION_MAP[$vs_version])"
-  if ($vs_version -eq '2019') {
+  if ($vs_version -eq 0) {
+    $generator_cmd = ""
+  } elseif ($vs_version -ge 2019) {
     $generator_cmd += "-G ""$cmake_generator"" -A x64"
-  }
-  else {
+  } else {
     $generator_cmd += "-G ""$cmake_generator Win64"""
   }
   return $generator_cmd

--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -41,7 +41,7 @@ param (
 
   # The version of Visual Studio to build with. Other Windows compilers are
   # not supported by this script. {2015, 2017, 2019}
-  # [default: 0 (use latest found version)]
+  # [default: 0 (use latest installed version)]
   [int][ValidateSet(2015, 2017, 2019)]
   [Alias("VS")]
   $vs_version = 0,
@@ -121,9 +121,9 @@ function New-CMake-Generator-Command {
   if ($vs_version -eq 0) {
     $generator_cmd = ""
   } elseif ($vs_version -ge 2019) {
-    $generator_cmd += "-G ""$cmake_generator"" -A x64"
+    $generator_cmd = "-G ""$cmake_generator"" -A x64"
   } else {
-    $generator_cmd += "-G ""$cmake_generator Win64"""
+    $generator_cmd = "-G ""$cmake_generator Win64"""
   }
   return $generator_cmd
 }


### PR DESCRIPTION
Allow CMake to pick the default compiler, this will be the most up-to-date Visual Studio on the system. The script still allows one to
specify a specific Visual Studio version

This was causing issues when attempting to use the build script to re-build targets originally build with Visual Studio 2019. The script
would default to attempting to rebuild with 2017, which would upset CMake and cause an error.

Fixes #356 