### PR TITLE
SQW constructor creation

### DIFF
--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TEST_DIRECTORIES
     "test_rebin"
     "test_sqw_file"
     "test_sqw"
+    "test_sqw_class"
     "test_sym_op"
     "test_symmetrisation"
     "test_tobyfit"

--- a/_test/common_functions/FakeFAccess.m
+++ b/_test/common_functions/FakeFAccess.m
@@ -1,0 +1,62 @@
+classdef FakeFAccess < sqw_binfile_common
+% A fake file access class that can return data as if from an sqw file
+
+properties
+    fake_data = [];
+    closed = false;
+end
+
+methods
+
+    function obj = FakeFAccess(data)
+        obj.fake_data = data;
+        obj.npixels_ = size(data, 2);
+    end
+
+    function data = get_pix(obj, varargin)
+        if nargin > 2
+            [pix_lo, pix_hi] = varargin{:};
+        else
+            pix_lo = 1;
+            pix_hi = size(obj.fake_data, 2);
+        end
+        try
+            data = obj.fake_data(:, pix_lo:pix_hi);
+        catch ME
+            switch ME.identifier
+            case 'MATLAB:badsubscript'
+                error('FAKEFACCESS:get_pix', 'End of fake file reached');
+            otherwise
+                rethrow(ME);
+            end
+        end
+    end
+
+    function new_obj = upgrade_file_format(obj)
+        new_obj = [];
+    end
+
+    function obj = fclose(obj)
+        obj.closed = true;
+    end
+
+    function obj = activate(obj)
+        obj.closed = false;
+    end
+
+    function is = is_activated(obj)
+        is = ~obj.closed;
+    end
+
+    function obj = set_npixels(obj, npix)
+        obj.npixels_ = npix;
+    end
+
+    function obj = set_filepath(obj, file_path)
+        [obj.filepath_, file_name, ext] = fileparts(file_path);
+        obj.filename_ = [file_name, ext];
+    end
+
+end
+
+end

--- a/_test/common_functions/benchmark_function.m
+++ b/_test/common_functions/benchmark_function.m
@@ -1,0 +1,28 @@
+function ftimes = benchmark_function(fhandle, niters, nrepetitions)
+%% BENCHMARK_FUNCTION time the given function handle
+% The function will be run `niters` times between the timing points and
+% `nrepetitions` times will be generated.
+%
+% Input:
+% ------
+% fhandle     The function handle to benchmark.
+%
+% niters      The number of times to run the function between time points.
+%
+% nrepitions  The number of times to repeat the benchmark, this differs from
+%             niters in that each repitition has its own time. In affect, the
+%             function `fhandle` is run niters*nrepetitions times.
+%
+% Output:
+% -------
+% ftimes   A list of the times taken to run the given function.
+%          size(ftimes) = [1, nprepetitions].
+%
+ftimes = zeros(1, nrepetitions);
+for rep = 1:nrepetitions
+    tic;
+    for iter = 1:niters
+        fhandle();
+    end
+    ftimes(rep) = toc/niters;
+end

--- a/_test/test_sqw_class/test_equal_to_tol.m
+++ b/_test/test_sqw_class/test_equal_to_tol.m
@@ -225,6 +225,15 @@ methods
         % check absolute tolerance still true
         assertTrue(equal_to_tol(sqw_copy, obj.sqw_2d_paged, value_diff + 1e-8));
     end
+
+    function test_objects_are_not_equal_if_one_has_empty_pixeldata(obj)
+        non_empty_sqw = obj.sqw_2d;
+        empty_sqw = obj.sqw_2d;
+        empty_sqw.data.pix = PixelData();
+
+        assertFalse(equal_to_tol(empty_sqw, non_empty_sqw));
+        assertFalse(equal_to_tol(non_empty_sqw, empty_sqw));
+    end
 end
 
 methods (Static)

--- a/_test/test_sqw_class/test_equal_to_tol.m
+++ b/_test/test_sqw_class/test_equal_to_tol.m
@@ -1,0 +1,261 @@
+classdef test_equal_to_tol < TestCase
+
+properties
+    old_config;
+    old_warn_state;
+
+    ALL_IN_MEM_PG_SIZE = 1e12;
+
+    test_sqw_file_path = '../test_sqw_file/sqw_2d_1.sqw';
+    sqw_2d;
+    sqw_2d_paged;
+end
+
+methods
+
+    function obj = test_equal_to_tol(~)
+        obj = obj@TestCase('test_equal_to_tol');
+
+        % Swallow any warnings for when pixel page size set too small
+        obj.old_warn_state = warning('OFF', 'PIXELDATA:validate_mem_alloc');
+
+        hc = hor_config();
+        obj.old_config = hc.get_data_to_store();
+
+        hc.log_level = 0;  % hide the (quite verbose) equal_to_tol output
+
+        % sqw_2d_1.sqw has ~1.8 MB of pixels, a 400 kB page size gives us 5
+        % pages of pixel data
+        hc.pixel_page_size = 400e3;
+        obj.sqw_2d_paged = sqw(obj.test_sqw_file_path);
+
+        % set a large pixel page size so we're all in memory by default
+        hc.pixel_page_size = obj.ALL_IN_MEM_PG_SIZE;
+        obj.sqw_2d = sqw(obj.test_sqw_file_path);
+    end
+
+    function delete(obj)
+        set(hor_config, obj.old_config);
+        warning(obj.old_warn_state);
+    end
+
+    function test_the_same_sqw_objects_are_equal(obj)
+        sqw_copy = obj.sqw_2d;
+        assertTrue(equal_to_tol(obj.sqw_2d, sqw_copy));
+    end
+
+    function test_the_same_sqw_objects_are_equal_with_no_pix_reorder(obj)
+        sqw_copy = obj.sqw_2d;
+        assertTrue(equal_to_tol(obj.sqw_2d, sqw_copy, 'reorder', false));
+    end
+
+    function test_the_same_sqw_objects_are_equal_if_testing_fraction_of_pix(obj)
+        sqw_copy = obj.sqw_2d;
+        assertTrue(equal_to_tol(obj.sqw_2d, sqw_copy, 'fraction', 0.5));
+    end
+
+    function test_same_sqw_objs_equal_if_pixels_in_each_bin_shuffled(obj)
+        original_sqw = copy(obj.sqw_2d);
+        pix = original_sqw.data.pix;
+        npix = original_sqw.data.npix;
+
+        shuffled_sqw = original_sqw;
+        shuffled_sqw.data.pix = obj.shuffle_pixel_bin_rows(pix, npix);
+
+        assertTrue(equal_to_tol(shuffled_sqw, original_sqw));
+    end
+
+    function test_paged_sqw_objects_equal_if_pix_within_each_bin_shuffled(obj)
+        original_sqw = copy(obj.sqw_2d_paged);
+        npix = [10, 5, 6, 3, 6];
+
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 30);
+        shuffled_data = obj.shuffle_pixel_bin_rows(PixelData(data), npix).data;
+
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+        shuffled_pix = obj.get_pix_with_fake_faccess(shuffled_data, npix_in_page);
+
+        % Replace sqw objects' npix and pix arrays
+        original_sqw.data.npix = npix;
+        original_sqw.data.pix = pix;
+        shuffled_sqw = copy(original_sqw);
+        shuffled_sqw.data.pix = shuffled_pix;
+
+        assertTrue(equal_to_tol(shuffled_sqw, original_sqw));
+    end
+
+    function test_paged_sqw_ne_if_pix_within_bin_shuffled_and_reorder_false(obj)
+        original_sqw = copy(obj.sqw_2d_paged);
+        npix = [10, 5, 6, 3, 6];
+
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 30);
+        shuffled_data = obj.shuffle_pixel_bin_rows(PixelData(data), npix).data;
+
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+        shuffled_pix = obj.get_pix_with_fake_faccess(shuffled_data, npix_in_page);
+
+        % Replace sqw objects' npix and pix arrays
+        original_sqw.data.npix = npix;
+        original_sqw.data.pix = pix;
+        shuffled_sqw = copy(original_sqw);
+        shuffled_sqw.data.pix = shuffled_pix;
+
+        assertFalse(equal_to_tol(shuffled_sqw, original_sqw, 'reorder', false));
+    end
+
+    function test_the_same_sqw_objects_are_equal_with_paged_pix(obj)
+        sqw_copy = obj.sqw_2d_paged;
+        assertTrue(equal_to_tol(obj.sqw_2d_paged, sqw_copy));
+    end
+
+    function test_the_same_sqw_objs_eq_if_fraction_of_pix_and_pix_are_paged(obj)
+        sqw_copy = obj.sqw_2d_paged;
+        assertTrue(equal_to_tol(obj.sqw_2d_paged, sqw_copy, 'fraction', 0.5));
+    end
+
+    function test_paged_and_non_paged_version_of_same_sqw_file_are_equal(obj)
+        assertTrue(equal_to_tol(obj.sqw_2d_paged, obj.sqw_2d, 'fraction', 0.5));
+    end
+
+    function test_false_returned_if_NaNs_in_sqw_and_nan_equal_is_false(obj)
+        original_sqw = copy(obj.sqw_2d);
+        original_sqw.data.s(5) = nan;
+        sqw_copy = copy(original_sqw);
+
+        assertFalse(equal_to_tol(original_sqw, obj.sqw_2d, 'nan_equal', false));
+        assertFalse(equal_to_tol(sqw_copy, original_sqw, 'nan_equal', false));
+    end
+
+    function test_true_returned_if_NaNs_in_sqw_and_nan_equal_is_true(obj)
+        original_sqw = copy(obj.sqw_2d);
+        original_sqw.data.s(5) = nan;
+        sqw_copy = copy(original_sqw);
+
+        assertFalse(equal_to_tol(original_sqw, obj.sqw_2d, 'nan_equal', true));
+        assertTrue(equal_to_tol(sqw_copy, original_sqw, 'nan_equal', true));
+    end
+
+    function test_using_fraction_argument_only_tests_fraction_of_the_bins(obj)
+        % Here we test that only a fraction of the pixels are compared when
+        % using the 'fraction' argument.
+        % A fraction value of 0.5 means that every other bin will be tested for
+        % equality of pixels. So, in one of the sqw objects, we zero out all
+        % the bins we do not intend to compare. This way, if we do compare any
+        % of those bins, there will be a mismatch.
+        original_sqw = copy(obj.sqw_2d_paged);
+        npix = [10, 5, 6, 3, 6];
+        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 30);
+        edited_data = data;
+
+        fraction = 0.5;
+        % get the bins to zero out
+        bins_to_edit = round(2:(1/fraction):numel(npix));
+
+        bin_end_idxs = cumsum(npix);
+        bin_start_idxs = bin_end_idxs - npix + 1;
+        for i = 1:numel(bins_to_edit)
+            bin_num = bins_to_edit(i);
+            edited_data(:, bin_start_idxs(bin_num):bin_end_idxs(bin_num)) = 0;
+        end
+
+        npix_in_page = 11;
+        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+        edited_pix = obj.get_pix_with_fake_faccess(edited_data, npix_in_page);
+
+        % Replace sqw objects' npix and pix arrays
+        original_sqw.data.npix = npix;
+        original_sqw.data.pix = pix;
+        edited_sqw = copy(original_sqw);
+        edited_sqw.data.pix = edited_pix;
+
+        % check equal_to_tol false when comparing all bins
+        assertFalse(equal_to_tol(edited_sqw, original_sqw, 'fraction', 1));
+        % check equal_to_tol true when comparing a fraction of the bins
+        assertTrue(equal_to_tol(edited_sqw, original_sqw, 'fraction', fraction));
+    end
+
+    function test_using_fraction_argument_is_faster_than_comparing_all_pix(obj)
+        sqw_copy = copy(obj.sqw_2d);
+
+        num_reps = 5;
+        num_iters = 1;
+
+        f = @() equal_to_tol(sqw_copy, obj.sqw_2d);
+        times_taken = benchmark_function(f, num_iters, num_reps);
+        median_time_full = median(times_taken);
+
+        f_partial = @() equal_to_tol(sqw_copy, obj.sqw_2d, 'fraction', 0.2);
+        times_taken_partial = benchmark_function(f_partial, num_iters, num_reps);
+        median_time_partial = median(times_taken_partial);
+
+        assertTrue(median_time_full > median_time_partial);
+    end
+
+    function test_equal_to_tol_true_for_eq_sqw_reorder_false_with_fraction(obj)
+        sqw_copy = copy(obj.sqw_2d_paged);
+        assertTrue( ...
+            equal_to_tol( ...
+                obj.sqw_2d_paged, ...
+                sqw_copy, ...
+                'fraction', 0.5, ...
+                'reorder', false ...
+            ) ...
+        );
+    end
+
+    function test_equal_to_tol_can_be_called_with_negative_tol_for_rel_tol(obj)
+        sqw_copy = copy(obj.sqw_2d_paged);
+        rel_tol = 1e-5;
+        assertTrue(equal_to_tol(sqw_copy, obj.sqw_2d_paged, -rel_tol));
+
+        % find first non-zero signal value
+        sig_idx = find(sqw_copy.data.s > 0, 1);
+
+        % increase the difference in the value by 1% more than rel_tol
+        value_diff = 1.01*rel_tol*obj.sqw_2d_paged.data.s(sig_idx);
+        sqw_copy.data.s(sig_idx) = obj.sqw_2d_paged.data.s(sig_idx) + value_diff;
+
+        assertFalse(equal_to_tol(sqw_copy, obj.sqw_2d_paged, -rel_tol));
+
+        % check increasing the rel_tol by 1% returns true
+        assertTrue(equal_to_tol(sqw_copy, obj.sqw_2d_paged, -rel_tol*1.01))
+
+        % check absolute tolerance still true
+        assertTrue(equal_to_tol(sqw_copy, obj.sqw_2d_paged, value_diff + 1e-8));
+    end
+end
+
+methods (Static)
+
+    function shuffled_pix = shuffle_pixel_bin_rows(pix, npix)
+        % Shuffle the pixels in the bins defined by the npix array
+        %
+        npix_non_empty = npix(npix ~= 0);
+        shuffled_pix = PixelData(pix.num_pixels);
+
+        bin_end_idxs = cumsum(npix_non_empty(:));
+        bin_start_idxs = bin_end_idxs - npix_non_empty(:) + 1;
+        for i = 1:numel(npix_non_empty)
+            bin_start = bin_start_idxs(i);
+            bin_end = bin_end_idxs(i);
+
+            pix_in_bin = pix.data(:, bin_start:bin_end);
+            shuffled_bin_pix = pix_in_bin(:, randperm(size(pix_in_bin, 2)));
+            shuffled_pix.data(:, bin_start:bin_end) = shuffled_bin_pix;
+
+            % Checksum to ensure the bins' columns contain the same values
+            assertEqual(sum(shuffled_bin_pix, 2), sum(pix_in_bin, 2), '', 1e-8);
+        end
+    end
+
+    function pix = get_pix_with_fake_faccess(data, npix_in_page)
+        faccess = FakeFAccess(data);
+        bytes_in_pixel = PixelData.DATA_POINT_SIZE*PixelData.DEFAULT_NUM_PIX_FIELDS;
+        pix = PixelData(faccess, npix_in_page*bytes_in_pixel);
+    end
+
+end
+
+end

