### PR TITLE
Write ADR for pixel data absolute/relative indexing

### DIFF
--- a/documentation/adr/0016-use-double-array-in-memory-for-pixel-data.md
+++ b/documentation/adr/0016-use-double-array-in-memory-for-pixel-data.md
@@ -13,7 +13,8 @@ Accepted
 
 Pixel data will be stored on disk as single precision (float32) data.
 
-MATLAB's default numeric data type is `double` (float64). Mixing `single` and `double` data in calculations typically produces as `single` result.
+MATLAB's default numeric data type is `double` (float64).
+Mixing `single` and `double` data in calculations produces a `single` result.
 
 Options are to:
 

--- a/documentation/adr/0016-use-double-array-in-memory-for-pixel-data.md
+++ b/documentation/adr/0016-use-double-array-in-memory-for-pixel-data.md
@@ -1,4 +1,5 @@
-[<-previous](0015-store-pixel-data-in-single-precision.md) | next->
+[<-previous](0015-store-pixel-data-in-single-precision.md) |
+[next->](0017-separate-absolute-and-relative-indexing-APIs-in-pixel-array.md)
 
 # 16 - Use double array for in-memory Pixel data
 
@@ -26,15 +27,11 @@ Significant performance improvements can be seen in some algorithms when perform
 
 Pixel binning is performed in both the MATLAB and C++ code. These routines do not create a consistent binning resulting from rounding errors in calculated data.
 
-
-
 ## Decision
 
-Pixel data will stored internally as an array of MATLAB doubles and converted on read or write. 
+Pixel data will stored internally as an array of MATLAB doubles and converted on read or write.
 
 Access to the data through the PixelData class API will return `double` values.
-
- 
 
 ## Consequences
 
@@ -43,4 +40,3 @@ Access to the data through the PixelData class API will return `double` values.
 - Calculated data values will be truncated when written to file.
 - The recomputation of pixel coordinates by different routines in `TobyFit` and `gen_sqw` means rounding errors may result in pixels to be binned differently -- these differences should be considered and if possible eliminated.
 - There is no requirement to maintain `single` and `double` precision implementations of most toolkit functions.
-

--- a/documentation/adr/0016-use-double-array-in-memory-for-pixel-data.md
+++ b/documentation/adr/0016-use-double-array-in-memory-for-pixel-data.md
@@ -25,7 +25,8 @@ Long chains of function calls are executed within some algorithms (e.g. TobyFit)
 
 Significant performance improvements can be seen in some algorithms when performed on `single` precision rather than `double` data..
 
-Pixel binning is performed in both the MATLAB and C++ code. These routines do not create a consistent binning resulting from rounding errors in calculated data.
+Pixel binning can be performed in both MATLAB and C++ code.
+The two routines can result in inconsistent binning due to rounding errors.
 
 ## Decision
 

--- a/documentation/adr/0017-separate-absolute-and-relative-indexing-APIs-in-pixel-array.md
+++ b/documentation/adr/0017-separate-absolute-and-relative-indexing-APIs-in-pixel-array.md
@@ -43,7 +43,7 @@ these APIs distinguish between the two types of indexing.
     Similarly, to retrieve a range of data from particular pixel array fields:
 
     ```matlab
-    pixels.get_data(100:200, {'signal', 'variance'})
+    pixels.get_data({'signal', 'variance'}, 100:200)
     ```
 
     At time of writing, there are no plans to implement similar `set_`

--- a/documentation/adr/0017-separate-absolute-and-relative-indexing-APIs-in-pixel-array.md
+++ b/documentation/adr/0017-separate-absolute-and-relative-indexing-APIs-in-pixel-array.md
@@ -46,6 +46,17 @@ these APIs distinguish between the two types of indexing.
     pixels.get_data(100:200, {'signal', 'variance'})
     ```
 
+    At time of writing, there are no plans to implement similar `set_`
+    methods with absolute indexing.
+    If there becomes a requirement for setters with absolute indexing,
+    these should follow a similar syntax.
+    For example, the following should set signal and variance from absolute
+    index 100 to 200, to zero:
+
+    ```matlab
+    set_data({'signal', 'variance'}, 100:200, zeros(2, 101));
+    ```
+
 2. **Perform relative indexing using attribute:**
 
     Obtaining pixel data using an attribute will return just the data for the
@@ -56,6 +67,15 @@ these APIs distinguish between the two types of indexing.
 
     ```matlab
     pixels.signal(10:20)
+    ```
+
+    Setting of pixel data will be possible using attributes and relative
+    indexing.
+    For example the following will set pixels 1 to 20 on the current page to
+    zero:
+
+    ```matlab
+    pixels.signal(1:20) = 0
     ```
 
 ## Consequences

--- a/documentation/adr/0017-separate-absolute-and-relative-indexing-APIs-in-pixel-array.md
+++ b/documentation/adr/0017-separate-absolute-and-relative-indexing-APIs-in-pixel-array.md
@@ -87,4 +87,5 @@ This should be done through documentation.
 - When using attributes (e.g. `.signal`),
 it should usually be accompanied by a `while has_more()` loop,
 looping through pages.
-The `get_` methods however, will usually not require a `while` loop.
+At the point of calling a `get_` method,
+a `while has_more()` loop will usually not be necessary.

--- a/documentation/adr/0017-separate-absolute-and-relative-indexing-APIs-in-pixel-array.md
+++ b/documentation/adr/0017-separate-absolute-and-relative-indexing-APIs-in-pixel-array.md
@@ -1,0 +1,70 @@
+[<-previous](./0016-use-double-array-in-memory-for-pixel-data.md) |
+next->
+
+# 17 - Separate absolute and relative indexing APIs in pixel array
+
+Date: 2020-Oct-15
+
+## Status
+
+Accepted
+
+## Context
+
+The pixel array within an SQW object can be too large to fit into memory.
+To avoid running out of memory, the object holding the pixel array can be
+file-backed.
+This means that only a "page" of the pixel array is loaded into memory at any
+one time.
+
+Therefore two possible ways to index into the pixel array exist:
+
+1. **Absolute index**:
+_The position of the pixel in the full, file-backed, pixel array_.
+
+2. **Relative index**:
+_The position of the pixel in the currently loaded page of pixel data._
+
+## Decision
+
+There will be two separate APIs for accessing data,
+these APIs distinguish between the two types of indexing.
+
+1. **Perform absolute indexing  using `get_` methods:**
+
+    Obtaining a subset of pixels or pixel data by absolute index will be
+    possible using a `get_` method.
+    For example, the following will retrieve pixels 100-200 by absolute index:
+
+    ```matlab
+    pixels.get_pixels(100:200)
+    ```
+
+    Similarly, to retrieve a range of data from particular pixel array fields:
+
+    ```matlab
+    pixels.get_data(100:200, {'signal', 'variance'})
+    ```
+
+2. **Perform relative indexing using attribute:**
+
+    Obtaining pixel data using an attribute will return just the data for the
+    currently cached page.
+    Hence, indexing into these attributes will be relative.
+    For example, the following will retrieve the signal values of pixels 10-20
+    in the currently cached page:
+
+    ```matlab
+    pixels.signal(10:20)
+    ```
+
+## Consequences
+
+- Users and developers will need to be made aware of the distinction between
+the two methods of indexing.
+This should be done through documentation.
+
+- When using attributes (e.g. `.signal`),
+it should usually be accompanied by a `while has_more()` loop,
+looping through pages.
+The `get_` methods however, will usually not require a `while` loop.


### PR DESCRIPTION
Adds an ARD record for the decisions made r.e. absolute/relative indexing into an SQW object's pixel array.

Fixes #408 