### PR TITLE
Update PixelData.get data to use absolute indexing

### DIFF
--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -472,14 +472,6 @@ methods
         obj.do_pixel_data_loop_with_f(f, data);
     end
 
-    function test_advance_loads_next_page_of_data_into_memory_for_get_data(obj)
-        data = rand(9, 30);
-        f = @(pix, iter) assertEqual(pix.get_data('signal'), ...
-                data(8, (iter*11 + 1):((iter*11 + 1) + pix.page_size - 1)));
-
-        obj.do_pixel_data_loop_with_f(f, data);
-    end
-
     function test_advance_raises_PIXELDATA_if_at_end_of_data(obj)
         npix = 30;
         data = rand(9, npix);

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -22,6 +22,9 @@ properties (Constant)
     NUM_BYTES_IN_VALUE = PixelData.DATA_POINT_SIZE;
     NUM_COLS_IN_PIX_BLOCK = PixelData.DEFAULT_NUM_PIX_FIELDS;
     BYTES_IN_PIXEL = test_PixelData.NUM_BYTES_IN_VALUE*test_PixelData.NUM_COLS_IN_PIX_BLOCK;
+    RUN_IDX = 5;
+    SIGNAL_IDX = 8;
+    VARIANCE_IDX = 9;
 end
 
 methods (Access = private)
@@ -1252,7 +1255,7 @@ methods
         assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
     end
 
-    function test_get_pixels_throws_if_an_idx_lt_1_with_in_memory_pix(obj)
+    function test_get_pixels_throws_if_an_idx_lt_1_with_in_memory_pix(~)
         in_mem_pix = PixelData(5);
         f = @() in_mem_pix.get_pixels(-1:3);
         assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
@@ -1337,6 +1340,164 @@ methods
         pix.advance();
         num_pix_in_final_pg = 8;
         assertEqual(pix.page_size, num_pix_in_final_pg);