--- a/_test/test_sqw_class/test_sqw_constructor.m
+++ b/_test/test_sqw_class/test_sqw_constructor.m
@@ -12,7 +12,7 @@ methods
     function obj = test_sqw_constructor(~)
         obj = obj@TestCase('test_sqw_constructor');
 
-        test_sqw_file = java.io.File(pwd(),fullfile(obj.sqw_files_path, obj.sqw_file_1d_name));
+        test_sqw_file = java.io.File(pwd(), fullfile(obj.sqw_files_path, obj.sqw_file_1d_name));
         obj.test_sqw_1d_fullpath = char(test_sqw_file.getCanonicalPath());
     end
 
@@ -63,5 +63,16 @@ methods
         % changed data is not mirrored in initial
         assertFalse(equal_to_tol(sqw_copy, sqw_obj))
     end
+
+    function test_save_load_returns_identical_object(obj)
+        tmp_filename=fullfile(tmp_dir, 'sqw_loadobj_test.mat');
+        cleanup_obj=onCleanup(@() delete(tmp_filename));
+
+        sqw_obj = sqw(obj.test_sqw_1d_fullpath);
+        save(tmp_filename, 'sqw_obj');
+        from_file = load(tmp_filename);
+        assertTrue(equal_to_tol(from_file.sqw_obj, sqw_obj))
+    end
+
 end
 end

--- a/_test/test_sqw_class/test_sqw_constructor.m
+++ b/_test/test_sqw_class/test_sqw_constructor.m
@@ -64,7 +64,10 @@ methods
         assertFalse(equal_to_tol(sqw_copy, sqw_obj))
     end
 
-    function test_save_load_returns_identical_object(obj)
+%TODO: disabled until full functionality is implemeneted in new class;
+% The addition of this method causes sqw_old tests to incorrectly load data from .mat files
+% as new-SQW class objects
+    function DISABLED_test_save_load_returns_identical_object(obj)
         tmp_filename=fullfile(tmp_dir, 'sqw_loadobj_test.mat');
         cleanup_obj=onCleanup(@() delete(tmp_filename));
 

--- a/_test/test_sqw_class/test_sqw_constructor.m
+++ b/_test/test_sqw_class/test_sqw_constructor.m
@@ -30,12 +30,13 @@ methods
     function test_filename_constructor_returns_populated_class(obj)
         sqw_obj = sqw(obj.test_sqw_1d_fullpath);
 
+        % expected data populated from instance of test object
         assertTrue(isa(sqw_obj, 'sqw'));
         assertEqual(sqw_obj.main_header.nfiles, 85)
         assertEqual(numel(sqw_obj.header), 85)
         assertEqual(numel(sqw_obj.detpar.group), 36864);
         assertEqual(numel(sqw_obj.data.pax), 1);
-        assertEqual(sqw_obj.data.pix.page_size, 100337);
+        assertEqual(sqw_obj.data.pix.num_pixels, 100337);
     end
 
     function test_copy_constructor_clones_object(obj)
@@ -43,12 +44,7 @@ methods
         sqw_copy = sqw(sqw_obj);
 
         assertTrue(isa(sqw_obj, 'sqw'));
-        assertEqual(sqw_copy.main_header, sqw_obj.main_header)
-        assertEqual(sqw_copy.header, sqw_obj.header)
-        assertEqual(sqw_copy.data.pax, sqw_obj.data.pax);
-        assertEqual(sqw_copy.detpar, sqw_obj.detpar);
-
-        assertTrue(equal_to_tol(sqw_copy, sqw_obj))
+        assertEqualToTol(sqw_copy, sqw_obj);
     end
 
     function test_copy_constructor_returns_distinct_object(obj)
@@ -58,10 +54,17 @@ methods
         sqw_copy.main_header.title = 'test_copy';
         sqw_copy.header = struct([]);
         sqw_copy.detpar.azim(1:10) = 0;
+        sqw_copy.data.dax = [2 1];
         sqw_copy.data.pix.signal = 1;
 
         % changed data is not mirrored in initial
-        assertFalse(equal_to_tol(sqw_copy, sqw_obj))
+        assertFalse(equal_to_tol(sqw_copy.main_header, sqw_obj.main_header));
+        assertFalse(equal_to_tol(sqw_copy.header, sqw_obj.header));
+        assertFalse(equal_to_tol(sqw_copy.detpar, sqw_obj.detpar));
+        assertFalse(equal_to_tol(sqw_copy.data, sqw_obj.data));
+        assertFalse(equal_to_tol(sqw_copy.data.pix, sqw_obj.data.pix));
+
+        assertFalse(equal_to_tol(sqw_copy, sqw_obj));
     end
 
 %TODO: disabled until full functionality is implemeneted in new class;
@@ -74,7 +77,7 @@ methods
         sqw_obj = sqw(obj.test_sqw_1d_fullpath);
         save(tmp_filename, 'sqw_obj');
         from_file = load(tmp_filename);
-        assertTrue(equal_to_tol(from_file.sqw_obj, sqw_obj))
+        assertEqualToTol(from_file.sqw_obj, sqw_obj);
     end
 
 end

--- a/_test/test_sqw_class/test_sqw_constructor.m
+++ b/_test/test_sqw_class/test_sqw_constructor.m
@@ -1,0 +1,67 @@
+classdef test_sqw_constructor < TestCase
+
+properties
+    sqw_file_1d_name = 'sqw_1d_1.sqw';
+    sqw_files_path = '../test_sqw_file/';
+
+    test_sqw_1d_fullpath = '';
+end
+
+methods
+
+    function obj = test_sqw_constructor(~)
+        obj = obj@TestCase('test_sqw_constructor');
+
+        test_sqw_file = java.io.File(pwd(),fullfile(obj.sqw_files_path, obj.sqw_file_1d_name));
+        obj.test_sqw_1d_fullpath = char(test_sqw_file.getCanonicalPath());
+    end
+
+    function test_default_constructor_returns_empty_instance(obj)
+        sqw_obj = sqw();
+
+        assertTrue(isa(sqw_obj, 'sqw'));
+        assertEqual(sqw_obj.main_header, struct([]));
+        assertEqual(sqw_obj.header, struct([]));
+        assertEqual(sqw_obj.detpar, struct([]));
+        assertEqual(sqw_obj.data.pix, PixelData());
+        assertEqual(numel(sqw_obj.data.pax), 0);
+    end
+
+    function test_filename_constructor_returns_populated_class(obj)
+        sqw_obj = sqw(obj.test_sqw_1d_fullpath);
+
+        assertTrue(isa(sqw_obj, 'sqw'));
+        assertEqual(sqw_obj.main_header.nfiles, 85)
+        assertEqual(numel(sqw_obj.header), 85)
+        assertEqual(numel(sqw_obj.detpar.group), 36864);
+        assertEqual(numel(sqw_obj.data.pax), 1);
+        assertEqual(sqw_obj.data.pix.page_size, 100337);
+    end
+
+    function test_copy_constructor_clones_object(obj)
+        sqw_obj = sqw(obj.test_sqw_1d_fullpath);
+        sqw_copy = sqw(sqw_obj);
+
+        assertTrue(isa(sqw_obj, 'sqw'));
+        assertEqual(sqw_copy.main_header, sqw_obj.main_header)
+        assertEqual(sqw_copy.header, sqw_obj.header)
+        assertEqual(sqw_copy.data.pax, sqw_obj.data.pax);
+        assertEqual(sqw_copy.detpar, sqw_obj.detpar);
+
+        assertTrue(equal_to_tol(sqw_copy, sqw_obj))
+    end
+
+    function test_copy_constructor_returns_distinct_object(obj)
+        sqw_obj = sqw(obj.test_sqw_1d_fullpath);
+        sqw_copy = sqw(sqw_obj);
+
+        sqw_copy.main_header.title = 'test_copy';
+        sqw_copy.header = struct([]);
+        sqw_copy.detpar.azim(1:10) = 0;
+        sqw_copy.data.pix.signal = 1;
+
+        % changed data is not mirrored in initial
+        assertFalse(equal_to_tol(sqw_copy, sqw_obj))
+    end
+end
+end

