### PR TITLE
Make PixelData.get_pixels retrieve data using absolute index

### DIFF
--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1171,35 +1171,22 @@ methods
         assertEqual(pix_chunk.data, concatenate_pixel_pages(pix));
     end
 
-    % function test_get_abs_pix_range_throws_if_end_idx_lt_start_idx(~)
-    %     pix = PixelData();
-    %     f = @() pix.get_abs_pix_range(10, 9);
-    %     assertExceptionThrown(f, 'PIXELDATA:get_abs_pix_range');
-    % end
-
-    % function test_get_abs_pix_range_throws_invalid_arg_if_args_not_int_gt_0(~)
-    %     pix = PixelData();
-    %     f = @() pix.get_abs_pix_range(1.5, 10);
-    %     assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
-    % end
-
-    function test_get_abs_pix_range_pages_pixels_if_page_size_is_exceeded(obj)
+    function test_get_abs_pix_range_reorders_output_according_to_indices(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
         npix_in_page = 11;
-
-        config_cleanup = set_temporary_config_options(...
-            hor_config(), 'pixel_page_size', obj.BYTES_IN_PIXEL*npix_in_page);
-
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix_chunk = pix.get_abs_pix_range(2:num_pix - 1);
 
-        assertTrue(pix_chunk.page_size < pix_chunk.num_pixels);
+        rand_order = randperm(num_pix);
+        pix_out = pix.get_abs_pix_range(rand_order);
 
-        raw_original_pix = concatenate_pixel_pages(pix);
-        raw_pix_chunk = concatenate_pixel_pages(pix_chunk);
-        assertElementsAlmostEqual(...
-            raw_pix_chunk, raw_original_pix(:, 2:num_pix - 1), 'relative', 1e-7);
+        assertEqual(pix_out.data, data(:, rand_order));
+    end
+
+    function test_get_abs_pix_range_throws_invalid_arg_if_indices_not_vector(~)
+        pix = PixelData();
+        f = @() pix.get_abs_pix_range(ones(2, 2));
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
     end
 
     % -- Helpers --

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1200,6 +1200,40 @@ methods
         assertExceptionThrown(f, 'PIXELDATA:get_abs_pix_range');
     end
 
+    function test_get_abs_pix_range_throws_if_an_idx_lt_1_with_paged_pix(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        idx_array = -1:20;
+        f = @() pix.get_abs_pix_range(idx_array);
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+    end
+
+    function test_paged_pix_get_abs_pix_range_can_be_called_with_a_logical(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        logical_array = logical(randi([0, 1], [1, 10]));
+        pix_out = pix.get_abs_pix_range(logical_array);
+
+        assertEqual(pix_out.data, data(:, logical_array));
+    end
+
+    function test_in_mem_pix_get_abs_pix_range_can_be_called_with_a_logical(obj)
+        num_pix = 30;
+        pix = PixelData(rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix));
+
+        logical_array = logical(randi([0, 1], [1, 10]));
+        pix_out = pix.get_abs_pix_range(logical_array);
+
+        assertEqual(pix_out.data, pix.data(:, logical_array));
+    end
+
+
     % -- Helpers --
     function pix = get_pix_with_fake_faccess(obj, data, npix_in_page)
         faccess = FakeFAccess(data);

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1113,6 +1113,22 @@ methods
         assertExceptionThrown(f, 'PIXELDATA:validate_mem_alloc');
     end
 
+    function test_move_to_page_loads_given_page_into_memory(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+
+        npix_in_page = 9;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        for pg_num = [2, 4, 3, 1]
+            pg_idx_start = (pg_num - 1)*npix_in_page + 1;
+            pg_idx_end = min(pg_num*npix_in_page, num_pix);
+
+            pix.move_to_page(pg_num);
+            assertEqual(pix.data, data(:, pg_idx_start:pg_idx_end));
+        end
+    end
+
     % -- Helpers --
     function pix = get_pix_with_fake_faccess(obj, data, npix_in_page)
         faccess = FakeFAccess(data);

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1139,7 +1139,7 @@ methods
         end_idx = 23;
 
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix_chunk = pix.get_abs_pix_range(start_idx, end_idx);
+        pix_chunk = pix.get_abs_pix_range(start_idx:end_idx);
 
         assertEqual(pix_chunk.data, data(:, start_idx:end_idx));
     end
@@ -1150,13 +1150,13 @@ methods
         npix_in_page = 10;
 
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix_chunk1 = pix.get_abs_pix_range(1, 3);
+        pix_chunk1 = pix.get_abs_pix_range(1:3);
         assertEqual(pix_chunk1.data, data(:, 1:3));
 
-        pix_chunk2 = pix.get_abs_pix_range(20, 20);
+        pix_chunk2 = pix.get_abs_pix_range(20);
         assertEqual(pix_chunk2.data, data(:, 20));
 
-        pix_chunk3 = pix.get_abs_pix_range(1, 1);
+        pix_chunk3 = pix.get_abs_pix_range(1:1);
         assertEqual(pix_chunk3.data, data(:, 1));
     end
 
@@ -1166,22 +1166,22 @@ methods
         npix_in_page = 11;
 
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix_chunk = pix.get_abs_pix_range(1, num_pix);
+        pix_chunk = pix.get_abs_pix_range(1:num_pix);
 
         assertEqual(pix_chunk.data, concatenate_pixel_pages(pix));
     end
 
-    function test_get_abs_pix_range_throws_if_end_idx_lt_start_idx(~)
-        pix = PixelData();
-        f = @() pix.get_abs_pix_range(10, 9);
-        assertExceptionThrown(f, 'PIXELDATA:get_abs_pix_range');
-    end
+    % function test_get_abs_pix_range_throws_if_end_idx_lt_start_idx(~)
+    %     pix = PixelData();
+    %     f = @() pix.get_abs_pix_range(10, 9);
+    %     assertExceptionThrown(f, 'PIXELDATA:get_abs_pix_range');
+    % end
 
-    function test_get_abs_pix_range_throws_invalid_arg_if_args_not_int_gt_0(~)
-        pix = PixelData();
-        f = @() pix.get_abs_pix_range(1.5, 10);
-        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
-    end
+    % function test_get_abs_pix_range_throws_invalid_arg_if_args_not_int_gt_0(~)
+    %     pix = PixelData();
+    %     f = @() pix.get_abs_pix_range(1.5, 10);
+    %     assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+    % end
 
     function test_get_abs_pix_range_pages_pixels_if_page_size_is_exceeded(obj)
         num_pix = 30;
@@ -1192,7 +1192,7 @@ methods
             hor_config(), 'pixel_page_size', obj.BYTES_IN_PIXEL*npix_in_page);
 
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix_chunk = pix.get_abs_pix_range(2, num_pix - 1);
+        pix_chunk = pix.get_abs_pix_range(2:num_pix - 1);
 
         assertTrue(pix_chunk.page_size < pix_chunk.num_pixels);
 

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1130,7 +1130,7 @@ methods
         end
     end
 
-    function test_get_abs_pix_range_retrieves_data_at_absolute_index(obj)
+    function test_get_pixels_retrieves_data_at_absolute_index(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
         npix_in_page = 11;
@@ -1139,108 +1139,108 @@ methods
         end_idx = 23;
 
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix_chunk = pix.get_abs_pix_range(start_idx:end_idx);
+        pix_chunk = pix.get_pixels(start_idx:end_idx);
 
         assertEqual(pix_chunk.data, data(:, start_idx:end_idx));
     end
 
-    function test_get_abs_pix_range_retrieves_correct_data_at_page_boundary(obj)
+    function test_get_pixels_retrieves_correct_data_at_page_boundary(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
         npix_in_page = 10;
 
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix_chunk1 = pix.get_abs_pix_range(1:3);
+        pix_chunk1 = pix.get_pixels(1:3);
         assertEqual(pix_chunk1.data, data(:, 1:3));
 
-        pix_chunk2 = pix.get_abs_pix_range(20);
+        pix_chunk2 = pix.get_pixels(20);
         assertEqual(pix_chunk2.data, data(:, 20));
 
-        pix_chunk3 = pix.get_abs_pix_range(1:1);
+        pix_chunk3 = pix.get_pixels(1:1);
         assertEqual(pix_chunk3.data, data(:, 1));
     end
 
-    function test_get_abs_pix_range_gets_all_data_if_full_range_requested(obj)
+    function test_get_pixels_gets_all_data_if_full_range_requested(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
         npix_in_page = 11;
 
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix_chunk = pix.get_abs_pix_range(1:num_pix);
+        pix_chunk = pix.get_pixels(1:num_pix);
 
         assertEqual(pix_chunk.data, concatenate_pixel_pages(pix));
     end
 
-    function test_get_abs_pix_range_reorders_output_according_to_indices(obj)
+    function test_get_pixels_reorders_output_according_to_indices(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
         npix_in_page = 11;
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
 
         rand_order = randperm(num_pix);
-        pix_out = pix.get_abs_pix_range(rand_order);
+        pix_out = pix.get_pixels(rand_order);
 
         assertEqual(pix_out.data, data(:, rand_order));
     end
 
-    function test_get_abs_pix_range_throws_invalid_arg_if_indices_not_vector(~)
+    function test_get_pixels_throws_invalid_arg_if_indices_not_vector(~)
         pix = PixelData();
-        f = @() pix.get_abs_pix_range(ones(2, 2));
+        f = @() pix.get_pixels(ones(2, 2));
         assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
     end
 
-    function test_get_abs_pix_range_throws_if_range_out_of_bounds(obj)
+    function test_get_pixels_throws_if_range_out_of_bounds(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
         npix_in_page = 11;
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
 
         idx_array = 25:35;
-        f = @() pix.get_abs_pix_range(idx_array);
-        assertExceptionThrown(f, 'PIXELDATA:get_abs_pix_range');
+        f = @() pix.get_pixels(idx_array);
+        assertExceptionThrown(f, 'PIXELDATA:get_pixels');
     end
 
-    function test_get_abs_pix_range_throws_if_an_idx_lt_1_with_paged_pix(obj)
+    function test_get_pixels_throws_if_an_idx_lt_1_with_paged_pix(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
         npix_in_page = 11;
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
 
         idx_array = -1:20;
-        f = @() pix.get_abs_pix_range(idx_array);
+        f = @() pix.get_pixels(idx_array);
         assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
     end
 
-    function test_get_abs_pix_range_throws_if_indices_not_positive_int(~)
+    function test_get_pixels_throws_if_indices_not_positive_int(~)
         pix = PixelData();
         idx_array = 1:0.1:5;
-        f = @() pix.get_abs_pix_range(idx_array);
+        f = @() pix.get_pixels(idx_array);
         assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
     end
 
-    function test_paged_pix_get_abs_pix_range_can_be_called_with_a_logical(obj)
+    function test_paged_pix_get_pixels_can_be_called_with_a_logical(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
         npix_in_page = 11;
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
 
         logical_array = logical(randi([0, 1], [1, 10]));
-        pix_out = pix.get_abs_pix_range(logical_array);
+        pix_out = pix.get_pixels(logical_array);
 
         assertEqual(pix_out.data, data(:, logical_array));
     end
 
-    function test_in_mem_pix_get_abs_pix_range_can_be_called_with_a_logical(~)
+    function test_in_mem_pix_get_pixels_can_be_called_with_a_logical(~)
         num_pix = 30;
         pix = PixelData(rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix));
 
         logical_array = logical(randi([0, 1], [1, 10]));
-        pix_out = pix.get_abs_pix_range(logical_array);
+        pix_out = pix.get_pixels(logical_array);
 
         assertEqual(pix_out.data, pix.data(:, logical_array));
     end
 
-    function test_get_abs_pix_range_can_handle_repeated_indices(obj)
+    function test_get_pixels_can_handle_repeated_indices(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
         npix_in_page = 11;
@@ -1248,7 +1248,7 @@ methods
 
         idx_array = cat(2, randperm(num_pix), randperm(num_pix));
 
-        pix_chunk = pix.get_abs_pix_range(idx_array);
+        pix_chunk = pix.get_pixels(idx_array);
         assertEqual(pix_chunk.data, data(:, idx_array));
     end
 

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -487,7 +487,7 @@ methods
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
 
         f = @() obj.advance_pix(pix, floor(npix/npix_in_page + 1));
-        assertExceptionThrown(f, 'PIXELDATA:advance')
+        assertExceptionThrown(f, 'PIXELDATA:move_to_page')
     end
 
     function test_advance_does_nothing_if_PixelData_not_file_backed(~)

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1130,6 +1130,54 @@ methods
         end
     end
 
+    function test_move_to_page_throws_if_arg_exceeds_number_of_pages(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        f = @() pix.move_to_page(ceil(num_pix/npix_in_page) + 1);
+        assertExceptionThrown(f, 'PIXELDATA:move_to_page');
+    end
+
+    function test_move_to_page_throws_if_arg_less_than_1(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        f = @() pix.move_to_page(0);
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+
+        f = @() pix.move_to_page(-1);
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+    end
+
+    function test_move_to_page_throws_if_arg_is_non_scalar(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        f = @() pix.move_to_page([1, 2]);
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+    end
+
+    function test_move_to_page_throws_if_arg_is_not_an_int(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        f = @() pix.move_to_page(1.5);
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+    end
+
+
     function test_get_pixels_retrieves_data_at_absolute_index(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1284,6 +1284,30 @@ methods
         assertEqual(pix_out.data, data(:, logical_array));
     end
 
+    function test_get_pixels_throws_if_logical_1_index_out_of_range(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        logical_array = cat(2, logical(randi([0, 1], [1, num_pix])), true);
+        f = @() pix.get_pixels(logical_array);
+
+        assertExceptionThrown(f, 'PIXELDATA:get_pixels');
+    end
+
+    function test_get_pixels_ignores_out_of_range_logical_0_indices(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        logical_array = cat(2, logical(randi([0, 1], [1, num_pix])), false);
+        pix_out = pix.get_pixels(logical_array);
+
+        assertEqual(pix_out.data, data(:, logical_array));
+    end
+
     function test_in_mem_pix_get_pixels_can_be_called_with_a_logical(~)
         num_pix = 30;
         pix = PixelData(rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix));

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1129,6 +1129,59 @@ methods
         end
     end
 
+    function test_get_abs_pix_range_retrieves_data_at_absolute_index(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+
+        start_idx = 9;
+        end_idx = 23;
+
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+        pix_chunk = pix.get_abs_pix_range(start_idx, end_idx);
+
+        assertEqual(pix_chunk.data, data(:, start_idx:end_idx));
+    end
+
+    function test_get_abs_pix_range_retrieves_correct_data_at_page_boundary(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 10;
+
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+        pix_chunk1 = pix.get_abs_pix_range(1, 3);
+        assertEqual(pix_chunk1.data, data(:, 1:3));
+
+        pix_chunk2 = pix.get_abs_pix_range(20, 20);
+        assertEqual(pix_chunk2.data, data(:, 20));
+
+        pix_chunk3 = pix.get_abs_pix_range(1, 1);
+        assertEqual(pix_chunk3.data, data(:, 1));
+    end
+
+    function test_get_abs_pix_range_gets_all_data_if_full_range_requested(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+        pix_chunk = pix.get_abs_pix_range(1, num_pix);
+
+        assertEqual(pix_chunk.data, concatenate_pixel_pages(pix));
+    end
+
+    function test_get_abs_pix_range_throws_if_end_idx_lt_start_idx(~)
+        pix = PixelData();
+        f = @() pix.get_abs_pix_range(10, 9);
+        assertExceptionThrown(f, 'PIXELDATA:get_abs_pix_range');
+    end
+
+    function test_get_abs_pix_range_throws_invalid_arg_if_args_not_int_gt_0(~)
+        pix = PixelData();
+        f = @() pix.get_abs_pix_range(1.5, 10);
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+    end
+
     % -- Helpers --
     function pix = get_pix_with_fake_faccess(obj, data, npix_in_page)
         faccess = FakeFAccess(data);

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1300,6 +1300,22 @@ methods
         assertEqual(pix_chunk.data, data(:, idx_array));
     end
 
+    function test_pg_size_is_correct_after_advance(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        assertEqual(pix.page_size, npix_in_page);
+
+        pix.advance();
+        assertEqual(pix.page_size, npix_in_page);
+
+        pix.advance();
+        num_pix_in_final_pg = 8;
+        assertEqual(pix.page_size, num_pix_in_final_pg);
+    end
+
     % -- Helpers --
     function pix = get_pix_with_fake_faccess(obj, data, npix_in_page)
         faccess = FakeFAccess(data);

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1259,6 +1259,12 @@ methods
         assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
     end
 
+    function test_get_pixels_throws_if_an_idx_lt_1_with_in_memory_pix(obj)
+        in_mem_pix = PixelData(5);
+        f = @() in_mem_pix.get_pixels(-1:3);
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+    end
+
     function test_get_pixels_throws_if_indices_not_positive_int(~)
         pix = PixelData();
         idx_array = 1:0.1:5;

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1189,6 +1189,17 @@ methods
         assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
     end
 
+    function test_get_abs_pix_range_throws_if_range_out_of_bounds(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        idx_array = 25:35;
+        f = @() pix.get_abs_pix_range(idx_array);
+        assertExceptionThrown(f, 'PIXELDATA:get_abs_pix_range');
+    end
+
     % -- Helpers --
     function pix = get_pix_with_fake_faccess(obj, data, npix_in_page)
         faccess = FakeFAccess(data);

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1330,7 +1330,7 @@ methods
         assertEqual(pix_chunk.data, data(:, idx_array));
     end
 
-    function test_pg_size_is_correct_after_advance(obj)
+    function test_pg_size_reports_size_of_partially_filled_pg_after_advance(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
         npix_in_page = 11;

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1230,7 +1230,7 @@ methods
         assertEqual(pix_out.data, data(:, logical_array));
     end
 
-    function test_in_mem_pix_get_abs_pix_range_can_be_called_with_a_logical(obj)
+    function test_in_mem_pix_get_abs_pix_range_can_be_called_with_a_logical(~)
         num_pix = 30;
         pix = PixelData(rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix));
 
@@ -1240,6 +1240,17 @@ methods
         assertEqual(pix_out.data, pix.data(:, logical_array));
     end
 
+    function test_get_abs_pix_range_can_handle_repeated_indices(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        idx_array = cat(2, randperm(num_pix), randperm(num_pix));
+
+        pix_chunk = pix.get_abs_pix_range(idx_array);
+        assertEqual(pix_chunk.data, data(:, idx_array));
+    end
 
     % -- Helpers --
     function pix = get_pix_with_fake_faccess(obj, data, npix_in_page)

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1226,9 +1226,10 @@ methods
         pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
 
         rand_order = randperm(num_pix);
+        shuffled_pix = data(:, rand_order);
         pix_out = pix.get_pixels(rand_order);
 
-        assertEqual(pix_out.data, data(:, rand_order));
+        assertEqual(pix_out.data, shuffled_pix);
     end
 
     function test_get_pixels_throws_invalid_arg_if_indices_not_vector(~)

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -1211,6 +1211,13 @@ methods
         assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
     end
 
+    function test_get_abs_pix_range_throws_if_indices_not_positive_int(~)
+        pix = PixelData();
+        idx_array = 1:0.1:5;
+        f = @() pix.get_abs_pix_range(idx_array);
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+    end
+
     function test_paged_pix_get_abs_pix_range_can_be_called_with_a_logical(obj)
         num_pix = 30;
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -229,6 +229,7 @@ methods
     pix_out = append(obj, pix);
     pix_out = mask(obj, mask_array, npix);
     pix_out = get_pixels(obj, pix_indices);
+    obj = move_to_page(obj, page_number);
 
     function obj = PixelData(arg, mem_alloc)
         % Construct a PixelData object from the given data. Default
@@ -462,7 +463,7 @@ methods
                 obj.write_dirty_page_();
             end
             try
-                obj.move_to_page(obj.page_number_ + 1);
+                obj = obj.move_to_page(obj.page_number_ + 1);
             catch ME
                 switch ME.identifier
                 case 'PIXELDATA:load_page_'
@@ -482,26 +483,6 @@ methods
         %  This function does nothing if pixels are not file-backed.
         %
         obj.move_to_page(1);
-    end
-
-    function obj = move_to_page(obj, page_number)
-        % Set the object to point at the given page number
-        %   This function does nothing if the object is not file-backed or is
-        %   already on the given page
-        %
-        if obj.is_file_backed_() && obj.page_number_ ~= page_number
-            if page_number > obj.get_num_pages_
-                error('PIXELDATA:move_to_page', ...
-                      'Cannot advance to page %i only %i pages of data found.', ...
-                      page_number, obj.get_num_pages_);
-            end
-            if obj.page_is_dirty_(obj.page_number_) && obj.dirty_page_edited_
-                obj.write_dirty_page_();
-            end
-            obj.page_number_ = page_number;
-            obj.dirty_page_edited_ = false;
-            obj.data_ = zeros(obj.PIXEL_BLOCK_COLS_, 0);
-        end
     end
 
     % --- Getters / Setters ---

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -667,7 +667,14 @@ methods
         if obj.num_pixels > 0 && obj.cache_is_empty_()
             % No pixels currently loaded, show the number that will be loaded
             % when a getter is called
-            page_size = min(obj.get_max_page_size_(), obj.num_pixels);
+            base_pg_size = obj.max_page_size_;
+            if base_pg_size*obj.page_number_ > obj.num_pixels
+                % In this case we're on the final page and there are fewer
+                % lefotver pixels than would be in a full-size page
+                page_size = obj.num_pixels - base_pg_size*(obj.page_number_ - 1);
+            else
+                page_size = min(base_pg_size, obj.num_pixels);
+            end
         else
             page_size = size(obj.data_, 2);
         end

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -496,11 +496,19 @@ methods
         % and clear the current cache
         %  This function does nothing if pixels are not file-backed.
         %
-        if obj.is_file_backed_() && obj.page_number_ ~= 1
+        obj.move_to_page(1);
+    end
+
+    function obj = move_to_page(obj, page_number)
+        % Set the object to point at the given page number
+        %   This function does nothing if the object is not file-backed or is
+        %   already on the given page
+        %
+        if obj.is_file_backed_() && obj.page_number_ ~= page_number
             if obj.page_is_dirty_(obj.page_number_) && obj.dirty_page_edited_
                 obj.write_dirty_page_();
             end
-            obj.page_number_ = 1;
+            obj.page_number_ = page_number;
             obj.dirty_page_edited_ = false;
             obj.data_ = zeros(obj.PIXEL_BLOCK_COLS_, 0);
         end

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -228,7 +228,7 @@ methods
     pix_out = do_unary_op(obj, unary_op);
     pix_out = append(obj, pix);
     pix_out = mask(obj, mask_array, npix);
-    pix_out = get_pixels(obj, pix_indices);
+    pix_out = get_pixels(obj, abs_pix_indices);
     obj = move_to_page(obj, page_number);
 
     function obj = PixelData(arg, mem_alloc)

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -228,6 +228,7 @@ methods
     pix_out = do_unary_op(obj, unary_op);
     pix_out = append(obj, pix);
     pix_out = mask(obj, mask_array, npix);
+    pix_out = get_abs_pix_range(obj, start_idx, end_idx);
 
     function obj = PixelData(arg, mem_alloc)
         % Construct a PixelData object from the given data. Default

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -228,7 +228,7 @@ methods
     pix_out = do_unary_op(obj, unary_op);
     pix_out = append(obj, pix);
     pix_out = mask(obj, mask_array, npix);
-    pix_out = get_abs_pix_range(obj, start_idx, end_idx);
+    pix_out = get_pixels(obj, pix_indices);
 
     function obj = PixelData(arg, mem_alloc)
         % Construct a PixelData object from the given data. Default
@@ -427,22 +427,6 @@ methods
         else
             data = obj.data(field_indices, pix_indices);
         end
-    end
-
-    function pixels = get_pixels(obj, pix_indices)
-        % Retrieve the pixels at the given indices in the current page, return
-        % a new PixelData object
-        %
-        % Input:
-        % ------
-        %   pix_indices     1-D array of pixel indices to retrieve
-        %
-        % Output:
-        % -------
-        %   pixels      PixelData object containing a subset of pixels
-        %
-        obj = obj.load_current_page_if_data_empty_();
-        pixels = PixelData(obj.data(:, pix_indices));
     end
 
     function has_more = has_more(obj)

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -478,7 +478,7 @@ methods
                 obj.write_dirty_page_();
             end
             try
-                obj.load_page_(obj.page_number_ + 1);
+                obj.move_to_page(obj.page_number_ + 1);
             catch ME
                 switch ME.identifier
                 case 'PIXELDATA:load_page_'
@@ -506,6 +506,11 @@ methods
         %   already on the given page
         %
         if obj.is_file_backed_() && obj.page_number_ ~= page_number
+            if page_number > obj.get_num_pages_
+                error('PIXELDATA:move_to_page', ...
+                      'Cannot advance to page %i only %i pages of data found.', ...
+                      page_number, obj.get_num_pages_);
+            end
             if obj.page_is_dirty_(obj.page_number_) && obj.dirty_page_edited_
                 obj.write_dirty_page_();
             end

--- a/horace_core/sqw/PixelData/@PixelData/get_abs_pix_range.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_abs_pix_range.m
@@ -1,9 +1,26 @@
 function pix_out = get_abs_pix_range(obj, pix_indices)
-%% GET_ABS_PIX_RANGE get the given range of pixels by absolute index into the
-% .sqw file backing the given PixelData object
+%% GET_ABS_PIX_RANGE get the given set of pixels by absolute index.
+%
+% The function attempts to mimic the behaviour you would see when indexing into
+% an Matlab array. The difference being the returned object is a PixelData
+% object and not an array.
 %
 % This function may be useful if you want to extract data for a particular
 % image bin.
+%
+% Input:
+% ------
+%   pix_indices    A vector of positive inegers or a vector of logicals.
+%                  If a vector of integers, include the pixels with those
+%                  indices, in the given order, in the returned PixelData
+%                  object.
+%                  If a vector of logicals keep pixels where the logical array
+%                  index is 1 and remove pixels where it's 0.
+%
+% Output:
+% -------
+%   pix_out        Another PixelData object containing only the pixels
+%                  specified in the pix_indices argument.
 %
 pix_indices = parse_args(pix_indices);
 

--- a/horace_core/sqw/PixelData/@PixelData/get_abs_pix_range.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_abs_pix_range.m
@@ -20,7 +20,7 @@ try
             pix_out.data(:, global_idxs) = obj.data(:, pg_idxs);
         end
     else
-        pix_out = obj.data(:, pix_indices);
+        pix_out = PixelData(obj.data(:, pix_indices));
     end
 catch ME
     switch ME.identifier
@@ -39,10 +39,17 @@ end  % function
 % -----------------------------------------------------------------------------
 function pix_indices = parse_args(varargin)
     parser = inputParser();
-    parser.addRequired('pix_indices', @isvector);
+    parser.addRequired('pix_indices', @is_positive_int_vector_or_logical_vector);
     parser.parse(varargin{:});
 
     pix_indices = parser.Results.pix_indices;
+    if islogical(pix_indices)
+        pix_indices = find(pix_indices);
+    end
+end
+
+function is = is_positive_int_vector_or_logical_vector(vec)
+    is = isvector(vec) && (islogical(vec) || (all(vec > 0 & all(floor(vec) == vec))));
 end
 
 function [idx_in_pg, global_idx] = get_idxs_in_current_pg(obj, abs_indices)

--- a/horace_core/sqw/PixelData/@PixelData/get_abs_pix_range.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_abs_pix_range.m
@@ -1,58 +1,48 @@
-function pix_out = get_abs_pix_range(obj, start_idx, end_idx)
-%% GET_ABS_PIX_RANGE get the given range of pixels by absolute index into sqw
-% file backing the given PixelData object
+function pix_out = get_abs_pix_range(obj, pix_indices)
+%% GET_ABS_PIX_RANGE get the given range of pixels by absolute index into the
+% .sqw file backing the given PixelData object
 %
 % This function may be useful if you want to extract data for a particular
 % image bin.
 %
-[start_idx, end_idx] = parse_args(obj, start_idx, end_idx);
+pix_indices = parse_args(pix_indices);
 
-start_page_num = ceil(start_idx/obj.max_page_size_);
-obj.move_to_page(start_page_num);
+if obj.is_file_backed_()
+    obj.move_to_first_page();
 
-num_pix_in_range = end_idx - start_idx;
-pg_start_idx = start_idx - (obj.page_number_ - 1)*obj.max_page_size_;
-pg_end_idx = min(obj.max_page_size_, pg_start_idx + num_pix_in_range);
+    pix_out = PixelData(numel(pix_indices));
 
-leftover = (pg_start_idx + num_pix_in_range) - obj.max_page_size_;
-pix_out = obj.get_pixels(pg_start_idx:pg_end_idx);
-while leftover > 0
-    obj = obj.advance();
-
-    pg_end_idx = min(obj.max_page_size_, leftover);
-    leftover = leftover - obj.max_page_size_;
-    pix_out.append(obj.get_pixels(1:pg_end_idx));
+    [pg_idxs, global_idxs] = get_idxs_in_current_pg(obj, pix_indices);
+    pix_out.data(:, global_idxs) = obj.data(:, pg_idxs);
+    while obj.has_more()
+        obj.advance();
+        [pg_idxs, global_idxs] = get_idxs_in_current_pg(obj, pix_indices);
+        pix_out.data(:, global_idxs) = obj.data(:, pg_idxs);
+    end
+else
+    pix_out = obj.data(:, pix_indices);
 end
 
 end  % function
 
 
 % -----------------------------------------------------------------------------
-function [start_idx, end_idx] = parse_args(obj, varargin)
+function pix_indices = parse_args(varargin)
     parser = inputParser();
-    parser.addRequired('start_idx', @is_scalar_int_greater_than_zero);
-    parser.addRequired('end_idx', @is_scalar_int_greater_than_zero);
+    parser.addRequired('pix_indices', @isvector);
     parser.parse(varargin{:});
 
-    start_idx = parser.Results.start_idx;
-    end_idx = parser.Results.end_idx;
-
-    if start_idx > end_idx
-        error('PIXELDATA:get_abs_pix_range', ...
-              ['Argument ''end_idx'' cannot be larger than ''start_idx''\n' ...
-               'Found start_idx = %i and end_idx = %i.'], start_idx, end_idx);
-    end
-
-    if end_idx > obj.num_pixels
-        error('PIXELDATA:get_abs_pix_range', ...
-              ['Given end_idx exceeds the number of pixels.\nFound ' ...
-               'end_idx = %i, %i pixels in object.'], end_idx, obj.num_pixels);
-    end
+    pix_indices = parser.Results.pix_indices;
 end
 
+function [idx_in_pg, global_idx] = get_idxs_in_current_pg(obj, abs_indices)
+    % Extract the indices from abs_indices that lie within the bounds of the
+    % currently cached page of data.
+    % Get the corresponding absolute indices as well.
+    %
+    pg_start_idx = (obj.page_number_ - 1)*obj.max_page_size_ + 1;
+    pg_end_idx = pg_start_idx + obj.max_page_size_ - 1;
 
-function is = is_scalar_int_greater_than_zero(int_candidate)
-    is = isscalar(int_candidate) ...
-        && (floor(int_candidate) == int_candidate) ...
-        && int_candidate > 0;
+    global_idx = find((abs_indices >= pg_start_idx) & (abs_indices <= pg_end_idx));
+    idx_in_pg = abs_indices(global_idx) - (obj.page_number_ - 1)*obj.max_page_size_;
 end

--- a/horace_core/sqw/PixelData/@PixelData/get_abs_pix_range.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_abs_pix_range.m
@@ -1,0 +1,58 @@
+function pix_out = get_abs_pix_range(obj, start_idx, end_idx)
+%% GET_ABS_PIX_RANGE get the given range of pixels by absolute index into sqw
+% file backing the given PixelData object
+%
+% This function may be useful if you want to extract data for a particular
+% image bin.
+%
+[start_idx, end_idx] = parse_args(obj, start_idx, end_idx);
+
+start_page_num = ceil(start_idx/obj.max_page_size_);
+obj.move_to_page(start_page_num);
+
+num_pix_in_range = end_idx - start_idx;
+pg_start_idx = start_idx - (obj.page_number_ - 1)*obj.max_page_size_;
+pg_end_idx = min(obj.max_page_size_, pg_start_idx + num_pix_in_range);
+
+leftover = (pg_start_idx + num_pix_in_range) - obj.max_page_size_;
+pix_out = obj.get_pixels(pg_start_idx:pg_end_idx);
+while leftover > 0
+    obj = obj.advance();
+
+    pg_end_idx = min(obj.max_page_size_, leftover);
+    leftover = leftover - obj.max_page_size_;
+    pix_out.append(obj.get_pixels(1:pg_end_idx));
+end
+
+end  % function
+
+
+% -----------------------------------------------------------------------------
+function [start_idx, end_idx] = parse_args(obj, varargin)
+    parser = inputParser();
+    parser.addRequired('start_idx', @is_scalar_int_greater_than_zero);
+    parser.addRequired('end_idx', @is_scalar_int_greater_than_zero);
+    parser.parse(varargin{:});
+
+    start_idx = parser.Results.start_idx;
+    end_idx = parser.Results.end_idx;
+
+    if start_idx > end_idx
+        error('PIXELDATA:get_abs_pix_range', ...
+              ['Argument ''end_idx'' cannot be larger than ''start_idx''\n' ...
+               'Found start_idx = %i and end_idx = %i.'], start_idx, end_idx);
+    end
+
+    if end_idx > obj.num_pixels
+        error('PIXELDATA:get_abs_pix_range', ...
+              ['Given end_idx exceeds the number of pixels.\nFound ' ...
+               'end_idx = %i, %i pixels in object.'], end_idx, obj.num_pixels);
+    end
+end
+
+
+function is = is_scalar_int_greater_than_zero(int_candidate)
+    is = isscalar(int_candidate) ...
+        && (floor(int_candidate) == int_candidate) ...
+        && int_candidate > 0;
+end

--- a/horace_core/sqw/PixelData/@PixelData/get_pixels.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_pixels.m
@@ -60,6 +60,15 @@ function [pix_indices, max_idx] = parse_args(obj, varargin)
 
     pix_indices = parser.Results.pix_indices;
     if islogical(pix_indices)
+        if numel(pix_indices) > obj.num_pixels
+            if any(pix_indices(obj.num_pixels + 1:end))
+                error('PIXELDATA:get_pixels', ...
+                      ['The logical indices contain a true value outside of ' ...
+                       'the array bounds.']);
+            else
+                pix_indices = pix_indices(1:obj.num_pixels);
+            end
+        end
         pix_indices = find(pix_indices);
     end
 

--- a/horace_core/sqw/PixelData/@PixelData/get_pixels.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_pixels.m
@@ -1,5 +1,10 @@
-function pix_out = get_abs_pix_range(obj, pix_indices)
-%% GET_ABS_PIX_RANGE get the given set of pixels by absolute index.
+function pix_out = get_pixels(obj, pix_indices)
+% GET_PIXELS Retrieve the pixels at the given indices in the current page, return
+% a new PixelData object
+%
+%  >> pix_out = pix.get_pixels(1:100)  % retrieve pixels at index 1-100
+%
+%  >> pix_out = pix.get_pixels([1, 0, 1])
 %
 % The function attempts to mimic the behaviour you would see when indexing into
 % an Matlab array. The difference being the returned object is a PixelData
@@ -26,7 +31,7 @@ pix_indices = parse_args(pix_indices);
 
 max_idx = max(pix_indices);
 if max_idx > obj.num_pixels
-    error('PIXELDATA:get_abs_pix_range', ...
+    error('PIXELDATA:get_pixels', ...
           'Pixel index out of range. Index must not exceed %i.', ...
           obj.num_pixels);
 end

--- a/horace_core/sqw/PixelData/@PixelData/get_pixels.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_pixels.m
@@ -26,8 +26,6 @@ function pix_out = get_pixels(obj, abs_pix_indices)
 % -------
 %   pix_out        Another PixelData object containing only the pixels
 %                  specified in the abs_pix_indices argument.
-%                  This PixelData object will hold all its pixels in memory and
-%                  ignore the pixel_page_size config option.
 %
 [abs_pix_indices, max_idx] = parse_args(obj, abs_pix_indices);
 

--- a/horace_core/sqw/PixelData/@PixelData/get_pixels.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_pixels.m
@@ -29,13 +29,6 @@ function pix_out = get_pixels(obj, pix_indices)
 %
 pix_indices = parse_args(pix_indices);
 
-max_idx = max(pix_indices);
-if max_idx > obj.num_pixels
-    error('PIXELDATA:get_pixels', ...
-          'Pixel index out of range. Index must not exceed %i.', ...
-          obj.num_pixels);
-end
-
 if obj.is_file_backed_()
     first_required_page = ceil(min(pix_indices)/obj.max_page_size_);
     obj.move_to_page(first_required_page);
@@ -68,6 +61,13 @@ function pix_indices = parse_args(varargin)
     pix_indices = parser.Results.pix_indices;
     if islogical(pix_indices)
         pix_indices = find(pix_indices);
+    end
+
+    max_idx = max(pix_indices);
+    if max_idx > obj.num_pixels
+        error('PIXELDATA:get_pixels', ...
+            'Pixel index out of range. Index must not exceed %i.', ...
+            obj.num_pixels);
     end
 end
 

--- a/horace_core/sqw/PixelData/@PixelData/get_pixels.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_pixels.m
@@ -2,12 +2,12 @@ function pix_out = get_pixels(obj, abs_pix_indices)
 % GET_PIXELS Retrieve the pixels at the given indices in the current page, return
 % a new PixelData object
 %
-%  >> pix_out = pix.get_pixels(1:100)  % retrieve pixels at index 1-100
+%  >> pix_out = pix.get_pixels(1:100)  % retrieve pixels at indices 1 to 100
 %
-%  >> pix_out = pix.get_pixels([1, 0, 1])
+%  >> pix_out = pix.get_pixels([1, 0, 1])  % retrieve pixels at indices 1 and 3
 %
 % The function attempts to mimic the behaviour you would see when indexing into
-% an Matlab array. The difference being the returned object is a PixelData
+% a Matlab array. The difference being the returned object is a PixelData
 % object and not an array.
 %
 % This function may be useful if you want to extract data for a particular
@@ -26,6 +26,8 @@ function pix_out = get_pixels(obj, abs_pix_indices)
 % -------
 %   pix_out        Another PixelData object containing only the pixels
 %                  specified in the abs_pix_indices argument.
+%                  This PixelData object will hold all its pixels in memory and
+%                  ignore the pixel_page_size config option.
 %
 [abs_pix_indices, max_idx] = parse_args(obj, abs_pix_indices);
 

--- a/horace_core/sqw/PixelData/@PixelData/get_pixels.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_pixels.m
@@ -27,7 +27,7 @@ function pix_out = get_pixels(obj, pix_indices)
 %   pix_out        Another PixelData object containing only the pixels
 %                  specified in the pix_indices argument.
 %
-pix_indices = parse_args(pix_indices);
+[pix_indices, max_idx] = parse_args(obj, pix_indices);
 
 if obj.is_file_backed_()
     first_required_page = ceil(min(pix_indices)/obj.max_page_size_);
@@ -53,7 +53,7 @@ end  % function
 
 
 % -----------------------------------------------------------------------------
-function pix_indices = parse_args(varargin)
+function [pix_indices, max_idx] = parse_args(obj, varargin)
     parser = inputParser();
     parser.addRequired('pix_indices', @is_positive_int_vector_or_logical_vector);
     parser.parse(varargin{:});
@@ -71,9 +71,11 @@ function pix_indices = parse_args(varargin)
     end
 end
 
+
 function is = is_positive_int_vector_or_logical_vector(vec)
     is = isvector(vec) && (islogical(vec) || (all(vec > 0 & all(floor(vec) == vec))));
 end
+
 
 function [idx_in_pg, global_idx] = get_idxs_in_current_pg(obj, abs_indices)
     % Extract the indices from abs_indices that lie within the bounds of the

--- a/horace_core/sqw/PixelData/@PixelData/mask.m
+++ b/horace_core/sqw/PixelData/@PixelData/mask.m
@@ -46,7 +46,7 @@ if numel(mask_array) == obj.num_pixels
     if obj.is_file_backed_()
         pix_out = do_mask_file_backed_with_full_mask_array(obj, mask_array);
     else
-        pix_out = obj.get_pixels(mask_array);
+        pix_out = do_mask_in_memory_with_full_mask_array(obj, mask_array);
     end
 
 elseif ~isempty(npix)
@@ -84,7 +84,7 @@ function pix_out = do_mask_file_backed_with_full_mask_array(obj, mask_array)
         end_idx = start_idx + obj.page_size - 1;
         mask_array_chunk = mask_array(start_idx:end_idx);
 
-        pix_out.append(obj.get_pixels(mask_array_chunk));
+        pix_out.append(PixelData(obj.data(:, mask_array_chunk)));
 
         if obj.has_more()
             obj = obj.advance();
@@ -132,7 +132,7 @@ function pix_out = do_mask_file_backed_with_npix(obj, mask_array, npix)
 
         mask_array_chunk = repelem(mask_array(start_idx:end_idx), npix_chunk);
 
-        pix_out.append(obj.get_pixels(mask_array_chunk));
+        pix_out.append(PixelData(obj.data(:, mask_array_chunk)));
 
         if obj.has_more()
             obj.advance();

--- a/horace_core/sqw/PixelData/@PixelData/move_to_page.m
+++ b/horace_core/sqw/PixelData/@PixelData/move_to_page.m
@@ -1,0 +1,39 @@
+function obj = move_to_page(obj, page_number)
+% Set the object to point at the given page number
+%   This function does nothing if the object is not file-backed or is
+%   already on the given page
+%
+page_number = parse_args(obj, page_number);
+
+if obj.is_file_backed_() && obj.page_number_ ~= page_number
+
+    if obj.page_is_dirty_(obj.page_number_) && obj.dirty_page_edited_
+        obj.write_dirty_page_();
+    end
+    obj.page_number_ = page_number;
+    obj.dirty_page_edited_ = false;
+    obj.data_ = zeros(obj.PIXEL_BLOCK_COLS_, 0);
+end
+
+end
+
+
+% -----------------------------------------------------------------------------
+function page_number = parse_args(obj, varargin)
+    parser = inputParser();
+    parser.addRequired('page_number', @is_scalar_positive_int);
+    parser.parse(varargin{:});
+
+    page_number = parser.Results.page_number;
+
+    if page_number > obj.get_num_pages_
+        error('PIXELDATA:move_to_page', ...
+              'Cannot advance to page %i only %i pages of data found.', ...
+              page_number, obj.get_num_pages_);
+    end
+end
+
+
+function is = is_scalar_positive_int(number)
+    is = isscalar(number) && (number == floor(number)) && number >= 1;
+end


### PR DESCRIPTION
This PR changes the behaviour of `PixelData.get_pixels` such that it indexes into the full, file-backed, pixel array. The previous behaviour was to index the currently cached page of pixels (which may or may not have been the full array). These changes are in line with the ADR written in https://github.com/pace-neutrons/Horace/issues/409.

To aid in the new implementation of `get_pixels` I've added the `PixelData.move_to_page` method. This allows you to move to an arbitrary page of the pixel data, rather than having to call `.advance()` n times.

I've also changed the behaviour of `.advance` so that it does not immediately load the next page of pixels. The pixels are not loaded until data is requested from that page. This makes it cheap to loop through pixel pages if you don't necessarily need data from every page.


Fixes #270 