+    end
+
+    function test_get_data_returns_data_across_pages_by_absolute_index(obj)
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 30);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        indices = [9:13, 20:24];
+        sig_var = pix.get_data({'signal', 'variance'}, indices);
+        expected_sig_var = data([obj.SIGNAL_IDX, obj.VARIANCE_IDX], indices);
+
+        assertEqual(sig_var, expected_sig_var);
+    end
+
+    function test_get_data_retrieves_correct_data_at_page_boundary(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 10;
+
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+        sig = pix.get_data('signal', 1:3);
+        assertEqual(sig, data(obj.SIGNAL_IDX, 1:3));
+
+        sig2 = pix.get_data('signal', 20);
+        assertEqual(sig2, data(obj.SIGNAL_IDX, 20));
+
+        sig3 = pix.get_data('signal', 1:1);
+        assertEqual(sig3, data(obj.SIGNAL_IDX, 1));
+    end
+
+    function test_paged_pix_get_data_returns_full_data_range_if_no_idx_arg(obj)
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 30);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        var_sig = pix.get_data({'variance', 'signal'});
+        expected_var_sig = data([obj.VARIANCE_IDX, obj.SIGNAL_IDX], :);
+
+        assertEqual(var_sig, expected_var_sig);
+    end
+
+    function test_paged_pix_get_data_can_be_called_with_a_logical(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        logical_array = logical(randi([0, 1], [1, 10]));
+        sig_var = pix.get_data({'signal', 'variance'}, logical_array);
+
+        expected_sig_var = data([obj.SIGNAL_IDX, obj.VARIANCE_IDX], ...
+                                logical_array);
+        assertEqual(sig_var, expected_sig_var);
+    end
+
+    function test_get_data_throws_if_logical_1_index_out_of_range(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        logical_array = cat(2, logical(randi([0, 1], [1, num_pix])), true);
+        f = @() pix.get_data('signal', logical_array);
+
+        assertExceptionThrown(f, 'PIXELDATA:get_data');
+    end
+
+    function test_get_data_ignores_out_of_range_logical_0_indices(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        logical_array = cat(2, logical(randi([0, 1], [1, num_pix])), false);
+        var_sig = pix.get_data({'variance', 'signal'}, logical_array);
+
+        assertEqual(var_sig, ...
+                    data([obj.VARIANCE_IDX, obj.SIGNAL_IDX], logical_array));
+    end
+
+
+    function test_in_mem_pix_get_data_can_be_called_with_a_logical(obj)
+        num_pix = 30;
+        pix = PixelData(rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix));
+
+        logical_array = logical(randi([0, 1], [1, 10]));
+        sig_var = pix.get_data({'signal', 'variance'}, logical_array);
+
+        assertEqual(sig_var, ...
+                    pix.data([obj.SIGNAL_IDX, obj.VARIANCE_IDX], logical_array));
+    end
+
+    function test_get_data_can_handle_repeated_indices(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        idx_array = cat(2, randperm(num_pix), randperm(num_pix));
+
+        sig_run = pix.get_data({'signal', 'run_idx'}, idx_array);
+        assertEqual(sig_run, data([obj.SIGNAL_IDX, obj.RUN_IDX], idx_array));
+    end
+
+
+    function test_get_data_reorders_output_according_to_indices(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        rand_order = randperm(num_pix);
+        shuffled_pix = data(:, rand_order);
+        sig_var = pix.get_data({'signal', 'variance'}, rand_order);
+
+        assertEqual(sig_var, ...
+                    shuffled_pix([obj.SIGNAL_IDX, obj.VARIANCE_IDX], :));
+    end
+
+    function test_get_data_throws_invalid_arg_if_indices_not_vector(~)
+        pix = PixelData();
+        f = @() pix.get_data('signal', ones(2, 2));
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+    end
+
+    function test_get_data_throws_if_range_out_of_bounds(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        idx_array = 25:35;
+        f = @() pix.get_data('signal', idx_array);
+        assertExceptionThrown(f, 'PIXELDATA:get_data');
+    end
+
+    function test_get_data_throws_if_an_idx_lt_1_with_paged_pix(obj)
+        num_pix = 30;
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix);
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+
+        idx_array = -1:20;
+        f = @() pix.get_data('signal', idx_array);
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+    end
+
+    function test_get_daata_throws_if_an_idx_lt_1_with_in_memory_pix(~)
+        in_mem_pix = PixelData(5);
+        f = @() in_mem_pix.get_data('signal', -1:3);
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
+    end
+
+    function test_get_data_throws_if_indices_not_positive_int(~)
+        pix = PixelData();
+        idx_array = 1:0.1:5;
+        f = @() pix.get_data('signal', idx_array);
+        assertExceptionThrown(f, 'MATLAB:InputParser:ArgumentFailedValidation');
     end
 
     % -- Helpers --

--- a/horace_core/configuration/@hor_config/hor_config.m
+++ b/horace_core/configuration/@hor_config/hor_config.m
@@ -100,7 +100,7 @@ classdef hor_config < config_base
     properties(Access=protected, Hidden=true)
         % private properties behind public interface
         mem_chunk_size_ = 10000000;
-        pixel_page_size_ = 3e9;  % default is 3GB
+        pixel_page_size_ = floor(realmax);  % we never want to page at the moment
         threads_ =1;
 
         ignore_nan_ = true;

--- a/horace_core/configuration/@hor_config/hor_config.m
+++ b/horace_core/configuration/@hor_config/hor_config.m
@@ -100,7 +100,10 @@ classdef hor_config < config_base
     properties(Access=protected, Hidden=true)
         % private properties behind public interface
         mem_chunk_size_ = 10000000;
-        pixel_page_size_ = floor(realmax);  % we never want to page at the moment
+
+        % set page size very large to effectively disable paging of pixels as
+        % the implementation is not complete
+        pixel_page_size_ = floor(realmax);
         threads_ =1;
 
         ignore_nan_ = true;

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -223,14 +223,14 @@ end
 methods
 
     % --- Pixel operations ---
+    pix_out = append(obj, pix);
     [mean_signal, mean_variance] = compute_bin_data(obj, npix)
     pix_out = do_binary_op(obj, operand, binary_op, varargin);
     pix_out = do_unary_op(obj, unary_op);
-    pix_out = append(obj, pix);
-    pix_out = mask(obj, mask_array, npix);
-    pix_out = get_pixels(obj, abs_pix_indices);
-    obj = move_to_page(obj, page_number);
     pix_out = get_data(obj, fields, abs_indices);
+    pix_out = get_pixels(obj, abs_pix_indices);
+    pix_out = mask(obj, mask_array, npix);
+    obj = move_to_page(obj, page_number);
 
     function obj = PixelData(arg, mem_alloc)
         % Construct a PixelData object from the given data. Default

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -230,6 +230,7 @@ methods
     pix_out = mask(obj, mask_array, npix);
     pix_out = get_pixels(obj, abs_pix_indices);
     obj = move_to_page(obj, page_number);
+    pix_out = get_data(obj, fields, abs_indices);
 
     function obj = PixelData(arg, mem_alloc)
         % Construct a PixelData object from the given data. Default
@@ -385,51 +386,6 @@ methods
     end
 
     % --- Data management ---
-    function data = get_data(obj, fields, pix_indices)
-        % Retrive data for a field, or fields, for the given pixel indices in
-        % the current page. If no pixel indices are given, all pixels in the
-        % current page are returned.
-        %
-        % This method provides a convinient way of retrieving multiple fields
-        % of data from the pixel block. When retrieving multiple fields, the
-        % columns of data will be ordered corresponding to the order the fields
-        % appear in the inputted cell array.
-        %
-        %   >> sig_and_err = pix.get_data({'signal', 'variance'})
-        %        retrives the signal and variance over the whole range of pixels
-        %
-        %   >> run_det_id_range = pix.get_data({'run_idx', 'detector_idx'}, 4:10);
-        %        retrives the run and detector IDs for pixels 4 to 10
-        %
-        % Input:
-        % ------
-        %   fields      The name of a field, or a cell array of field names
-        %   pix_indices The pixel indices to retrieve, if not given, get full range
-        %
-        if ~isa(fields, 'cell')
-            fields = {fields};
-        end
-        obj = obj.load_current_page_if_data_empty_();
-        try
-            field_indices = cell2mat(obj.FIELD_INDEX_MAP_.values(fields));
-        catch ME
-            switch ME.identifier
-            case 'MATLAB:Containers:Map:NoKey'
-                error('PIXELDATA:get_data', ...
-                      'Invalid field requested in PixelData.get_data().')
-            otherwise
-                rethrow(ME)
-            end
-        end
-
-        if nargin < 3
-            % No pixel indices given, return them all
-            data = obj.data(field_indices, :);
-        else
-            data = obj.data(field_indices, pix_indices);
-        end
-    end
-
     function has_more = has_more(obj)
         % Returns true if there are subsequent pixels stored in the file that
         % are not held in the current page

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -227,7 +227,7 @@ methods
     [mean_signal, mean_variance] = compute_bin_data(obj, npix)
     pix_out = do_binary_op(obj, operand, binary_op, varargin);
     pix_out = do_unary_op(obj, unary_op);
-    pix_out = get_data(obj, fields, abs_indices);
+    pix_out = get_data(obj, fields, abs_pix_indices);
     pix_out = get_pixels(obj, abs_pix_indices);
     pix_out = mask(obj, mask_array, npix);
     obj = move_to_page(obj, page_number);

--- a/horace_core/sqw/PixelData/@PixelData/get_data.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_data.m
@@ -1,4 +1,4 @@
-function data = get_data(obj, pix_fields, abs_pix_indices)
+function data = get_data(obj, pix_fields, varargin)
 % Retrive data for a field, or fields, for the given pixel indices in
 % the current page. If no pixel indices are given, all pixels in the
 % current page are returned.
@@ -19,23 +19,11 @@ function data = get_data(obj, pix_fields, abs_pix_indices)
 %   pix_fields       The name of a field, or a cell array of field names
 %   abs_pix_indices  The pixel indices to retrieve, if not given, get full range
 %
-if ~isa(pix_fields, 'cell')
-    pix_fields = {pix_fields};
-end
-obj = obj.load_current_page_if_data_empty_();
-try
-    field_indices = cell2mat(obj.FIELD_INDEX_MAP_.values(pix_fields));
-catch ME
-    switch ME.identifier
-    case 'MATLAB:Containers:Map:NoKey'
-        error('PIXELDATA:get_data', ...
-                'Invalid field requested in PixelData.get_data().')
-    otherwise
-        rethrow(ME)
-    end
-end
+[pix_fields, abs_pix_indices] = parse_args(obj, pix_fields, varargin{:});
 
-if nargin < 3
+field_indices = cell2mat(obj.FIELD_INDEX_MAP_.values(pix_fields));
+
+if abs_pix_indices == -1
     % No pixel indices given, return them all
     data = obj.data(field_indices, :);
 else
@@ -43,3 +31,40 @@ else
 end
 
 end  % function
+
+
+% -----------------------------------------------------------------------------
+function [pix_fields, abs_pix_indices] = parse_args(obj, varargin)
+    parser = inputParser();
+    parser.addRequired('pix_fields', @(x) ischar(x) || iscell(x));
+    parser.addOptional('abs_pix_indices', -1, @is_positive_int_vector_or_logical_vector);
+    parser.parse(varargin{:});
+
+    pix_fields = parser.Results.pix_fields;
+    abs_pix_indices = parser.Results.abs_pix_indices;
+
+    pix_fields = validate_pix_fields(obj, pix_fields);
+end
+
+
+function pix_fields = validate_pix_fields(obj, pix_fields)
+    if ~isa(pix_fields, 'cell')
+        pix_fields = {pix_fields};
+    end
+
+    for i = 1:numel(pix_fields)
+        field = pix_fields{i};
+        if ~obj.FIELD_INDEX_MAP_.isKey({field})
+            valid_fields = obj.FIELD_INDEX_MAP_.keys();
+            error('PIXELDATA:get_data', ...
+                  ['Given field ''%s'' is not a valid pixel field.\n' ...
+                   'Valid fields are: [''%s'']'], ...
+                  strip(evalc('disp(field)')), strjoin(valid_fields, ''', '''));
+        end
+    end
+end
+
+
+function is = is_positive_int_vector_or_logical_vector(vec)
+    is = isvector(vec) && (islogical(vec) || (all(vec > 0 & all(floor(vec) == vec))));
+end

--- a/horace_core/sqw/PixelData/@PixelData/get_data.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_data.m
@@ -1,4 +1,4 @@
-function data = get_data(obj, pix_fields, varargin)
+function data_out = get_data(obj, pix_fields, varargin)
 % Retrive data for a field, or fields, for the given pixel indices in
 % the current page. If no pixel indices are given, all pixels in the
 % current page are returned.
@@ -19,22 +19,53 @@ function data = get_data(obj, pix_fields, varargin)
 %   pix_fields       The name of a field, or a cell array of field names
 %   abs_pix_indices  The pixel indices to retrieve, if not given, get full range
 %
-[pix_fields, abs_pix_indices] = parse_args(obj, pix_fields, varargin{:});
-
+[pix_fields, abs_pix_indices, max_idx] = parse_args(obj, pix_fields, varargin{:});
 field_indices = cell2mat(obj.FIELD_INDEX_MAP_.values(pix_fields));
 
-if abs_pix_indices == -1
-    % No pixel indices given, return them all
-    data = obj.data(field_indices, :);
+if obj.is_file_backed_()
+
+    base_pg_size = obj.max_page_size_;
+    if abs_pix_indices == -1
+        first_required_page = 1;
+    else
+        first_required_page = ceil(min(abs_pix_indices)/base_pg_size);
+    end
+    obj.move_to_page(first_required_page);
+
+    if abs_pix_indices == -1
+        max_idx = inf;
+        data_out = zeros(numel(pix_fields), obj.num_pixels);
+    else
+        data_out = zeros(numel(pix_fields), numel(abs_pix_indices));
+    end
+
+    data_out = assign_page_values(...
+            obj, data_out, abs_pix_indices, field_indices, base_pg_size);
+    while obj.has_more()
+        obj.advance();
+        if (obj.page_number_ - 1)*base_pg_size + 1 > max_idx
+            break;
+        end
+        data_out = assign_page_values(...
+                obj, data_out, abs_pix_indices, field_indices, base_pg_size);
+    end
+
 else
-    data = obj.data(field_indices, abs_pix_indices);
+
+    if abs_pix_indices == -1
+        % No pixel indices given, return them all
+        data_out = obj.data(field_indices, :);
+    else
+        data_out = obj.data(field_indices, abs_pix_indices);
+    end
+
 end
 
 end  % function
 
 
 % -----------------------------------------------------------------------------
-function [pix_fields, abs_pix_indices] = parse_args(obj, varargin)
+function [pix_fields, abs_pix_indices, max_idx] = parse_args(obj, varargin)
     parser = inputParser();
     parser.addRequired('pix_fields', @(x) ischar(x) || iscell(x));
     parser.addOptional('abs_pix_indices', -1, @is_positive_int_vector_or_logical_vector);
@@ -44,6 +75,26 @@ function [pix_fields, abs_pix_indices] = parse_args(obj, varargin)
     abs_pix_indices = parser.Results.abs_pix_indices;
 
     pix_fields = validate_pix_fields(obj, pix_fields);
+
+    if islogical(abs_pix_indices)
+        if numel(abs_pix_indices) > obj.num_pixels
+            if any(abs_pix_indices(obj.num_pixels + 1:end))
+                error('PIXELDATA:get_data', ...
+                      ['The logical indices contain a true value outside of ' ...
+                       'the array bounds.']);
+            else
+                abs_pix_indices = abs_pix_indices(1:obj.num_pixels);
+            end
+        end
+        abs_pix_indices = find(abs_pix_indices);
+    end
+
+    max_idx = max(abs_pix_indices);
+    if max_idx > obj.num_pixels
+        error('PIXELDATA:get_data', ...
+            'Pixel index out of range. Index must not exceed %i.', ...
+            obj.num_pixels);
+    end
 end
 
 
@@ -67,4 +118,31 @@ end
 
 function is = is_positive_int_vector_or_logical_vector(vec)
     is = isvector(vec) && (islogical(vec) || (all(vec > 0 & all(floor(vec) == vec))));
+end
+
+
+function [idx_in_pg, global_idx] = get_idxs_in_current_pg(obj, abs_indices)
+    % Extract the indices from abs_indices that lie within the bounds of the
+    % currently cached page of data.
+    % Get the corresponding absolute indices as well.
+    %
+    pg_start_idx = (obj.page_number_ - 1)*obj.max_page_size_ + 1;
+    pg_end_idx = pg_start_idx + obj.max_page_size_ - 1;
+
+    global_idx = find((abs_indices >= pg_start_idx) & (abs_indices <= pg_end_idx));
+    idx_in_pg = abs_indices(global_idx) - (obj.page_number_ - 1)*obj.max_page_size_;
+end
+
+
+function data_out = assign_page_values(...
+        obj, data_out, abs_pix_indices, field_indices, base_pg_size ...
+    )
+    start_idx = (obj.page_number_ - 1)*base_pg_size + 1;
+    end_idx = min(obj.page_number_*base_pg_size, obj.num_pixels);
+    if abs_pix_indices == -1
+        data_out(:, start_idx:end_idx) = obj.data(field_indices, 1:end);
+    else
+        [pg_idxs, global_idxs] = get_idxs_in_current_pg(obj, abs_pix_indices);
+        data_out(:, global_idxs) = obj.data(field_indices, pg_idxs);
+    end
 end

--- a/horace_core/sqw/PixelData/@PixelData/get_data.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_data.m
@@ -1,4 +1,4 @@
-function data = get_data(obj, pix_fields, pix_indices)
+function data = get_data(obj, pix_fields, abs_pix_indices)
 % Retrive data for a field, or fields, for the given pixel indices in
 % the current page. If no pixel indices are given, all pixels in the
 % current page are returned.
@@ -16,8 +16,8 @@ function data = get_data(obj, pix_fields, pix_indices)
 %
 % Input:
 % ------
-%   pix_fields   The name of a field, or a cell array of field names
-%   pix_indices  The pixel indices to retrieve, if not given, get full range
+%   pix_fields       The name of a field, or a cell array of field names
+%   abs_pix_indices  The pixel indices to retrieve, if not given, get full range
 %
 if ~isa(pix_fields, 'cell')
     pix_fields = {pix_fields};
@@ -39,7 +39,7 @@ if nargin < 3
     % No pixel indices given, return them all
     data = obj.data(field_indices, :);
 else
-    data = obj.data(field_indices, pix_indices);
+    data = obj.data(field_indices, abs_pix_indices);
 end
 
 end  % function

--- a/horace_core/sqw/PixelData/@PixelData/get_data.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_data.m
@@ -58,6 +58,20 @@ end  % function
 
 
 % -----------------------------------------------------------------------------
+function data_out = assign_page_values(...
+        obj, data_out, abs_pix_indices, field_indices, base_pg_size ...
+    )
+    start_idx = (obj.page_number_ - 1)*base_pg_size + 1;
+    end_idx = min(obj.page_number_*base_pg_size, obj.num_pixels);
+    if abs_pix_indices == -1
+        data_out(:, start_idx:end_idx) = obj.data(field_indices, 1:end);
+    else
+        [pg_idxs, global_idxs] = get_idxs_in_current_page_(obj, abs_pix_indices);
+        data_out(:, global_idxs) = obj.data(field_indices, pg_idxs);
+    end
+end
+
+
 function [pix_fields, abs_pix_indices] = parse_args(obj, varargin)
     parser = inputParser();
     parser.addRequired('pix_fields', @(x) ischar(x) || iscell(x));
@@ -93,6 +107,11 @@ function [pix_fields, abs_pix_indices] = parse_args(obj, varargin)
 end
 
 
+function is = is_positive_int_vector_or_logical_vector(vec)
+    is = isvector(vec) && (islogical(vec) || (all(vec > 0 & all(floor(vec) == vec))));
+end
+
+
 function pix_fields = validate_pix_fields(obj, pix_fields)
     if ~isa(pix_fields, 'cell')
         pix_fields = {pix_fields};
@@ -107,24 +126,5 @@ function pix_fields = validate_pix_fields(obj, pix_fields)
                    'Valid fields are: [''%s'']'], ...
                   strip(evalc('disp(field)')), strjoin(valid_fields, ''', '''));
         end
-    end
-end
-
-
-function is = is_positive_int_vector_or_logical_vector(vec)
-    is = isvector(vec) && (islogical(vec) || (all(vec > 0 & all(floor(vec) == vec))));
-end
-
-
-function data_out = assign_page_values(...
-        obj, data_out, abs_pix_indices, field_indices, base_pg_size ...
-    )
-    start_idx = (obj.page_number_ - 1)*base_pg_size + 1;
-    end_idx = min(obj.page_number_*base_pg_size, obj.num_pixels);
-    if abs_pix_indices == -1
-        data_out(:, start_idx:end_idx) = obj.data(field_indices, 1:end);
-    else
-        [pg_idxs, global_idxs] = get_idxs_in_current_page_(obj, abs_pix_indices);
-        data_out(:, global_idxs) = obj.data(field_indices, pg_idxs);
     end
 end

--- a/horace_core/sqw/PixelData/@PixelData/get_data.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_data.m
@@ -1,4 +1,4 @@
-function data = get_data(obj, fields, pix_indices)
+function data = get_data(obj, pix_fields, pix_indices)
 % Retrive data for a field, or fields, for the given pixel indices in
 % the current page. If no pixel indices are given, all pixels in the
 % current page are returned.
@@ -16,15 +16,15 @@ function data = get_data(obj, fields, pix_indices)
 %
 % Input:
 % ------
-%   fields      The name of a field, or a cell array of field names
-%   pix_indices The pixel indices to retrieve, if not given, get full range
+%   pix_fields   The name of a field, or a cell array of field names
+%   pix_indices  The pixel indices to retrieve, if not given, get full range
 %
-if ~isa(fields, 'cell')
-    fields = {fields};
+if ~isa(pix_fields, 'cell')
+    pix_fields = {pix_fields};
 end
 obj = obj.load_current_page_if_data_empty_();
 try
-    field_indices = cell2mat(obj.FIELD_INDEX_MAP_.values(fields));
+    field_indices = cell2mat(obj.FIELD_INDEX_MAP_.values(pix_fields));
 catch ME
     switch ME.identifier
     case 'MATLAB:Containers:Map:NoKey'
@@ -41,3 +41,5 @@ if nargin < 3
 else
     data = obj.data(field_indices, pix_indices);
 end
+
+end  % function

--- a/horace_core/sqw/PixelData/@PixelData/get_data.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_data.m
@@ -116,19 +116,6 @@ function is = is_positive_int_vector_or_logical_vector(vec)
 end
 
 
-function [idx_in_pg, global_idx] = get_idxs_in_current_pg(obj, abs_indices)
-    % Extract the indices from abs_indices that lie within the bounds of the
-    % currently cached page of data.
-    % Get the corresponding absolute indices as well.
-    %
-    pg_start_idx = (obj.page_number_ - 1)*obj.max_page_size_ + 1;
-    pg_end_idx = pg_start_idx + obj.max_page_size_ - 1;
-
-    global_idx = find((abs_indices >= pg_start_idx) & (abs_indices <= pg_end_idx));
-    idx_in_pg = abs_indices(global_idx) - (obj.page_number_ - 1)*obj.max_page_size_;
-end
-
-
 function data_out = assign_page_values(...
         obj, data_out, abs_pix_indices, field_indices, base_pg_size ...
     )
@@ -137,7 +124,7 @@ function data_out = assign_page_values(...
     if abs_pix_indices == -1
         data_out(:, start_idx:end_idx) = obj.data(field_indices, 1:end);
     else
-        [pg_idxs, global_idxs] = get_idxs_in_current_pg(obj, abs_pix_indices);
+        [pg_idxs, global_idxs] = get_idxs_in_current_page_(obj, abs_pix_indices);
         data_out(:, global_idxs) = obj.data(field_indices, pg_idxs);
     end
 end

--- a/horace_core/sqw/PixelData/@PixelData/get_data.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_data.m
@@ -1,0 +1,43 @@
+function data = get_data(obj, fields, pix_indices)
+% Retrive data for a field, or fields, for the given pixel indices in
+% the current page. If no pixel indices are given, all pixels in the
+% current page are returned.
+%
+% This method provides a convinient way of retrieving multiple fields
+% of data from the pixel block. When retrieving multiple fields, the
+% columns of data will be ordered corresponding to the order the fields
+% appear in the inputted cell array.
+%
+%   >> sig_and_err = pix.get_data({'signal', 'variance'})
+%        retrives the signal and variance over the whole range of pixels
+%
+%   >> run_det_id_range = pix.get_data({'run_idx', 'detector_idx'}, 4:10);
+%        retrives the run and detector IDs for pixels 4 to 10
+%
+% Input:
+% ------
+%   fields      The name of a field, or a cell array of field names
+%   pix_indices The pixel indices to retrieve, if not given, get full range
+%
+if ~isa(fields, 'cell')
+    fields = {fields};
+end
+obj = obj.load_current_page_if_data_empty_();
+try
+    field_indices = cell2mat(obj.FIELD_INDEX_MAP_.values(fields));
+catch ME
+    switch ME.identifier
+    case 'MATLAB:Containers:Map:NoKey'
+        error('PIXELDATA:get_data', ...
+                'Invalid field requested in PixelData.get_data().')
+    otherwise
+        rethrow(ME)
+    end
+end
+
+if nargin < 3
+    % No pixel indices given, return them all
+    data = obj.data(field_indices, :);
+else
+    data = obj.data(field_indices, pix_indices);
+end

--- a/horace_core/sqw/PixelData/@PixelData/get_pixels.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_pixels.m
@@ -35,11 +35,11 @@ if obj.is_file_backed_()
 
     pix_out = PixelData(numel(abs_pix_indices));
 
-    [pg_idxs, global_idxs] = get_idxs_in_current_pg(obj, abs_pix_indices);
+    [pg_idxs, global_idxs] = get_idxs_in_current_page_(obj, abs_pix_indices);
     pix_out.data(:, global_idxs) = obj.data(:, pg_idxs);
     while obj.has_more()
         obj.advance();
-        [pg_idxs, global_idxs] = get_idxs_in_current_pg(obj, abs_pix_indices);
+        [pg_idxs, global_idxs] = get_idxs_in_current_page_(obj, abs_pix_indices);
         pix_out.data(:, global_idxs) = obj.data(:, pg_idxs);
     end
 else
@@ -80,17 +80,4 @@ end
 
 function is = is_positive_int_vector_or_logical_vector(vec)
     is = isvector(vec) && (islogical(vec) || (all(vec > 0 & all(floor(vec) == vec))));
-end
-
-
-function [idx_in_pg, global_idx] = get_idxs_in_current_pg(obj, abs_indices)
-    % Extract the indices from abs_indices that lie within the bounds of the
-    % currently cached page of data.
-    % Get the corresponding absolute indices as well.
-    %
-    pg_start_idx = (obj.page_number_ - 1)*obj.max_page_size_ + 1;
-    pg_end_idx = pg_start_idx + obj.max_page_size_ - 1;
-
-    global_idx = find((abs_indices >= pg_start_idx) & (abs_indices <= pg_end_idx));
-    idx_in_pg = abs_indices(global_idx) - (obj.page_number_ - 1)*obj.max_page_size_;
 end

--- a/horace_core/sqw/PixelData/@PixelData/get_pixels.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_pixels.m
@@ -27,7 +27,7 @@ function pix_out = get_pixels(obj, abs_pix_indices)
 %   pix_out        Another PixelData object containing only the pixels
 %                  specified in the abs_pix_indices argument.
 %
-[abs_pix_indices, max_idx] = parse_args(obj, abs_pix_indices);
+abs_pix_indices = parse_args(obj, abs_pix_indices);
 
 if obj.is_file_backed_()
     first_required_page = ceil(min(abs_pix_indices)/obj.max_page_size_);
@@ -39,9 +39,6 @@ if obj.is_file_backed_()
     pix_out.data(:, global_idxs) = obj.data(:, pg_idxs);
     while obj.has_more()
         obj.advance();
-        if (obj.page_number_ - 1)*obj.max_page_size_ + 1 > max_idx
-            break;
-        end
         [pg_idxs, global_idxs] = get_idxs_in_current_pg(obj, abs_pix_indices);
         pix_out.data(:, global_idxs) = obj.data(:, pg_idxs);
     end
@@ -53,7 +50,7 @@ end  % function
 
 
 % -----------------------------------------------------------------------------
-function [abs_pix_indices, max_idx] = parse_args(obj, varargin)
+function abs_pix_indices = parse_args(obj, varargin)
     parser = inputParser();
     parser.addRequired('abs_pix_indices', @is_positive_int_vector_or_logical_vector);
     parser.parse(varargin{:});

--- a/horace_core/sqw/PixelData/@PixelData/private/get_idxs_in_current_page_.m
+++ b/horace_core/sqw/PixelData/@PixelData/private/get_idxs_in_current_page_.m
@@ -1,0 +1,31 @@
+function [idx_in_pg, global_idx] = get_idxs_in_current_page_(obj, abs_indices)
+% Extract the indices from abs_indices that lie within the bounds of the
+% currently cached page of data and the corresponding page indices.
+%
+% Indices that do not exist in the current page are ignored.
+%
+% Example:
+% --------
+% If the PixelData object has 10 pixels, has a page size of 4, is on page 2,
+% and `abs_indices` = [5, 3, 8, 4], then this function will return
+% `global_idx` = [5, 8] (since 5 and 8 are the global indices in this page) and
+% `idx_in_pg` = [1, 4] (since these are the indices relative to the second
+% page).
+%
+% Input:
+% ------
+% obj          This PixelData object.
+% abs_indices  The absolute indices of the desired pixels.
+%
+% Output:
+% -------
+%  idx_in_page  The page indices corresponding to the given absolute indices
+%               that exist within the current page.
+%  global_idx   The absolute indices that exist within the current page. This
+%               will be a subset of `abs_indices`.
+%
+pg_start_idx = (obj.page_number_ - 1)*obj.max_page_size_ + 1;
+pg_end_idx = pg_start_idx + obj.max_page_size_ - 1;
+
+global_idx = find((abs_indices >= pg_start_idx) & (abs_indices <= pg_end_idx));
+idx_in_pg = abs_indices(global_idx) - (obj.page_number_ - 1)*obj.max_page_size_;


### PR DESCRIPTION
This PR updates `PixelData.get_data` to use absolute indexing rather than relative (to page) indexing.

This brings `get_data`'s API up-to-date with `get_pixels` and the API described in the ADR added in https://github.com/pace-neutrons/Horace/pull/409.

Fixes #413 