--- a/_test/test_sqw_class/test_sqw_copy.m
+++ b/_test/test_sqw_class/test_sqw_copy.m
@@ -1,0 +1,57 @@
+ classdef test_sqw_copy < TestCase
+
+ properties
+     sqw_file_1d_name = 'sqw_1d_1.sqw';
+     sqw_files_path = '../test_sqw_file/';
+
+     test_sqw_1d_fullpath = '';
+ end
+
+ methods
+
+     function obj = test_sqw_copy(~)
+         obj = obj@TestCase('test_sqw_copy');
+
+         test_sqw_file = java.io.File(pwd(), fullfile(obj.sqw_files_path, obj.sqw_file_1d_name));
+         obj.test_sqw_1d_fullpath = char(test_sqw_file.getCanonicalPath());
+     end
+
+    function test_copy_returns_object_with_identical_data(obj)
+        sqw_obj = sqw(obj.test_sqw_1d_fullpath);
+        sqw_copy = copy(sqw_obj);
+
+        assertEqualToTol(sqw_copy, sqw_obj);
+    end
+
+    function test_copy_returns_distinct_object(obj)
+        sqw_obj = sqw(obj.test_sqw_1d_fullpath);
+        sqw_copy = copy(sqw_obj);
+
+        sqw_copy.main_header.title = 'test_copy';
+        sqw_copy.header = struct([]);
+        sqw_copy.detpar.azim(1:10) = 0;
+        sqw_copy.data.dax = [2 1];
+        sqw_copy.data.pix.signal = 1;
+
+        % changed data is not mirrored in initial
+        assertFalse(equal_to_tol(sqw_copy.main_header, sqw_obj.main_header));
+        assertFalse(equal_to_tol(sqw_copy.header, sqw_obj.header));
+        assertFalse(equal_to_tol(sqw_copy.detpar, sqw_obj.detpar));
+        assertFalse(equal_to_tol(sqw_copy.data, sqw_obj.data));
+        assertFalse(equal_to_tol(sqw_copy.data.pix, sqw_obj.data.pix));
+    end
+
+    function test_copy_excluding_pix_returns_empty_pix_data(obj)
+        sqw_obj = sqw(obj.test_sqw_1d_fullpath);
+        sqw_copy = copy(sqw_obj, 'exclude_pix', true);
+
+        % PixelData is not copied
+        assertEqual(sqw_copy.data.pix, PixelData());
+
+        % confirm selected other data is copied
+        assertEqual(sqw_copy.main_header.title, sqw_obj.main_header.title);
+        assertEqualToTol(sqw_copy.header, sqw_obj.header);
+        assertEqualToTol(sqw_copy.detpar, sqw_obj.detpar);
+    end
+ end
+ end

--- a/_test/test_sqw_class/test_sqw_copy.m
+++ b/_test/test_sqw_class/test_sqw_copy.m
@@ -1,57 +1,57 @@
- classdef test_sqw_copy < TestCase
-
- properties
-     sqw_file_1d_name = 'sqw_1d_1.sqw';
-     sqw_files_path = '../test_sqw_file/';
-
-     test_sqw_1d_fullpath = '';
- end
-
- methods
-
-     function obj = test_sqw_copy(~)
-         obj = obj@TestCase('test_sqw_copy');
-
-         test_sqw_file = java.io.File(pwd(), fullfile(obj.sqw_files_path, obj.sqw_file_1d_name));
-         obj.test_sqw_1d_fullpath = char(test_sqw_file.getCanonicalPath());
-     end
-
-    function test_copy_returns_object_with_identical_data(obj)
-        sqw_obj = sqw(obj.test_sqw_1d_fullpath);
-        sqw_copy = copy(sqw_obj);
-
-        assertEqualToTol(sqw_copy, sqw_obj);
+classdef test_sqw_copy < TestCase
+    
+    properties
+        sqw_file_1d_name = 'sqw_1d_1.sqw';
+        sqw_files_path = '../test_sqw_file/';
+        
+        test_sqw_1d_fullpath = '';
     end
-
-    function test_copy_returns_distinct_object(obj)
-        sqw_obj = sqw(obj.test_sqw_1d_fullpath);
-        sqw_copy = copy(sqw_obj);
-
-        sqw_copy.main_header.title = 'test_copy';
-        sqw_copy.header = struct([]);
-        sqw_copy.detpar.azim(1:10) = 0;
-        sqw_copy.data.dax = [2 1];
-        sqw_copy.data.pix.signal = 1;
-
-        % changed data is not mirrored in initial
-        assertFalse(equal_to_tol(sqw_copy.main_header, sqw_obj.main_header));
-        assertFalse(equal_to_tol(sqw_copy.header, sqw_obj.header));
-        assertFalse(equal_to_tol(sqw_copy.detpar, sqw_obj.detpar));
-        assertFalse(equal_to_tol(sqw_copy.data, sqw_obj.data));
-        assertFalse(equal_to_tol(sqw_copy.data.pix, sqw_obj.data.pix));
+    
+    methods
+        
+        function obj = test_sqw_copy(~)
+            obj = obj@TestCase('test_sqw_copy');
+            
+            test_sqw_file = java.io.File(pwd(), fullfile(obj.sqw_files_path, obj.sqw_file_1d_name));
+            obj.test_sqw_1d_fullpath = char(test_sqw_file.getCanonicalPath());
+        end
+        
+        function test_copy_returns_object_with_identical_data(obj)
+            sqw_obj = sqw(obj.test_sqw_1d_fullpath);
+            sqw_copy = copy(sqw_obj);
+            
+            assertEqualToTol(sqw_copy, sqw_obj);
+        end
+        
+        function test_copy_returns_distinct_object(obj)
+            sqw_obj = sqw(obj.test_sqw_1d_fullpath);
+            sqw_copy = copy(sqw_obj);
+            
+            sqw_copy.main_header.title = 'test_copy';
+            sqw_copy.header = struct([]);
+            sqw_copy.detpar.azim(1:10) = 0;
+            sqw_copy.data.dax = [2, 1];
+            sqw_copy.data.pix.signal = 1;
+            
+            % changed data is not mirrored in initial
+            assertFalse(equal_to_tol(sqw_copy.main_header, sqw_obj.main_header));
+            assertFalse(equal_to_tol(sqw_copy.header, sqw_obj.header));
+            assertFalse(equal_to_tol(sqw_copy.detpar, sqw_obj.detpar));
+            assertFalse(equal_to_tol(sqw_copy.data, sqw_obj.data));
+            assertFalse(equal_to_tol(sqw_copy.data.pix, sqw_obj.data.pix));
+        end
+        
+        function test_copy_excluding_pix_returns_empty_pix_data(obj)
+            sqw_obj = sqw(obj.test_sqw_1d_fullpath);
+            sqw_copy = copy(sqw_obj, 'exclude_pix', true);
+            
+            % PixelData is not copied
+            assertEqual(sqw_copy.data.pix, PixelData());
+            
+            % confirm selected other data is copied
+            assertEqual(sqw_copy.main_header.title, sqw_obj.main_header.title);
+            assertEqualToTol(sqw_copy.header, sqw_obj.header);
+            assertEqualToTol(sqw_copy.detpar, sqw_obj.detpar);
+        end
     end
-
-    function test_copy_excluding_pix_returns_empty_pix_data(obj)
-        sqw_obj = sqw(obj.test_sqw_1d_fullpath);
-        sqw_copy = copy(sqw_obj, 'exclude_pix', true);
-
-        % PixelData is not copied
-        assertEqual(sqw_copy.data.pix, PixelData());
-
-        % confirm selected other data is copied
-        assertEqual(sqw_copy.main_header.title, sqw_obj.main_header.title);
-        assertEqualToTol(sqw_copy.header, sqw_obj.header);
-        assertEqualToTol(sqw_copy.detpar, sqw_obj.detpar);
-    end
- end
- end
+end

--- a/admin/validate_horace.m
+++ b/admin/validate_horace.m
@@ -60,7 +60,8 @@ if isempty(test_folders)% no tests specified on command line - run them all
         'test_transformation', ...
         'test_utilities', ...
         'test_sqw_file', ...
-        'test_sqw' ...
+        'test_sqw', ...
+        'test_sqw_class', ...
         'test_gen_sqw_workflow' ...
         % 'test_spinw_integration', ...
         };
@@ -116,11 +117,11 @@ if parallel && license('checkout',  'Distrib_Computing_Toolbox')
     cores = feature('numCores');
     if verLessThan('matlab',  '8.4')
         if matlabpool('SIZE') == 0
-            
+
             if cores > 12
                 cores = 12;
             end
-            
+
             matlabpool(cores);
         end
     else
@@ -131,21 +132,21 @@ if parallel && license('checkout',  'Distrib_Computing_Toolbox')
             parpool(cores);
         end
     end
-    
+
     test_ok = false(1, numel(test_folders_full));
     time = bigtic();
-    
+
     parfor i = 1:numel(test_folders_full)
         test_ok(i) = runtests(test_folders_full{i})
     end
-    
+
     bigtoc(time,  '===COMPLETED UNIT TESTS IN PARALLEL');
     tests_ok = all(test_ok);
 else
     time = bigtic();
     tests_ok = runtests(test_folders_full{:});
     bigtoc(time,  '===COMPLETED UNIT TESTS RUN ');
-    
+
 end
 
 close all

--- a/horace_core/sqw/@SQWDnDBase/SQWDnDBase.m
+++ b/horace_core/sqw/@SQWDnDBase/SQWDnDBase.m
@@ -1,38 +1,37 @@
 classdef (Abstract) SQWDnDBase
     %SQWDnDBase Abstract SQW/DnD object base class
-    %   Abstract class defining common API and atrributes of the SQW and 
+    %   Abstract class defining common API and atrributes of the SQW and
     %   DnD objects
-    
+
     properties (Abstract) % Public
-       AbsProp
+      %  abstract_prop
     end
-    
+
     properties (Access = ?SQWDnDBase)  % Protected members
-        Property1
+        % base_property
     end
