### PR TITLE
Add some clarification on Git SHA in deploy SMG

### DIFF
--- a/documentation/smg/12_deploying_releases_to_GitHub.md
+++ b/documentation/smg/12_deploying_releases_to_GitHub.md
@@ -94,7 +94,8 @@ Set `HERBERT_BRANCH_NAME` to the relevant Herbert branch/revision.
 3. When the pipelines have run and created the release artifacts,
 pass the name and numbers of the release's build jobs to the `Deploy` pipeline.
 You must also specify the Git SHA revision to tag on GitHub,
-this should be the SHA of the Git revision at the head of the release branch.
+this should be the full SHA of the Git revision built in the release pipelines
+(usually the head of the release branch).
 The Git SHA is used to validate that all the packages being pushed to GitHub
 are the same revision and that that revision matches the revision to be
 tagged.

--- a/documentation/smg/12_deploying_releases_to_GitHub.md
+++ b/documentation/smg/12_deploying_releases_to_GitHub.md
@@ -33,7 +33,10 @@ Horace and Herbert each have their own deploy pipeline named `Deploy`.
 When triggered, this pipeline takes the following parameters:
 
 - `tag_sha`: The SHA of the Git revision on which to create the release tag
+  (usually the head of the release branch).
+
 - `version_number`: The full version number of the release e.g. `3.4.1`
+
 - `release_job_ids`: The IDs of jobs that contain target release artifacts.
 This is a multiline string parameter whose input should have the form:
 
@@ -90,7 +93,11 @@ Set `HERBERT_BRANCH_NAME` to the relevant Herbert branch/revision.
 
 3. When the pipelines have run and created the release artifacts,
 pass the name and numbers of the release's build jobs to the `Deploy` pipeline.
-You must also specify the Git SHA revision to tag on GitHub.
+You must also specify the Git SHA revision to tag on GitHub,
+this should be the SHA of the Git revision at the head of the release branch.
+The Git SHA is used to validate that all the packages being pushed to GitHub
+are the same revision and that that revision matches the revision to be
+tagged.
 Ensure the parameter `is_draft` is checked/set to true.
 This will create a draft release on GitHub and upload the build artifacts to it.
 


### PR DESCRIPTION
Hopefully this makes more explicit the purpose the Git SHAs in the deployment process.

Fixes #437 .