### PR TITLE
Do not use Groovy interpolation for Jenkins creds

### DIFF
--- a/documentation/smg/08_setting_up_jenkins_ci.md
+++ b/documentation/smg/08_setting_up_jenkins_ci.md
@@ -271,9 +271,49 @@ For this, the `pace.builder` GitHub account has been created and given write
 permissions to the Horace and Herbert repository.
 The email for this account is `pace.buider.stfc@gmail.co.uk`.
 
+### Using Jenkins credentials
+
 Credentials are saved in the Jenkins PACE area providing an API token linked
 to the account.
+See the
+"[using credentials](https://www.jenkins.io/doc/book/using/using-credentials/)"
+section of the Jenkins documentation.
+
 These credentials can be accessed within the Jenkinsfile using a
 `withCredentials` block,
-this block will prevent the credentials being printed to the terminal.
-Jenkins logs are not private, be careful to never publish passwords or API tokens.
+this block will prevent the credentials being printed to the Jenkins log.
+
+Do not assume Jenkins logs are private,
+be careful to never publish passwords or API tokens.
+
+#### Credentials in shell commands
+
+Avoid string interpolation of credentials when using `"`.
+Use literal (single-quoted) strings instead, or,
+if you need to use string interpolation for another variable,
+escape the `$` with a backslash when referencing the credential.
+See
+[the Jenkins docs](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#interpolation-of-sensitive-environment-variables)
+for the explanation why.
+
+```Groovy
+def url = "https://github.com/"
+
+withCredentials([string(credentialsId: 'TOKEN_ID', variable: 'secret')]) {
+
+  /* INSECURE */
+  sh """
+    curl -H "Authorization: token ${secret}" ${url}
+  """
+
+  /* OK */
+  sh '''
+    curl -H "Authorization: token ${secret}" https://github.com/
+  '''
+
+  /* OK */
+  sh """
+    curl -H "Authorization: token \${secret}" ${url}
+  """
+}
+```

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -144,7 +144,7 @@ def post_github_status(String state, String message) {
           variable: 'api_token')]) {
         if (isUnix()) {
           sh """
-            curl -H "Authorization: token ${api_token}" \
+            curl -H "Authorization: token \${api_token}" \
               --request POST \
               --data '{"state": "${state}", \
                 "description": "${message}", \
@@ -163,7 +163,7 @@ def post_github_status(String state, String message) {
               "context" = "$JOB_BASE_NAME"}
 
             Invoke-RestMethod -URI "$PR_STATUSES_URL" \
-              -Headers @{Authorization = "token ${api_token}"} \
+              -Headers @{Authorization = "token \$env:api_token"} \
               -Method 'POST' \
               -Body (\$payload|ConvertTo-JSON) \
               -ContentType "application/json"


### PR DESCRIPTION
If you use Groovy string interpolation when passing credentials to a
shell command, the secret will be executed in plain text on the agent.
The Jenkins logs will still mask the credentials, but any command
logging on the agent machine will leak the secret.

Using the environment variable set by the withCredentials block means
the command does not contain the secret, any command logs will only show
an environment variable was accessed.

See https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#interpolation-of-sensitive-environment-variables.