-    
+
     methods (Abstract)
-       abstMethod(obj)
+       % x = abstract_method(obj)
     end
-    
+
     methods  % Public
-        function outputArg = method1(obj,inputArg)
-            %METHOD1 Summary of this method goes here
-            %   Detailed explanation goes here
-            outputArg = obj.Property1 + inputArg;
-        end
+        % function outputArg = method1(obj,inputArg)
+        %     %METHOD1 Summary of this method goes here
+        %     %   Detailed explanation goes here
+        %     outputArg = obj.Property1 + inputArg;
+        % end
     end
-    
+
     methods (Access = ?SQWDnDBase)  % Protected members
-        w = binary_op_manager (w1, w2, binary_op)
-        w = unary_op_manager (w1, unary_op)
-        
-        function obj = untitled(inputArg1,inputArg2)
-            %UNTITLED Construct an instance of this class
-            %   Detailed explanation goes here
-            obj.Property1 = inputArg1 + inputArg2;
-        end
-        
-    end    
+        % w = binary_op_manager (w1, w2, binary_op)
+        % w = unary_op_manager (w1, unary_op)
+
+        % function obj = untitled(inputArg1,inputArg2)
+        % % UNTITLED Construct an instance of this class
+        % %   Detailed explanation goes here
+        %   obj.Property1 = inputArg1 + inputArg2;
+        % end
+    end
 end
 

--- a/horace_core/sqw/@SQWDnDBase/SQWDnDBase.m
+++ b/horace_core/sqw/@SQWDnDBase/SQWDnDBase.m
@@ -7,7 +7,7 @@ classdef (Abstract) SQWDnDBase
       %  abstract_prop
     end
 
-    properties (Access = ?SQWDnDBase)  % Protected members
+    properties (Access = protected)
         % base_property
     end
 
@@ -23,7 +23,7 @@ classdef (Abstract) SQWDnDBase
         % end
     end
 
-    methods (Access = ?SQWDnDBase)  % Protected members
+    methods (Access = protected)
         % w = binary_op_manager (w1, w2, binary_op)
         % w = unary_op_manager (w1, unary_op)
 

--- a/horace_core/sqw/@sqw/copy.m
+++ b/horace_core/sqw/@sqw/copy.m
@@ -1,0 +1,42 @@
+function new_sqw = copy(obj, varargin)
+% Copy this SQW object or an array of sqw objects
+%
+%   >> new_sqw = copy(old_sqw);
+%
+%   >> new_sqw = copy(old_sqw, 'exclude_pix', true);
+%
+% Keyword Inputs:
+% ---------------
+% exclude_pix   The sqw object copy will contain an empty PixelData object
+%
+% As PixelData is a handle class, we must call the copy operator on the pixels
+% for the two SQW objects to not point to the same pixel data.
+
+[obj, exclude_pix] = parse_args(obj, varargin{:});
+
+new_sqw = obj;
+for i = 1:numel(obj)
+    new_sqw(i).main_header = obj(i).main_header;
+    new_sqw(i).header = obj(i).header;
+    new_sqw(i).detpar = obj(i).detpar;
+    new_sqw(i).data = obj(i).data;
+
+    if isa(obj, 'sqw') && ~exclude_pix
+        new_sqw(i).data.pix = copy(obj(i).data.pix);
+    elseif exclude_pix
+        new_sqw(i).data.pix = PixelData();
+    end
+end
+
+end
+
+
+% -----------------------------------------------------------------------------
+function [obj, exclude_pix] = parse_args(obj, varargin)
+    parser = inputParser();
+    parser.addRequired('obj', @(x) isa(x, 'sqw'));
+    parser.addParameter('exclude_pix', false, @(x) islogical(x));
+    parser.parse(obj, varargin{:});
+
+    exclude_pix = parser.Results.exclude_pix;
+end

--- a/horace_core/sqw/@sqw/copy.m
+++ b/horace_core/sqw/@sqw/copy.m
@@ -16,14 +16,9 @@ function new_sqw = copy(obj, varargin)
 
 new_sqw = obj;
 for i = 1:numel(obj)
-    new_sqw(i).main_header = obj(i).main_header;
-    new_sqw(i).header = obj(i).header;
-    new_sqw(i).detpar = obj(i).detpar;
-    new_sqw(i).data = obj(i).data;
-
-    if isa(obj, 'sqw') && ~exclude_pix
+    if ~exclude_pix
         new_sqw(i).data.pix = copy(obj(i).data.pix);
-    elseif exclude_pix
+    else
         new_sqw(i).data.pix = PixelData();
     end
 end
@@ -35,7 +30,7 @@ end
 function [obj, exclude_pix] = parse_args(obj, varargin)
     parser = inputParser();
     parser.addRequired('obj', @(x) isa(x, 'sqw'));
-    parser.addParameter('exclude_pix', false, @(x) islogical(x));
+    parser.addParameter('exclude_pix', false, @islogical);
     parser.parse(obj, varargin{:});
 
     exclude_pix = parser.Results.exclude_pix;

--- a/horace_core/sqw/@sqw/equal_to_tol.m
+++ b/horace_core/sqw/@sqw/equal_to_tol.m
@@ -139,7 +139,6 @@ else
     % Test pixels in a fraction of non-empty bins, accounting for reordering of pixels
     % if required
 
-
     % Test all fields except the PixelArray
     class_fields = properties(w1);
     for idx = 1:numel(class_fields)
@@ -150,53 +149,55 @@ else
            tmp1.pix=PixelData();
            tmp2.pix=PixelData();
        end
-       [ok, msss] = equal_to_tol(tmp1, tmp2, args{:}, 'name_a',name_a,'name_b',name_b);
+       [ok, mess] = equal_to_tol(tmp1, tmp2, args{:}, 'name_a',name_a,'name_b',name_b);
        if ~ok, return, end
     end
 
     % Check a subset of the bins with reordering
-    npix=w1.data.npix(:);
-    nend=cumsum(npix);  % we already know that w1.data.npix and w2.data.npix are equal
-    nbeg=nend-npix+1;
+    npix = w1.data.npix(:);
+    nend = cumsum(npix); % we already know that w1.data.npix and w2.data.npix are equal
+    nbeg = nend - npix + 1;
 
-    if opt.fraction>0 && any(npix~=0)
+    if opt.fraction > 0 && any(npix ~= 0)
         % Testing of bins requested and there is least one bin with more than one pixel
         % Get indices of bins to test
-        ibin=find(npix>0);
+        ibin = find(npix > 0);
         num_non_empty = numel(ibin);
-        if opt.fraction<1
-            ind=round(1:1/opt.fraction:numel(ibin))';   % Test only a fraction of the non-empty bins
-            ibin=ibin(ind);
+        if opt.fraction < 1
+            ind = round(1:(1/opt.fraction):numel(ibin))'; % Test only a fraction of the non-empty bins
+            ibin = ibin(ind);
         end
-        if horace_info_level>=1
-            disp(['                       Number of bins = ',num2str(numel(npix))])
-            disp(['             Number of non-empty bins = ',num2str(num_non_empty)])
-            disp(['Number of bins that will be reordered = ',num2str(numel(ibin))])
+        if horace_info_level >= 1
+            disp(['                       Number of bins = ', num2str(numel(npix))])
+            disp(['             Number of non-empty bins = ', num2str(num_non_empty)])
+            disp(['Number of bins that will be reordered = ', num2str(numel(ibin))])
             disp(' ')
         end
         % Get the pixel indicies
-        ipix = replicate_iarray(nbeg(ibin),npix(ibin)) + sawtooth_iarray(npix(ibin)) - 1;
-        ibinarr = replicate_iarray(ibin,npix(ibin));    % bin index for each retained pixel
+        ipix = replicate_iarray(nbeg(ibin), npix(ibin)) + sawtooth_iarray(npix(ibin)) - 1;
+        ibinarr = replicate_iarray(ibin, npix(ibin)); % bin index for each retained pixel
         % Now test contents for equality
-        pix1=w1.data.pix;
-        pix2=w2.data.pix;
-        name_a = [name_a,'.pix'];
-        name_b = [name_b,'.pix'];
+        pix1 = w1.data.pix;
+        pix2 = w2.data.pix;
+        name_a = [name_a, '.pix'];
+        name_b = [name_b, '.pix'];
         if opt.reorder
             % Sort retained pixels by bin and then run,det,energy bin indicies
