### PR TITLE
Increase default pixel page size setting

### DIFF
--- a/horace_core/configuration/@hor_config/hor_config.m
+++ b/horace_core/configuration/@hor_config/hor_config.m
@@ -100,7 +100,7 @@ classdef hor_config < config_base
     properties(Access=protected, Hidden=true)
         % private properties behind public interface
         mem_chunk_size_ = 10000000;
-        pixel_page_size_ = 3e9;  % default is 3GB
+        pixel_page_size_ = floor(realmax);  % we never want to page at the moment
         threads_ =1;
 
         ignore_nan_ = true;

--- a/horace_core/configuration/@hor_config/hor_config.m
+++ b/horace_core/configuration/@hor_config/hor_config.m
@@ -100,7 +100,10 @@ classdef hor_config < config_base
     properties(Access=protected, Hidden=true)
         % private properties behind public interface
         mem_chunk_size_ = 10000000;
-        pixel_page_size_ = floor(realmax);  % we never want to page at the moment
+
+        % set page size very large to effectively disable paging of pixels as
+        % the implementation is not complete
+        pixel_page_size_ = floor(realmax);
         threads_ =1;
 
         ignore_nan_ = true;


### PR DESCRIPTION
Since many operations still have not been adapted for file-backed data, this value should be as high as possible such that we're not paging any data for the time being.

Fixes #406 