-            fields = {'run_idx', 'detector_idx', 'energy_idx'};
-            [~,ix]=sortrows([ibinarr, pix1.get_data(fields, ipix)']);
-            s1=pix1.get_pixels(ipix).data';
-            s1=s1(ix,:);
-            [~,ix]=sortrows([ibinarr, pix2.get_data(fields, ipix)']);
-            s2=pix2.get_pixels(ipix).data';
-            s2=s2(ix,:);
+            sort_by = {'run_idx', 'detector_idx', 'energy_idx'};
+            [~, ix] = sortrows([ibinarr, pix1.get_data(sort_by, ipix)']);
+            s1 = pix1.get_pixels(ipix);
+            s1 = s1.get_pixels(ix);
+
+            [~, ix] = sortrows([ibinarr, pix2.get_data(sort_by, ipix)']);
+            s2 = pix2.get_pixels(ipix);
+            s2 = s2.get_pixels(ix);
+
             % Now compare retained pixels
-            [ok,mess]=equal_to_tol(s1,s2,args{:},'name_a',name_a,'name_b',name_b );
+            [ok, mess] = equal_to_tol(s1, s2, args{:}, 'name_a', name_a, 'name_b', name_b);
         else
-            s1=pix1.get_pixels(ipix).data;
-            s2=pix2.get_pixels(ipix).data;
-            [ok,mess]=equal_to_tol(s1,s2,args{:},'name_a',name_a,'name_b',name_b);
+            s1 = pix1.get_pixels(ipix);
+            s2 = pix2.get_pixels(ipix);
+            [ok, mess] = equal_to_tol(s1, s2, args{:}, 'name_a', name_a, 'name_b', name_b);
         end
     end
 

--- a/horace_core/sqw/@sqw/equal_to_tol.m
+++ b/horace_core/sqw/@sqw/equal_to_tol.m
@@ -141,13 +141,13 @@ for idx = 1:numel(class_fields)
 end
 
 % Return if failed before expensive or unnecessary PixelData tests
-if ~ok || isempty(w1.data.pix)
+if ~ok
     return
 end
 
 % Perform pixel comparisons
-if (~opt.reorder && opt.fraction==1)
-    % Test strict equality of all pixels
+if (~opt.reorder && opt.fraction==1) || isempty(w1.data.pix) || isempty(w2.data.pix)
+    % Test strict equality of all pixels including cases where one PixelData is empty
     [ok, mess] = equal_to_tol(w1.data.pix, w2.data.pix, args{:}, 'name_a', name_a, 'name_b', name_b);
 else
     % Test pixels in a fraction of non-empty bins, accounting for reordering of pixels

--- a/horace_core/sqw/@sqw/equal_to_tol.m
+++ b/horace_core/sqw/@sqw/equal_to_tol.m
@@ -125,14 +125,26 @@ if ~isnumeric(opt.fraction) || opt.fraction<0 || opt.fraction>1
 end
 
 % Perform comparison
-if (~opt.reorder && opt.fraction==1) || ~isa(w1, 'sqw')
+if (~opt.reorder && opt.fraction==1) || isempty(w1.data.pix)
 
     % Test strict equality of all pixels; pass members as structures to get to the generic equal_to_tol
     class_fields = properties(w1);
     for idx = 1:numel(class_fields)
-       field_name = class_fields(idx);
-       [ok, msss] = equal_to_tol(w1.(field_name), w2.(field_name), args{:}, 'name_a',name_a,'name_b',name_b);
-       if ~ok, return, end
+       field_name = class_fields{idx};
+       tmp1 = w1.(field_name);
+       tmp2 = w2.(field_name);
+       if strcmp(field_name, 'data') && isa(tmp1.pix, 'PixelData')
+           %pixel data equality checked below
+           tmp1.pix=PixelData();
+           tmp2.pix=PixelData();
+       end
+       [ok, mess] = equal_to_tol(tmp1, tmp2, args{:}, ...
+           'name_a', name_a, 'name_b', name_b);
+    end
+
+    if ok
+       [ok, mess] = equal_to_tol(w1.data.pix, w2.data.pix, args{:}, ...
+           'name_a', name_a, 'name_b', name_b);
     end
 
 else

--- a/horace_core/sqw/@sqw/equal_to_tol.m
+++ b/horace_core/sqw/@sqw/equal_to_tol.m
@@ -1,0 +1,204 @@
+function [ok,mess]=equal_to_tol(w1,w2,varargin)
+% Check if two sqw objects are equal to a given tolerance
+%
+%   >> ok = equal_to_tol (a, b)
+%   >> ok = equal_to_tol (a, b, tol)
+%   >> ok = equal_to_tol (..., keyword1, val1, keyword2, val2,...)
+%   >> [ok, mess] = equal_to_tol (...)
+%
+% Class specific version of the generic equal_to_tol that by default
+%   (1) assumes NaN are equivalent (see option 'nan_equal'), and
+%   (2) ignores the order of pixels within a bin as the order is irrelevant
+%       (change the default with option 'reorder')
+%
+% In addition, it is possible to check the contents of just a random
+% fraction of non-empty bins (see option 'fraction') in order to speed up
+% the comparison of large objects.
+%
+% Input:
+% ------
+%   w1,w2   Test objects (scalar objects, or arrays of objects with same sizes)
+%
+%   tol     Tolerance criterion for numeric arrays (Default: [0,0] i.e. equality)
+%           It has the form: [abs_tol, rel_tol] where
+%               abs_tol     absolute tolerance (>=0; if =0 equality required)
+%               rel_tol     relative tolerance (>=0; if =0 equality required)
+%           If either criterion is satified then equality within tolerance
+%           is accepted.
+%             Examples:
+%               [1e-4, 1e-6]    absolute 1e-4 or relative 1e-6 required
+%               [1e-4, 0]       absolute 1e-4 required
+%               [0, 1e-6]       relative 1e-6 required
+%               [0, 0]          equality required
+%               0               equivalent to [0,0]
+%
+%           For backwards compatibility, a scalar tolerance can be given
+%           where the sign determines absolute or relative tolerance
+%               +ve : absolute tolerance  abserr = abs(a-b)
+%               -ve : relative tolerance  relerr = abs(a-b)/max(abs(a),abs(b))
+%             Examples:
+%               1e-4            absolute tolerance, equivalent to [1e-4, 0]
+%               -1e-6           relative tolerance, equivalent to [0, 1e-6]
+%           [To apply an absolute as well as a relative tolerance with a
+%            scalar negative value, set the value of the legacy keyword
+%           'min_denominator' (see below)]
+%
+% Valid keywords are:
+%  'nan_equal'      Treat NaNs as equal (true or false; default=true)
+%
+%  'ignore_str'     Ignore the length and content of strings or cell arrays
+%                  of strings (true or false; default=false)
+%
+%  'reorder'        Ignore the order of pixels within each bin
+%                  (true or false; default=true)
+%                   Only applies if sqw-type object
+%
+%  'fraction'       Compare pixels in only a fraction of the non-empty bins
+%                  (0<= fracton <= 1; default=1 i.e. test all bins)
+%                   Only applies if sqw-type object
+%
+%  	The reorder and fraction options are available because the order of the
+%   pixels within the pix array for a given bin is unimportant. Reordering
+%   takes time, however, so the option to test on a few bins is given.
+
+if isa(w1,'SQWDnDBase') && isa(w2,'SQWDnDBase')
+    % Check array sizes match
+    if ~isequal(size(w1),size(w2))
+        ok=false; mess='Sizes of sqw object arrays being compared are not equal'; return
+    end
+    % Check that corresponding objects in the array have the same type
+    for i=1:numel(w1)
+        if class(w1(i)) ~= class(w2(i))
+            elmtstr=''; if numel(w1)>1, elmtstr=['(element ',num2str(i),')']; end
+            ok=false;
+            mess=['Objects being compared are not both sqw-type or both dnd-type ',elmtstr];
+            return
+        end
+    end
+    % Perform comparison
+    sz = size(w1);
+    for i=1:numel(w1)
+        in_name = cell(1,2);
+        in_name{1} = variable_name (inputname(1),false,sz,i,'input_1');
+        in_name{2} = variable_name (inputname(2),false,sz,i,'input_2');
+        if nargin > 2
+            opt = {'name_a','name_b'};
+            [keyval_list,other]=extract_keyvalues(varargin,opt);
+            if ~isempty(keyval_list)
+                ic = 1;
+                for j=1:2:numel(keyval_list)-1
+                    in_name{ic} = variable_name(keyval_list{j+1},false,sz,i);
+                    ic = ic+1;
+                end
+            end
+        else
+            other = varargin;
+        end
+        [ok,mess]=equal_to_tol_internal(w1(i),w2(i),in_name{1},in_name{2},other{:});
+        if ~ok, return, end
+    end
+else
+    ok=false; mess='One of the objects to be compared is not an sqw object'; return
+end
+
+
+%----------------------------------------------------------------------------------------
+function [ok,mess]=equal_to_tol_internal(w1,w2,name_a,name_b,varargin)
+% Compare scalar sqw objects of same type (sqw-type or dnd-type)
+
+horace_info_level=get(hor_config,'log_level');
+
+% Check for presence of reorder and/or fraction option(s) (only relevant if sqw-type)
+opt=struct('reorder',true,'fraction',1);
+flagnames={};
+cntl.keys_at_end=false;
+cntl.keys_once=false;   % so name_a and name_b can be overridden
+[args,opt,~,~,ok,mess]=parse_arguments(varargin,opt,flagnames,cntl);
+if ~ok
+    error(mess);
+end
+if ~islognumscalar(opt.reorder)
+    error('''reorder'' must be a logical scalar (or 0 or 1)')
+end
+if ~isnumeric(opt.fraction) || opt.fraction<0 || opt.fraction>1
+    error('''fraction'' must lie in the range 0 to 1 inclusive')
+end
+
+% Perform comparison
+if (~opt.reorder && opt.fraction==1) || ~isa(w1, 'sqw')
+
+    % Test strict equality of all pixels; pass members as structures to get to the generic equal_to_tol
+    class_fields = properties(w1);
+    for idx = 1:numel(class_fields)
+       field_name = class_fields(idx);
+       [ok, msss] = equal_to_tol(w1.(field_name), w2.(field_name), args{:}, 'name_a',name_a,'name_b',name_b);
+       if ~ok, return, end
+    end
+
+else
+    % Test pixels in a fraction of non-empty bins, accounting for reordering of pixels
+    % if required
+
+
+    % Test all fields except the PixelArray
+    class_fields = properties(w1);
+    for idx = 1:numel(class_fields)
+       field_name = class_fields{idx};
+       tmp1 = w1.(field_name);
+       tmp2 = w2.(field_name);
+       if strcmp(field_name, 'data') && isa(tmp1.pix, 'PixelData')
+           tmp1.pix=PixelData();
+           tmp2.pix=PixelData();
+       end
+       [ok, msss] = equal_to_tol(tmp1, tmp2, args{:}, 'name_a',name_a,'name_b',name_b);
+       if ~ok, return, end
+    end
+
+    % Check a subset of the bins with reordering
+    npix=w1.data.npix(:);
+    nend=cumsum(npix);  % we already know that w1.data.npix and w2.data.npix are equal
+    nbeg=nend-npix+1;
+
+    if opt.fraction>0 && any(npix~=0)
+        % Testing of bins requested and there is least one bin with more than one pixel
+        % Get indices of bins to test
+        ibin=find(npix>0);
+        num_non_empty = numel(ibin);
+        if opt.fraction<1
+            ind=round(1:1/opt.fraction:numel(ibin))';   % Test only a fraction of the non-empty bins
+            ibin=ibin(ind);
+        end
+        if horace_info_level>=1
+            disp(['                       Number of bins = ',num2str(numel(npix))])
+            disp(['             Number of non-empty bins = ',num2str(num_non_empty)])
+            disp(['Number of bins that will be reordered = ',num2str(numel(ibin))])
+            disp(' ')
+        end
+        % Get the pixel indicies
+        ipix = replicate_iarray(nbeg(ibin),npix(ibin)) + sawtooth_iarray(npix(ibin)) - 1;
+        ibinarr = replicate_iarray(ibin,npix(ibin));    % bin index for each retained pixel
+        % Now test contents for equality
+        pix1=w1.data.pix;
+        pix2=w2.data.pix;
+        name_a = [name_a,'.pix'];
+        name_b = [name_b,'.pix'];
+        if opt.reorder
+            % Sort retained pixels by bin and then run,det,energy bin indicies
+            fields = {'run_idx', 'detector_idx', 'energy_idx'};
+            [~,ix]=sortrows([ibinarr, pix1.get_data(fields, ipix)']);
+            s1=pix1.get_pixels(ipix).data';
+            s1=s1(ix,:);
+            [~,ix]=sortrows([ibinarr, pix2.get_data(fields, ipix)']);
+            s2=pix2.get_pixels(ipix).data';
+            s2=s2(ix,:);
+            % Now compare retained pixels
+            [ok,mess]=equal_to_tol(s1,s2,args{:},'name_a',name_a,'name_b',name_b );
+        else
+            s1=pix1.get_pixels(ipix).data;
+            s2=pix2.get_pixels(ipix).data;
+            [ok,mess]=equal_to_tol(s1,s2,args{:},'name_a',name_a,'name_b',name_b);
+        end
+    end
+
+end
+

--- a/horace_core/sqw/@sqw/equal_to_tol.m
+++ b/horace_core/sqw/@sqw/equal_to_tol.m
@@ -1,4 +1,4 @@
-function [ok,mess]=equal_to_tol(w1,w2,varargin)
+function [ok, mess] = equal_to_tol(w1, w2, varargin)
 % Check if two sqw objects are equal to a given tolerance
 %
 %   >> ok = equal_to_tol (a, b)
@@ -61,66 +61,72 @@ function [ok,mess]=equal_to_tol(w1,w2,varargin)
 %   pixels within the pix array for a given bin is unimportant. Reordering
 %   takes time, however, so the option to test on a few bins is given.
 
-if isa(w1,'SQWDnDBase') && isa(w2,'SQWDnDBase')
+if isa(w1, 'SQWDnDBase') && isa(w2, 'SQWDnDBase')
     % Check array sizes match
-    if ~isequal(size(w1),size(w2))
-        ok=false; mess='Sizes of sqw object arrays being compared are not equal'; return
+    if ~isequal(size(w1), size(w2))
+        ok = false;
+        mess = 'Sizes of sqw object arrays being compared are not equal';
+        return
     end
     % Check that corresponding objects in the array have the same type
-    for i=1:numel(w1)
+    for i = 1:numel(w1)
         if class(w1(i)) ~= class(w2(i))
-            elmtstr=''; if numel(w1)>1, elmtstr=['(element ',num2str(i),')']; end
-            ok=false;
-            mess=['Objects being compared are not both sqw-type or both dnd-type ',elmtstr];
+            elmtstr = '';
+            if numel(w1) > 1, elmtstr = ['(element ', num2str(i), ')'];
+            end
+            ok = false;
+            mess = ['Objects being compared are not both sqw-type or both dnd-type ', elmtstr];
             return
         end
     end
     % Perform comparison
     sz = size(w1);
-    for i=1:numel(w1)
-        in_name = cell(1,2);
-        in_name{1} = variable_name (inputname(1),false,sz,i,'input_1');
-        in_name{2} = variable_name (inputname(2),false,sz,i,'input_2');
+    for i = 1:numel(w1)
+        in_name = cell(1, 2);
+        in_name{1} = variable_name(inputname(1), false, sz, i, 'input_1');
+        in_name{2} = variable_name(inputname(2), false, sz, i, 'input_2');
         if nargin > 2
-            opt = {'name_a','name_b'};
-            [keyval_list,other]=extract_keyvalues(varargin,opt);
+            opt = {'name_a', 'name_b'};
+            [keyval_list, other] = extract_keyvalues(varargin, opt);
             if ~isempty(keyval_list)
                 ic = 1;
-                for j=1:2:numel(keyval_list)-1
-                    in_name{ic} = variable_name(keyval_list{j+1},false,sz,i);
-                    ic = ic+1;
+                for j = 1:2:numel(keyval_list) - 1
+                    in_name{ic} = variable_name(keyval_list{j+1}, false, sz, i);
+                    ic = ic + 1;
                 end
             end
         else
             other = varargin;
         end
-        [ok,mess]=equal_to_tol_internal(w1(i),w2(i),in_name{1},in_name{2},other{:});
+        [ok, mess] = equal_to_tol_internal(w1(i), w2(i), in_name{1}, in_name{2}, other{:});
         if ~ok, return, end
     end
 else
-    ok=false; mess='One of the objects to be compared is not an sqw object'; return
+    ok = false;
+    mess = 'One of the objects to be compared is not an sqw object';
+    return
 end
 
 
 %----------------------------------------------------------------------------------------
-function [ok,mess]=equal_to_tol_internal(w1,w2,name_a,name_b,varargin)
+function [ok, mess] = equal_to_tol_internal(w1, w2, name_a, name_b, varargin)
 % Compare scalar sqw objects of same type (sqw-type or dnd-type)
 
-horace_info_level=get(hor_config,'log_level');
+horace_info_level = get(hor_config, 'log_level');
 
 % Check for presence of reorder and/or fraction option(s) (only relevant if sqw-type)
-opt=struct('reorder',true,'fraction',1);
-flagnames={};
-cntl.keys_at_end=false;
-cntl.keys_once=false;   % so name_a and name_b can be overridden
-[args,opt,~,~,ok,mess]=parse_arguments(varargin,opt,flagnames,cntl);
+opt = struct('reorder', true, 'fraction', 1);
+flagnames = {};
+cntl.keys_at_end = false;
+cntl.keys_once = false; % so name_a and name_b can be overridden
+[args, opt, ~, ~, ok, mess] = parse_arguments(varargin, opt, flagnames, cntl);
 if ~ok
     error(mess);
 end
 if ~islognumscalar(opt.reorder)
     error('''reorder'' must be a logical scalar (or 0 or 1)')
 end
-if ~isnumeric(opt.fraction) || opt.fraction<0 || opt.fraction>1
+if ~isnumeric(opt.fraction) || opt.fraction < 0 || opt.fraction > 1
     error('''fraction'' must lie in the range 0 to 1 inclusive')
 end
 
@@ -129,15 +135,15 @@ end
 % below. Pass class fields to the generic equal_to_tol.
 class_fields = properties(w1);
 for idx = 1:numel(class_fields)
-   field_name = class_fields{idx};
-   tmp1 = w1.(field_name);
-   tmp2 = w2.(field_name);
-   if strcmp(field_name, 'data') && isa(tmp1.pix, 'PixelData')
-       % pixel data equality is checked below
-       tmp1.pix = PixelData();
-       tmp2.pix = PixelData();
-   end
-   [ok, mess] = equal_to_tol(tmp1, tmp2, args{:}, 'name_a', name_a, 'name_b', name_b);
+    field_name = class_fields{idx};
+    tmp1 = w1.(field_name);
+    tmp2 = w2.(field_name);
+    if strcmp(field_name, 'data') && isa(tmp1.pix, 'PixelData')
+        % pixel data equality is checked below
+        tmp1.pix = PixelData();
+        tmp2.pix = PixelData();
+    end
+    [ok, mess] = equal_to_tol(tmp1, tmp2, args{:}, 'name_a', name_a, 'name_b', name_b);
 end
 
 % Return if failed before expensive or unnecessary PixelData tests
@@ -146,25 +152,25 @@ if ~ok
 end
 
 % Perform pixel comparisons
-if (~opt.reorder && opt.fraction==1) || isempty(w1.data.pix) || isempty(w2.data.pix)
+if (~opt.reorder && opt.fraction == 1) || isempty(w1.data.pix) || isempty(w2.data.pix)
     % Test strict equality of all pixels including cases where one PixelData is empty
     [ok, mess] = equal_to_tol(w1.data.pix, w2.data.pix, args{:}, 'name_a', name_a, 'name_b', name_b);
 else
     % Test pixels in a fraction of non-empty bins, accounting for reordering of pixels
     % if required
-
+    
     % Check a subset of the bins with reordering
     npix = w1.data.npix(:);
     nend = cumsum(npix); % we already know that w1.data.npix and w2.data.npix are equal
     nbeg = nend - npix + 1;
-
+    
     if opt.fraction > 0 && any(npix ~= 0)
         % Testing of bins requested and there is least one bin with more than one pixel
         % Get indices of bins to test
         ibin = find(npix > 0);
         num_non_empty = numel(ibin);
         if opt.fraction < 1
-            ind = round(1:(1/opt.fraction):numel(ibin))'; % Test only a fraction of the non-empty bins
+            ind = round(1:(1 / opt.fraction):numel(ibin))'; % Test only a fraction of the non-empty bins
             ibin = ibin(ind);
         end
         if horace_info_level >= 1
@@ -187,11 +193,11 @@ else
             [~, ix] = sortrows([ibinarr, pix1.get_data(sort_by, ipix)']);
             s1 = pix1.get_pixels(ipix);
             s1 = s1.get_pixels(ix);
-
+            
             [~, ix] = sortrows([ibinarr, pix2.get_data(sort_by, ipix)']);
             s2 = pix2.get_pixels(ipix);
             s2 = s2.get_pixels(ix);
-
+            
             % Now compare retained pixels
             [ok, mess] = equal_to_tol(s1, s2, args{:}, 'name_a', name_a, 'name_b', name_b);
         else
@@ -200,6 +206,5 @@ else
             [ok, mess] = equal_to_tol(s1, s2, args{:}, 'name_a', name_a, 'name_b', name_b);
         end
     end
-
+    
 end
-

--- a/horace_core/sqw/@sqw/private/make_sqw.m
+++ b/horace_core/sqw/@sqw/private/make_sqw.m
@@ -1,0 +1,7 @@
+function d = make_sqw(ndims)
+    % Create a structure for an sqw object
+    d.main_header=make_sqw_main_header;
+    d.header=make_sqw_header;
+    d.detpar=make_sqw_detpar;
+    d.data=data_sqw_dnd(ndims);
+end

--- a/horace_core/sqw/@sqw/private/make_sqw.m
+++ b/horace_core/sqw/@sqw/private/make_sqw.m
@@ -1,7 +1,12 @@
 function d = make_sqw(ndims)
-    % Create a structure for an sqw object
-    d.main_header=make_sqw_main_header;
-    d.header=make_sqw_header;
-    d.detpar=make_sqw_detpar;
-    d.data=data_sqw_dnd(ndims);
+% Create a valid structure for an sqw object
+%
+% Input:
+% -------
+% ndim            Number of dimensions
+%
+    d.main_header = make_sqw_main_header;
+    d.header = make_sqw_header;
+    d.detpar = make_sqw_detpar;
+    d.data = data_sqw_dnd(ndims);
 end

--- a/horace_core/sqw/@sqw/private/make_sqw_detpar.m
+++ b/horace_core/sqw/@sqw/private/make_sqw_detpar.m
@@ -22,11 +22,6 @@ function data = make_sqw_detpar
 %                 (West bank=0 deg, North bank=90 deg etc.)
 %   data.width      Row vector of detector widths (m)
 %   data.height     Row vector of detector heights (m)
-%
-
-% Original author: T.G.Perring
-%
-% $Revision:: 1759 ($Date:: 2020-02-10 16:06:00 +0000 (Mon, 10 Feb 2020) $)
 
 data = struct([]);  % empty structure
 

--- a/horace_core/sqw/@sqw/private/make_sqw_detpar.m
+++ b/horace_core/sqw/@sqw/private/make_sqw_detpar.m
@@ -1,0 +1,32 @@
+function data = make_sqw_detpar
+% Make a valid detpar field
+%
+% Syntax:
+%   >> data = make_sqw_detpar
+%
+% Output:
+% -------
+% The default is to create an empty structure, so that the sqw structure neatly
+% resembles the old d0d, d1d,...
+%
+% In the general case, the fields would be:
+%
+%   data         Structure containing fields read from file (details below)
+%
+%   data.filename   Name of file excluding path
+%   data.filepath   Path to file including terminating file separator
+%   data.group      Row vector of detector group number
+%   data.x2         Row vector of secondary flightpath (m)
+%   data.phi        Row vector of scattering angles (deg)
+%   data.azim       Row vector of azimuthal angles (deg)
+%                 (West bank=0 deg, North bank=90 deg etc.)
+%   data.width      Row vector of detector widths (m)
+%   data.height     Row vector of detector heights (m)
+%
+
+% Original author: T.G.Perring
+%
+% $Revision:: 1759 ($Date:: 2020-02-10 16:06:00 +0000 (Mon, 10 Feb 2020) $)
+
+data = struct([]);  % empty structure
+

--- a/horace_core/sqw/@sqw/private/make_sqw_header.m
+++ b/horace_core/sqw/@sqw/private/make_sqw_header.m
@@ -35,9 +35,5 @@ function data = make_sqw_header
 %   data.instrument Instrument information - free format
 %   data.sample     Sample information - free format
 
-% Original author: T.G.Perring
-%
-% $Revision:: 1759 ($Date:: 2020-02-10 16:06:00 +0000 (Mon, 10 Feb 2020) $)
-
 data = struct([]);  % empty structure
 

--- a/horace_core/sqw/@sqw/private/make_sqw_header.m
+++ b/horace_core/sqw/@sqw/private/make_sqw_header.m
@@ -1,0 +1,43 @@
+function data = make_sqw_header
+% Make a valid default header block.
+%
+% Syntax:
+%   >> data = make_sqw_header
+%
+% Output:
+% -------
+% The default is to create an empty structure, so that the sqw structure neatly
+% resembles the old d0d, d1d,...
+%
+% In the general case, the fields would be:
+%
+%   data        Structure containing following fields
+%
+%   data.filename   Name of sqw file excluding path
+%   data.filepath   Path to sqw file including terminating file separator
+%   data.efix       Fixed energy (ei or ef depending on emode)
+%   data.emode      Emode=1 direct geometry, =2 indirect geometry
+%   data.alatt      Lattice parameters (Angstroms)
+%   data.angdeg     Lattice angles (deg)
+%   data.cu         First vector defining scattering plane (r.l.u.)
+%   data.cv         Second vector defining scattering plane (r.l.u.)
+%   data.psi        Orientation angle (deg)
+%   data.omega      --|
+%   data.dpsi         |  Crystal misorientation description (deg)
+%   data.gl           |  (See notes elsewhere e.g. Tobyfit manual
+%   data.gs         --|
+%   data.en         Energy bin boundaries (meV) [column vector]
+%   data.uoffset    Offset of origin of projection axes in r.l.u. and energy ie. [h; k; l; en] [column vector]
+%   data.u_to_rlu   Matrix (4x4) of projection axes in hkle representation
+%                      u(:,1) first vector - u(1:3,1) r.l.u., u(4,1) energy etc.
+%   data.ulen       Length of projection axes vectors in Ang^-1 or meV [row vector]
+%   data.ulabel     Labels of the projection axes [1x4 cell array of character strings]
+%   data.instrument Instrument information - free format
+%   data.sample     Sample information - free format
+
+% Original author: T.G.Perring
+%
+% $Revision:: 1759 ($Date:: 2020-02-10 16:06:00 +0000 (Mon, 10 Feb 2020) $)
+
+data = struct([]);  % empty structure
+

--- a/horace_core/sqw/@sqw/private/make_sqw_main_header.m
+++ b/horace_core/sqw/@sqw/private/make_sqw_main_header.m
@@ -1,0 +1,26 @@
+function data = make_sqw_main_header
+% Make a valid default main header block.
+%
+% Syntax:
+%   >> data = make_sqw_main_header
+%
+% Output:
+% -------
+% The default is to create an empty structure, so that the sqw structure neatly
+% resembles the old d0d, d1d,...
+%
+% In the general case, the fields would be:
+%
+%   data        Structure containing following fields:
+%
+%   data.filename   Name of sqw file that is being read, excluding path
+%   data.filepath   Path to sqw file that is being read, including terminating file separator
+%   data.title      Title of sqw data structure
+%   data.nfiles     Number of spe files that contribute
+
+% Original author: T.G.Perring
+%
+% $Revision:: 1759 ($Date:: 2020-02-10 16:06:00 +0000 (Mon, 10 Feb 2020) $)
+
+data = struct([]);  % empty structure    
+

--- a/horace_core/sqw/@sqw/private/make_sqw_main_header.m
+++ b/horace_core/sqw/@sqw/private/make_sqw_main_header.m
@@ -18,9 +18,5 @@ function data = make_sqw_main_header
 %   data.title      Title of sqw data structure
 %   data.nfiles     Number of spe files that contribute
 
-% Original author: T.G.Perring
-%
-% $Revision:: 1759 ($Date:: 2020-02-10 16:06:00 +0000 (Mon, 10 Feb 2020) $)
-
-data = struct([]);  % empty structure    
+data = struct([]);  % empty structure
 

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -1,0 +1,96 @@
+classdef sqw < SQWDnDBase
+
+    %SQW_NEW reate an sqw object
+    %
+    % Syntax:
+    %   >> w = sqw (filename)       % Create an sqw object from a file
+    %   >> w = sqw (sqw_object)     % Create a new SQW object from a existing one
+    %   >> w = sqw (struct)         % Create from a structure with valid fields
+    %   >> w = sqw ()               % Create a default, zero-dimensional SQW object
+
+    properties
+        main_header
+        header
+        detpar
+        data
+    end
+
+    methods
+        function obj = sqw(varargin)
+            % Constructors
+            % i) struct
+            % ii) filename
+            % iii) copy
+            obj = obj@SQWDnDBase();
+
+            [args] = obj.parse_args(varargin{:});
+
+            % i) copy
+            if ~isempty(args.sqw_obj)
+               obj = copy(args.sqw_obj);
+
+            % ii) filename
+            elseif ~isempty(args.filename)
+                ldr = sqw_formats_factory.instance().get_loader(varargin{1});
+                if ~strcmpi(ldr.data_type,'a')   % not a valid sqw-type structure
+                    error('Data file does not contain valid sqw-type object');
+                end
+
+                w=struct();
+                [w.main_header,w.header,w.detpar,w.data] = ldr.get_sqw('-legacy');
+                obj = obj.init_from_loader_struct(w);
+
+            % iii) struct
+            elseif ~isempty(args.data_struct)
+                obj = obj.init_from_loader_struct(args.data_struct);
+            end
+        end
+    end
+
+    methods (Static, Access = 'private')
+        % Signatures of private functions declared in files
+        sqw_struct = make_sqw(ndims);
+        detpar_struct = make_sqw_detpar();
+        header = make_sqw_header();
+        main_header = make_sqw_main_header();
+
+        function args = parse_args(varargin)
+            % Parse a single argument passed to the SQW constructor
+            %
+            % Return struct with the data set to the appropriate element:
+            % args.filename  % string, presumed to be filename
+            % args.sqw_obj   % SQW class instance
+            % args.data_struct % generic struct, presumed to represent SQW
+            parser = inputParser();
+            parser.addOptional('input', [], @(x) (isa(x, 'SQWDnDBase') || is_string(x) || isstruct(x)));
+            parser.KeepUnmatched = true;
+            parser.parse(varargin{:});
+
+            input = parser.Results.input;
+            args = struct('sqw_obj', [], 'filename', [], 'data_struct', []);
+            if isa(input, 'sqw')
+               if isa(input, 'DnDBase')
+                    error('SQW cannot be constructed from a DnD object');
+               end
+                args.sqw_obj = input;
+            elseif is_string(parser.Results.input)
+                args.filename = input;
+            elseif isstruct(input) && ~isempty(input)
+                args.data_struct = input;
+            else
+                % create struct holding default instance
+                args.data_struct = make_sqw(0);
+            end
+        end
+    end
+
+    methods (Access ='private')
+        function obj = init_from_loader_struct(obj, data_struct)
+            obj.main_header = data_struct.main_header;
+            obj.header = data_struct.header;
+            obj.detpar = data_struct.detpar;
+            obj.data = data_struct.data;
+        end
+    end
+end
+

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -1,6 +1,5 @@
 classdef sqw < SQWDnDBase
-
-    %SQW_NEW reate an sqw object
+    %SQW Create an sqw object
     %
     % Syntax:
     %   >> w = sqw (filename)       % Create an sqw object from a file
@@ -37,6 +36,24 @@ classdef sqw < SQWDnDBase
             elseif ~isempty(args.data_struct)
                 obj = obj.init_from_loader_struct(args.data_struct);
             end
+        end
+    end
+
+    methods (Static)
+        function obj = loadobj(S)
+            % Load a sqw object from a .mat file
+            %
+            %   >> obj = loadobj(S)
+            %
+            % Input:
+            % ------
+            %   S       An instance of this object or struct
+            %
+            % Output:
+            % -------
+            %   obj     An instance of this object
+            %
+               obj = sqw(S);
         end
     end
 

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -61,10 +61,11 @@ classdef sqw < SQWDnDBase
 
             input = parser.Results.input;
             args = struct('sqw_obj', [], 'filename', [], 'data_struct', []);
-            if isa(input, 'sqw')
-               if isa(input, 'DnDBase')
-                    error('SQW cannot be constructed from a DnD object');
-               end
+
+            if isa(input, 'SQWDnDBase')
+                if isa(input, 'DnDBase')
+                    error('SQW:sqw', 'SQW cannot be constructed from a DnD object');
+                end
                 args.sqw_obj = input;
             elseif is_string(parser.Results.input)
                 args.filename = input;

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -40,21 +40,24 @@ classdef sqw < SQWDnDBase
     end
 
     methods (Static)
-        function obj = loadobj(S)
-            % Load a sqw object from a .mat file
-            %
-            %   >> obj = loadobj(S)
-            %
-            % Input:
-            % ------
-            %   S       An instance of this object or struct
-            %
-            % Output:
-            % -------
-            %   obj     An instance of this object
-            %
-               obj = sqw(S);
-        end
+%TODO: disabled until full functionality is implemeneted in new class;
+% The addition of this method causes sqw_old tests to incorrectly load data from .mat files
+% as new-SQW class objects
+%        function obj = loadobj(S)
+%            % Load a sqw object from a .mat file
+%            %
+%            %   >> obj = loadobj(S)
+%            %
+%            % Input:
+%            % ------
+%            %   S       An instance of this object or struct
+%            %
+%            % Output:
+%            % -------
+%            %   obj     An instance of this object
+%            %
+%               obj = sqw(S);
+%        end
     end
 
     methods (Static, Access = 'private')

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -5,7 +5,7 @@ classdef sqw < SQWDnDBase
     % Syntax:
     %   >> w = sqw (filename)       % Create an sqw object from a file
     %   >> w = sqw (sqw_object)     % Create a new SQW object from a existing one
-    %   >> w = sqw (struct)         % Create from a structure with valid fields
+    %   >> w = sqw (struct)         % Create from a structure with valid fields (internal use)
     %   >> w = sqw ()               % Create a default, zero-dimensional SQW object
 
     properties
@@ -18,7 +18,7 @@ classdef sqw < SQWDnDBase
     methods
         function obj = sqw(varargin)
             % Constructors
-            % i) struct
+            % i) struct (internal)
             % ii) filename
             % iii) copy
             obj = obj@SQWDnDBase();

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -31,14 +31,7 @@ classdef sqw < SQWDnDBase
 
             % ii) filename
             elseif ~isempty(args.filename)
-                ldr = sqw_formats_factory.instance().get_loader(varargin{1});
-                if ~strcmpi(ldr.data_type,'a')   % not a valid sqw-type structure
-                    error('Data file does not contain valid sqw-type object');
-                end
-
-                w=struct();
-                [w.main_header,w.header,w.detpar,w.data] = ldr.get_sqw('-legacy');
-                obj = obj.init_from_loader_struct(w);
+               obj = obj.init_from_file(args.filename);
 
             % iii) struct
             elseif ~isempty(args.data_struct)
@@ -84,7 +77,21 @@ classdef sqw < SQWDnDBase
         end
     end
 
-    methods (Access ='private')
+    methods (Access = 'private')
+        function obj = init_from_file(obj, in_filename)
+            % Parse SQW from file
+            %
+            % An error is raised if the data file is identified not a SQW object
+            ldr = sqw_formats_factory.instance().get_loader(in_filename);
+            if ~strcmpi(ldr.data_type,'a')   % not a valid sqw-type structure
+                error('SQW:sqw', 'Data file does not contain valid sqw-type object');
+            end
+
+            w=struct();
+            [w.main_header, w.header, w.detpar, w.data] = ldr.get_sqw('-legacy');
+            obj = obj.init_from_loader_struct(w);
+        end
+
         function obj = init_from_loader_struct(obj, data_struct)
             obj.main_header = data_struct.main_header;
             obj.header = data_struct.header;

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -6,14 +6,14 @@ classdef sqw < SQWDnDBase
     %   >> w = sqw (sqw_object)     % Create a new SQW object from a existing one
     %   >> w = sqw (struct)         % Create from a structure with valid fields (internal use)
     %   >> w = sqw ()               % Create a default, zero-dimensional SQW object
-
+    
     properties
         main_header
         header
         detpar
         data
     end
-
+    
     methods
         function obj = sqw(varargin)
             % Constructors
@@ -21,52 +21,52 @@ classdef sqw < SQWDnDBase
             % ii) filename
             % iii) copy
             obj = obj@SQWDnDBase();
-
+            
             [args] = obj.parse_args(varargin{:});
-
+            
             % i) copy
             if ~isempty(args.sqw_obj)
-               obj = copy(args.sqw_obj);
-
-            % ii) filename
+                obj = copy(args.sqw_obj);
+                
+                % ii) filename
             elseif ~isempty(args.filename)
-               obj = obj.init_from_file(args.filename);
-
-            % iii) struct
+                obj = obj.init_from_file(args.filename);
+                
+                % iii) struct
             elseif ~isempty(args.data_struct)
                 obj = obj.init_from_loader_struct(args.data_struct);
             end
         end
     end
-
-    methods (Static)
-%TODO: disabled until full functionality is implemeneted in new class;
-% The addition of this method causes sqw_old tests to incorrectly load data from .mat files
-% as new-SQW class objects
-%        function obj = loadobj(S)
-%            % Load a sqw object from a .mat file
-%            %
-%            %   >> obj = loadobj(S)
-%            %
-%            % Input:
-%            % ------
-%            %   S       An instance of this object or struct
-%            %
-%            % Output:
-%            % -------
-%            %   obj     An instance of this object
-%            %
-%               obj = sqw(S);
-%        end
+    
+    methods(Static)
+        %TODO: disabled until full functionality is implemeneted in new class;
+        % The addition of this method causes sqw_old tests to incorrectly load data from .mat files
+        % as new-SQW class objects
+        %        function obj = loadobj(S)
+        %            % Load a sqw object from a .mat file
+        %            %
+        %            %   >> obj = loadobj(S)
+        %            %
+        %            % Input:
+        %            % ------
+        %            %   S       An instance of this object or struct
+        %            %
+        %            % Output:
+        %            % -------
+        %            %   obj     An instance of this object
+        %            %
+        %               obj = sqw(S);
+        %        end
     end
-
-    methods (Static, Access = 'private')
+    
+    methods(Static, Access = 'private')
         % Signatures of private functions declared in files
         sqw_struct = make_sqw(ndims);
         detpar_struct = make_sqw_detpar();
         header = make_sqw_header();
         main_header = make_sqw_main_header();
-
+        
         function args = parse_args(varargin)
             % Parse a single argument passed to the SQW constructor
             %
@@ -78,10 +78,10 @@ classdef sqw < SQWDnDBase
             parser.addOptional('input', [], @(x) (isa(x, 'SQWDnDBase') || is_string(x) || isstruct(x)));
             parser.KeepUnmatched = true;
             parser.parse(varargin{:});
-
+            
             input = parser.Results.input;
             args = struct('sqw_obj', [], 'filename', [], 'data_struct', []);
-
+            
             if isa(input, 'SQWDnDBase')
                 if isa(input, 'DnDBase')
                     error('SQW:sqw', 'SQW cannot be constructed from a DnD object');
@@ -97,22 +97,22 @@ classdef sqw < SQWDnDBase
             end
         end
     end
-
-    methods (Access = 'private')
+    
+    methods(Access = 'private')
         function obj = init_from_file(obj, in_filename)
             % Parse SQW from file
             %
             % An error is raised if the data file is identified not a SQW object
             ldr = sqw_formats_factory.instance().get_loader(in_filename);
-            if ~strcmpi(ldr.data_type,'a')   % not a valid sqw-type structure
+            if ~strcmpi(ldr.data_type, 'a') % not a valid sqw-type structure
                 error('SQW:sqw', 'Data file does not contain valid sqw-type object');
             end
-
-            w=struct();
+            
+            w = struct();
             [w.main_header, w.header, w.detpar, w.data] = ldr.get_sqw('-legacy');
             obj = obj.init_from_loader_struct(w);
         end
-
+        
         function obj = init_from_loader_struct(obj, data_struct)
             obj.main_header = data_struct.main_header;
             obj.header = data_struct.header;
@@ -121,4 +121,3 @@ classdef sqw < SQWDnDBase
         end
     end
 end
-

--- a/horace_core/sqw/PixelData/@PixelData/equal_to_tol.m
+++ b/horace_core/sqw/PixelData/@PixelData/equal_to_tol.m
@@ -1,0 +1,128 @@
+function [ok, mess] = equal_to_tol(obj, other_pix, varargin)
+%% EQUAL_TO_TOL Check if two PixelData objects are equal to a given tolerance
+%
+% Input:
+% ------
+% pix        The first pixel data object to compare.
+%
+% other_pix  The second pixel data object to compare.
+%
+% tol        Tolerance criterion for numeric arrays
+%            (default = [0, 0] i.e. equality)
+%            It has the form: [abs_tol, rel_tol] where
+%               abs_tol     absolute tolerance (>=0; if =0 equality required)
+%               rel_tol     relative tolerance (>=0; if =0 equality required)
+%            If either criterion is satisfied then equality within tolerance
+%            is accepted.
+%             Examples:
+%               [1e-4, 1e-6]    absolute 1e-4 or relative 1e-6 required
+%               [1e-4, 0]       absolute 1e-4 required
+%               [0, 1e-6]       relative 1e-6 required
+%               [0, 0]          equality required
+%               0               equivalent to [0,0]
+%
+%            A scalar tolerance can be given where the sign determines if
+%            the tolerance is absolute or relative:
+%               +ve : absolute tolerance  abserr = abs(a-b)
+%               -ve : relative tolerance  relerr = abs(a-b)/max(abs(a),abs(b))
+%            Examples:
+%               1e-4            absolute tolerance, equivalent to [1e-4, 0]
+%               -1e-6           relative tolerance, equivalent to [0, 1e-6]
+%
+% Keyword Input:
+% ---------------
+% nan_equal  Treat NaNs as equal (true or false; default=true).
+%
+% name_a     Explicit name of variable a for use in messages
+%            Usually not required, as the name of a variable will
+%            be discovered. However, if the input argument is an array
+%            element e.g. my_variable{3}  then the name is not
+%            discoverable in Matlab, and default 'input_1' will be
+%            used unless a different value is given with the keyword 'name_a'.
+%            (default = 'input_1').
+%
+% name_b     Explicit name of variable b for use in messages.
+%            The same comments apply as for 'name_a' except the default is
+%            'input_2'.
+%            (default = 'input_2').
+%
+parse_args(varargin{:});
+
+[ok, mess] = validate_other_pix(obj, other_pix);
+if ~ok
+    return
+end
+
+obj = obj.move_to_first_page();
+other_pix = other_pix.move_to_first_page();
+
+if obj.page_size == other_pix.page_size
+    [ok, mess] = equal_to_tol(obj.data, other_pix.data, varargin{:});
+    while ok && obj.has_more()
+        obj = obj.advance();
+        other_pix = other_pix.advance();
+        [ok, mess] = equal_to_tol(obj.data, other_pix.data, varargin{:});
+    end
+elseif ~obj.is_file_backed_()
+    [ok, mess] = pix_paged_and_in_mem_equal_to_tol(other_pix, obj, varargin{:});
+elseif ~other_pix.is_file_backed_()
+    [ok, mess] = pix_paged_and_in_mem_equal_to_tol(obj, other_pix, varargin{:});
+else
+    error('PIXELDATA:equal_to_tol', ...
+          ['Cannot compare PixelData objects that have different page ' ...
+           'sizes.\nFound page sizes %i and %i.'], obj.page_size, ...
+          other_pix.page_size);
+end
+
+end
+
+
+% -----------------------------------------------------------------------------
+function [ok, mess] = pix_paged_and_in_mem_equal_to_tol(...
+        paged_pix, in_mem_pix, varargin)
+    start_idx = 1;
+    end_idx = paged_pix.page_size;
+    [ok, mess] = equal_to_tol(in_mem_pix.data(:, start_idx:end_idx), ...
+                              paged_pix.data, varargin{:});
+    while ok && paged_pix.has_more()
+        paged_pix.advance();
+        start_idx = end_idx + 1;
+        end_idx = end_idx + paged_pix.page_size;
+        [ok, mess] = equal_to_tol(in_mem_pix.data(:, start_idx:end_idx), ...
+                                  paged_pix.data, varargin{:});
+    end
+end
+
+
+function [ok, mess] = validate_other_pix(obj, other_pix)
+    ok = true;
+    mess = '';
+
+    if ~isa(other_pix, 'PixelData')
+        ok = false;
+        mess = sprintf('Objects of class ''%s'' and ''%s'' cannot be equal.', ...
+                       class(obj), class(other_pix));
+        return
+    end
+
+    if ~all(size(obj) == size(other_pix))
+        ok = false;
+        mess = sprintf(['PixelData objects are not equal. ' ...
+                        'Argument 1 has size [%s] , argument 2 has size [%s]'], ...
+                       num2str(size(obj)), num2str(size(other_pix)));
+        return
+    end
+end
+
+
+function parse_args(varargin)
+    parser = inputParser();
+    % these params are used for validation only, they will be passed to
+    % Herbert's equal_to_tol via varargin
+    parser.addOptional('tol', [0, 0], @(x) (numel(x) <= 2));
+    parser.addParameter('nan_equal', true, @(x) isscalar(x) && islogical(x));
+    parser.addParameter('name_a', 'input_1', @ischar);
+    parser.addParameter('name_b', 'input_2', @ischar);
+    parser.KeepUnmatched = true;  % ignore unmatched parameters
+    parser.parse(varargin{:});
+end


### PR DESCRIPTION
Initial SQW constructors for the core use cases

Deliberately retain current the original class attributes in first phase of rewrite. These will be replace/updated later in the process.
Base class is not used for anything at the moment so cleaned out the demo props it had contained.