### PR TITLE
Add Binary Ops to D2D object

### DIFF
--- a/_test/test_dnd_class/test_binary_ops.m
+++ b/_test/test_dnd_class/test_binary_ops.m
@@ -1,0 +1,141 @@
+classdef test_binary_ops < TestCase
+%% TEST_BINARY_OPS tests for behaviour of binary operations between SQW and
+% and other type of objects e.g. scalars, dnd and other SQW objects
+%
+properties (Constant)
+    DOUBLE_REL_TOLERANCE = 10e-6;
+end
+
+properties
+    test_sqw_file_path = '../test_sqw_file/sqw_2d_1.sqw';
+    base_sqw_obj;
+    sqw_obj;
+    dnd_obj;
+end
+
+methods
+
+    function obj = test_binary_ops(varargin)
+        obj = obj@TestCase('test_binary_ops');
+
+        obj.base_sqw_obj = sqw(obj.test_sqw_file_path);
+    end
+
+    function obj = setUp(obj)
+        obj.sqw_obj = copy(obj.base_sqw_obj);
+        obj.dnd_obj = d2d(obj.base_sqw_obj);
+    end
+
+    function test_DNDBASE_error_if_operand_is_char(obj)
+        f = @() ('some char' + obj.dnd_obj);
+        ff = @()  (obj.dnd_obj + 'some char');
+        assertExceptionThrown(f, 'DNDBASE:binary_op_manager_single');
+        assertExceptionThrown(ff, 'DNDBASE:binary_op_manager_single');
+    end
+
+    function test_DNDBASE_error_if_operand_is_cell_array(obj)
+        f = @() ({1, 2, 3} + obj.dnd_obj);
+        ff = @() (obj.dnd_obj + {0});
+        assertExceptionThrown(f, 'DNDBASE:binary_op_manager_single');
+        assertExceptionThrown(ff, 'DNDBASE:binary_op_manager_single');
+    end
+
+    function test_DNDBASE_error_if_operand_is_numeric_but_not_double(obj)
+        unsupported_types = {@single, @int8, @int16, @int32, @int64, ...
+                             @uint8, @uint16, @uint32, @uint64};
+
+        for i = 1:numel(unsupported_types)
+            type_func = unsupported_types{i};
+            numeric_array = type_func(ones(size(obj.sqw_obj.data.npix)));
+            f = @() (obj.dnd_obj + numeric_array);
+            ff = @() (numeric_array + obj.dnd_obj);
+            assertExceptionThrown(f, 'DNDBASE:binary_op_manager_single');
+            assertExceptionThrown(ff, 'DNDBASE:binary_op_manager_single');
+        end
+    end
+
+    function test_adding_dnd_and_sqw_objects_2nd_operand_is_sqw_returns_sqw(obj)
+        out = obj.dnd_obj + obj.sqw_obj;
+
+        assertTrue(isa(out, 'sqw'));
+
+        expected_signal = obj.sqw_obj.data.s + obj.dnd_obj.s;
+        assertElementsAlmostEqual(out.data.s, expected_signal, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+    end
+
+    function test_dnd_minus_equivalent_sqw_returns_sqw_with_zero_image_data(obj)
+        out = obj.dnd_obj - obj.sqw_obj;
+
+        assertTrue(isa(out, 'sqw'));
+
+        % Scale the difference to account for floating point errors
+        scaled_diff = out.data.s./max(obj.dnd_obj.s, obj.sqw_obj.data.s);
+        scaled_diff(isnan(scaled_diff)) = 0;
+
+        expected_signal = zeros(size(obj.sqw_obj.data.s));
+        assertElementsAlmostEqual(scaled_diff, expected_signal, 'absolute', ...
+                                  1e-7);
+    end
+
+    function test_subtracting_scalar_from_dnd_returns_dnd(obj)
+        scalar_operand = 1.3;
+        out = obj.dnd_obj - scalar_operand;
+
+        assertTrue(isa(out, 'DnDBase'));
+
+        expected_signal = obj.dnd_obj.s - scalar_operand;
+        expected_signal(obj.dnd_obj.npix == 0) = 0;
+        assertElementsAlmostEqual(out.s, expected_signal, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+    end
+
+    function test_subtracting_dnd_from_scalar_returns_dnd(obj)
+        scalar_operand = 0.3;
+        out = scalar_operand - obj.dnd_obj;
+
+        assertTrue(isa(out, 'DnDBase'));
+
+        expected_signal = scalar_operand - obj.dnd_obj.s;
+        expected_signal(obj.dnd_obj.npix == 0) = 0;
+        assertElementsAlmostEqual(out.s, expected_signal, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+    end
+
+    function test_subtracting_two_dnd_objects_returns_dnd(obj)
+        out = obj.dnd_obj - obj.dnd_obj;
+
+        assertTrue(isa(out, 'DnDBase'));
+        assertElementsAlmostEqual(out.s, zeros(size(out.s)));
+    end
+
+    function test_adding_dnd_and_sigvar_with_dnd_1st_operand_returns_dnd(obj)
+        signal = 1e5 * (1 + rand(size(obj.dnd_obj.s)));
+        variance = 1e5 * (1 + rand(size(obj.dnd_obj.s)));
+        out = obj.dnd_obj + sigvar(signal, variance);
+
+        assertTrue(isa(out, 'DnDBase'));
+
+        expected_signal = obj.dnd_obj.s + signal;
+        expected_signal(obj.dnd_obj.npix == 0) = 0;
+        assertElementsAlmostEqual(out.s, expected_signal, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+    end
+
+    function test_adding_dnd_and_sigvar_with_dnd_2nd_operand_returns_sigvar(obj)
+        signal = 1e5 * (1 + rand(size(obj.dnd_obj.s)));
+        variance = 1e5 * (1 + rand(size(obj.dnd_obj.s)));
+        out = sigvar(signal, variance) + obj.dnd_obj;
+
+        assertTrue(isa(out, 'sigvar'));
+
+        expected_sigvar = sigvar(obj.dnd_obj.s + signal, ...
+                                 obj.dnd_obj.e + variance);
+        assertElementsAlmostEqual(out.s, expected_sigvar.s, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+        assertElementsAlmostEqual(out.e, expected_sigvar.e, 'relative', ...
+                                  obj.DOUBLE_REL_TOLERANCE);
+    end
+end
+
+end

--- a/_test/test_sqw/test_PixelData_binary_ops.m
+++ b/_test/test_sqw/test_PixelData_binary_ops.m
@@ -290,32 +290,6 @@ methods
         assertExceptionThrown(f, 'PIXELDATA:binary_op_double_');
     end
 
-    function test_PIXELDATA_error_on_with_dnd_of_wrong_size(obj)
-        dnd_obj = d1d_old(obj.test_sqw_file_path);
-        pix = PixelData(zeros(9, 2));
-        f = @() pix.do_binary_op(dnd_obj, @plus_single);
-        assertExceptionThrown(f, 'PIXELDATA:do_binary_op');
-    end
-
-    function test_with_1d_dnd_returns_correct_pix_with_single_page(obj)
-        dnd_obj = d1d_old(obj.test_sqw_file_path);
-        npix = dnd_obj.npix;
-        pix = PixelData(ones(9, sum(npix)));
-
-        new_pix = pix.do_binary_op(dnd_obj, @plus_single, 'flip', false, ...
-                                   'npix', npix);
-
-        original_pix_data = concatenate_pixel_pages(pix);
-        new_pix_data = concatenate_pixel_pages(new_pix);
-
-        expected_pix = original_pix_data;
-        expected_pix(obj.SIGNAL_IDX, :) = ...
-            expected_pix(obj.SIGNAL_IDX, :) + repelem(dnd_obj.s(:), npix(:))';
-        expected_pix(obj.VARIANCE_IDX, :) = ...
-            expected_pix(obj.VARIANCE_IDX, :) + repelem(dnd_obj.e(:), npix(:))';
-        assertEqual(new_pix_data, expected_pix);
-    end
-
     function test_with_sigvar_returns_correct_pix_with_single_page(obj)
         dnd_obj = d1d_old(obj.test_sqw_file_path);
         npix = dnd_obj.npix;
@@ -335,28 +309,6 @@ methods
         expected_pix(obj.VARIANCE_IDX, :) = ...
             expected_pix(obj.VARIANCE_IDX, :) + repelem(svar.e(:), npix(:))';
         assertEqual(new_pix_data, expected_pix);
-    end
-
-    function test_with_1d_dnd_returns_correct_pix_with_gt_1_page(obj)
-        dnd_obj = d1d_old(obj.test_sqw_file_path);
-        npix = dnd_obj.npix;
-
-        pix_per_page = floor(sum(npix)/6);
-        pix = PixelData(obj.test_sqw_file_path, pix_per_page*obj.BYTES_PER_PIX);
-
-        new_pix = pix.do_binary_op(dnd_obj, @plus_single, 'flip', false, ...
-                                'npix', npix);
-
-        original_pix_data = concatenate_pixel_pages(pix);
-        new_pix_data = concatenate_pixel_pages(new_pix);
-
-        expected_pix = original_pix_data;
-        expected_pix(obj.SIGNAL_IDX, :) = ...
-            expected_pix(obj.SIGNAL_IDX, :) + repelem(dnd_obj.s(:), npix(:))';
-        expected_pix(obj.VARIANCE_IDX, :) = ...
-            expected_pix(obj.VARIANCE_IDX, :) + repelem(dnd_obj.e(:), npix(:))';
-        assertElementsAlmostEqual(new_pix_data, expected_pix, 'relative', ...
-                                  obj.FLOAT_TOLERANCE);
     end
 
     function test_with_sigvar_returns_correct_pix_with_gt_1_page(obj)
@@ -414,35 +366,6 @@ methods
             expected_pix(obj.SIGNAL_IDX, :) + repelem(svar.s(:), npix(:))';
         expected_pix(obj.VARIANCE_IDX, :) = ...
             expected_pix(obj.VARIANCE_IDX, :) + repelem(svar.e(:), npix(:))';
-        assertElementsAlmostEqual(new_pix_data, expected_pix, 'relative', 1e-7);
-    end
-
-    function test_multiplying_with_2D_dnd_returns_correct_pix_with_gt_1_page(obj)
-        dnd_obj = d2d_old(obj.test_sqw_2d_file_path);
-        npix = dnd_obj.npix;
-
-        pix_per_page = floor(sum(npix(:)/6));
-        mem_alloc = pix_per_page*obj.BYTES_PER_PIX;
-        pix = PixelData(obj.test_sqw_2d_file_path, mem_alloc);
-
-        new_pix = pix.do_binary_op(dnd_obj, @mtimes_single, 'flip', false, ...
-                                   'npix', npix);
-
-        original_pix_data = concatenate_pixel_pages(pix);
-        new_pix_data = concatenate_pixel_pages(new_pix);
-
-        s_dnd = repelem(dnd_obj.s(:), npix(:))';
-        e_dnd = repelem(dnd_obj.e(:), npix(:))';
-        s_pix = original_pix_data(obj.SIGNAL_IDX, :);
-        e_pix = original_pix_data(obj.VARIANCE_IDX, :);
-
-        expected_pix = original_pix_data;
-        expected_pix(obj.SIGNAL_IDX, :) = s_pix.*s_dnd;
-
-        % See mtimes_single for variance calculation
-        expected_variance = (s_dnd.^2).*e_pix + (s_pix.^2).*e_dnd;
-        expected_pix(obj.VARIANCE_IDX, :) = expected_variance;
-
         assertElementsAlmostEqual(new_pix_data, expected_pix, 'relative', 1e-7);
     end
 

--- a/_test/test_sqw_class/test_binary_ops.m
+++ b/_test/test_sqw_class/test_binary_ops.m
@@ -10,7 +10,7 @@ properties
     test_sqw_file_path = '../test_sqw_file/sqw_2d_1.sqw';
     base_sqw_obj;
     sqw_obj;
-%    dnd_obj;
+    dnd_obj;
 end
 
 methods
@@ -23,7 +23,7 @@ methods
 
     function obj = setUp(obj)
         obj.sqw_obj = copy(obj.base_sqw_obj);
-%        obj.dnd_obj = d2d_old(obj.base_sqw_obj);
+        obj.dnd_obj = d2d(obj.base_sqw_obj);
     end
 
     function test_SQW_error_if_operand_is_char(obj)
@@ -61,7 +61,7 @@ methods
         assertExceptionThrown(f, 'SQW:binary_op_manager_single');
     end
 
-    function DISABLED_test_adding_sqw_and_dnd_objects_1st_operand_is_sqw_returns_sqw(obj)
+    function test_adding_sqw_and_dnd_objects_1st_operand_is_sqw_returns_sqw(obj)
         out = obj.sqw_obj + obj.dnd_obj;
 
         assertTrue(isa(out, 'sqw'));
@@ -71,7 +71,7 @@ methods
                                   obj.DOUBLE_REL_TOLERANCE);
     end
 
-    function DISABLED_test_adding_sqw_and_dnd_objects_2nd_operand_is_sqw_returns_sqw(obj)
+    function test_adding_sqw_and_dnd_objects_2nd_operand_is_sqw_returns_sqw(obj)
         out = obj.dnd_obj + obj.sqw_obj;
 
         assertTrue(isa(out, 'sqw'));
@@ -81,7 +81,7 @@ methods
                                   obj.DOUBLE_REL_TOLERANCE);
     end
 
-    function DISABLED_test_dnd_minus_equivalent_sqw_returns_sqw_with_zero_image_data(obj)
+    function test_dnd_minus_equivalent_sqw_returns_sqw_with_zero_image_data(obj)
         out = obj.dnd_obj - obj.sqw_obj;
 
         assertTrue(isa(out, 'sqw'));
@@ -95,7 +95,7 @@ methods
                                   1e-7);
     end
 
-    function DISABLED_test_sqw_minus_equivalent_dnd_returns_sqw_with_zero_image_data(obj)
+    function test_sqw_minus_equivalent_dnd_returns_sqw_with_zero_image_data(obj)
         out = obj.sqw_obj - obj.dnd_obj;
 
         assertTrue(isa(out, 'sqw'));
@@ -109,7 +109,7 @@ methods
                                   1e-7);
     end
 
-    function DISABLED_test_subtracting_dnd_from_sqw_returns_sqw(obj)
+    function test_subtracting_dnd_from_sqw_returns_sqw(obj)
         obj.dnd_obj.s = ones(size(obj.dnd_obj.npix));
         out = obj.sqw_obj - obj.dnd_obj;
 

--- a/_test/test_sqw_class/test_binary_ops.m
+++ b/_test/test_sqw_class/test_binary_ops.m
@@ -71,29 +71,6 @@ methods
                                   obj.DOUBLE_REL_TOLERANCE);
     end
 
-    function test_adding_sqw_and_dnd_objects_2nd_operand_is_sqw_returns_sqw(obj)
-        out = obj.dnd_obj + obj.sqw_obj;
-
-        assertTrue(isa(out, 'sqw'));
-
-        expected_signal = obj.sqw_obj.data.s + obj.dnd_obj.s;
-        assertElementsAlmostEqual(out.data.s, expected_signal, 'relative', ...
-                                  obj.DOUBLE_REL_TOLERANCE);
-    end
-
-    function test_dnd_minus_equivalent_sqw_returns_sqw_with_zero_image_data(obj)
-        out = obj.dnd_obj - obj.sqw_obj;
-
-        assertTrue(isa(out, 'sqw'));
-
-        % Scale the difference to account for floating point errors
-        scaled_diff = out.data.s./max(obj.dnd_obj.s, obj.sqw_obj.data.s);
-        scaled_diff(isnan(scaled_diff)) = 0;
-
-        expected_signal = zeros(size(obj.sqw_obj.data.s));
-        assertElementsAlmostEqual(scaled_diff, expected_signal, 'absolute', ...
-                                  1e-7);
-    end
 
     function test_sqw_minus_equivalent_dnd_returns_sqw_with_zero_image_data(obj)
         out = obj.sqw_obj - obj.dnd_obj;
@@ -181,5 +158,4 @@ methods
     end
 
 end
-
 end

--- a/horace_core/sqw/@DnDBase/DnDBase.m
+++ b/horace_core/sqw/@DnDBase/DnDBase.m
@@ -37,6 +37,7 @@ classdef (Abstract)  DnDBase < SQWDnDBase
 
     methods(Access = protected)
         wout = unary_op_manager(obj, operation_handle);
+        wout = binary_op_manager_single(w1, w2, binary_op);
         [ok, mess] = equal_to_tol_internal(w1, w2, name_a, name_b, varargin);
     end
 

--- a/horace_core/sqw/@DnDBase/DnDBase.m
+++ b/horace_core/sqw/@DnDBase/DnDBase.m
@@ -47,7 +47,6 @@ classdef (Abstract)  DnDBase < SQWDnDBase
         [nd, sz] = dimensions(w);
         wout = copy(w);
 
-
         function obj = DnDBase(varargin)
             obj = obj@SQWDnDBase();
         end

--- a/horace_core/sqw/@DnDBase/binary_op_manager_single.m
+++ b/horace_core/sqw/@DnDBase/binary_op_manager_single.m
@@ -9,6 +9,12 @@ function wout = binary_op_manager_single(w1,w2,binary_op)
 %   (2) have dimensions method that gives the dimensionality of the double array
 %           >> nd = dimensions(obj)
 
+if ~is_allowed_type(w1) || ~is_allowed_type(w2)
+    error('DNDBASE:binary_op_manager_single', ...
+          ['Cannot perform binary operation between types ' ...
+           '''%s'' and ''%s''.'], class(w1), class(w2));
+end
+
 if ~isa(w1,'double') && ~isa(w2,'double')
     if isequal(sigvar_size(w1), sigvar_size(w2))
         if isa(w1,'DnDBase')
@@ -24,7 +30,8 @@ if ~isa(w1,'double') && ~isa(w2,'double')
         result = binary_op(sigvar(w1), sigvar(w2));
         wout = sigvar_set(wout, result);
     else
-        error ('Sizes of signal arrays in the objects are different')
+        error('DNDBASE:binary_op_manager_single', ...
+            'Sizes of signal arrays in the objects are different')
     end
 
 elseif ~isa(w1,'double') && isa(w2,'double')
@@ -33,7 +40,8 @@ elseif ~isa(w1,'double') && isa(w2,'double')
         result = binary_op(sigvar(w1), sigvar(w2,[]));
         wout = sigvar_set(wout,result);
     else
-        error ('Check that the numeric variable is scalar or array with same size as object signal')
+        error('DNDBASE:binary_op_manager_single', ...
+            'Check that the numeric variable is scalar or array with same size as object signal')
     end
 
 elseif isa(w1,'double') && ~isa(w2,'double')
@@ -42,10 +50,13 @@ elseif isa(w1,'double') && ~isa(w2,'double')
         result = binary_op(sigvar(w1,[]), sigvar(w2));
         wout = sigvar_set(wout,result);
     else
-        error ('Check that the numeric variable is scalar or array with same size as object signal')
+        error('DNDBASE:binary_op_manager_single', ...
+            'Check that the numeric variable is scalar or array with same size as object signal')
     end
-
-else
-    error ('binary operations between objects and doubles only defined')
+end
 end
 
+function allowed = is_allowed_type(obj)
+    allowed_types = {'double', 'SQWDnDBase', 'sigvar'};
+    allowed = any(cellfun(@(t) isa(obj, t), allowed_types));
+end

--- a/horace_core/sqw/@DnDBase/binary_op_manager_single.m
+++ b/horace_core/sqw/@DnDBase/binary_op_manager_single.m
@@ -28,22 +28,22 @@ if ~isa(w1,'double') && ~isa(w2,'double')
     end
 
 elseif ~isa(w1,'double') && isa(w2,'double')
-%    if isscalar(w2) || isequal(sigvar_size(w1),size(w2))
-%        wout = w1;
-%        result = binary_op(sigvar(w1), sigvar(w2,[]));
-%        wout = sigvar_set(wout,result);
-%    else
+    if isscalar(w2) || isequal(sigvar_size(w1),size(w2))
+        wout = w1;
+        result = binary_op(sigvar(w1), sigvar(w2,[]));
+        wout = sigvar_set(wout,result);
+    else
         error ('Check that the numeric variable is scalar or array with same size as object signal')
-%    end
+    end
 
 elseif isa(w1,'double') && ~isa(w2,'double')
-%    if isscalar(w1) || isequal(sigvar_size(w2),size(w1))
-%        wout = w2;
-%        result = binary_op(sigvar(w1,[]), sigvar(w2));
-%        wout = sigvar_set(wout,result);
-%    else
+    if isscalar(w1) || isequal(sigvar_size(w2),size(w1))
+        wout = w2;
+        result = binary_op(sigvar(w1,[]), sigvar(w2));
+        wout = sigvar_set(wout,result);
+    else
         error ('Check that the numeric variable is scalar or array with same size as object signal')
-%    end
+    end
 
 else
     error ('binary operations between objects and doubles only defined')

--- a/horace_core/sqw/@DnDBase/binary_op_manager_single.m
+++ b/horace_core/sqw/@DnDBase/binary_op_manager_single.m
@@ -1,0 +1,51 @@
+function wout = binary_op_manager_single(w1,w2,binary_op)
+% Implement binary operator for objects with a signal and a variance array.
+
+% Generic method, slightly generalised for dnd objects, that requires:
+%   (1) have methods to set, get and find size of signal and variance arrays:
+%           >> sz = sigvar_size(obj)
+%           >> w = sigvar(obj)          % w is sigvar object (has fields w.s, w.e)
+%           >> obj = sigvar_set(obj,w)  % w is sigvar object
+%   (2) have dimensions method that gives the dimensionality of the double array
+%           >> nd = dimensions(obj)
+
+if ~isa(w1,'double') && ~isa(w2,'double')
+    if isequal(sigvar_size(w1), sigvar_size(w2))
+        if isa(w1,'DnDBase')
+            wout = w1;
+        else
+            wout = w2;
+        end
+
+        if isa(w1,'DnDBase') && isa(w2,'DnDBase')
+            wout.npix(w2.npix==0)=0; % ensures that empty bins in either w1 or w2 result in an empty bin
+        end
+
+        result = binary_op(sigvar(w1), sigvar(w2));
+        wout = sigvar_set(wout, result);
+    else
+        error ('Sizes of signal arrays in the objects are different')
+    end
+
+elseif ~isa(w1,'double') && isa(w2,'double')
+%    if isscalar(w2) || isequal(sigvar_size(w1),size(w2))
+%        wout = w1;
+%        result = binary_op(sigvar(w1), sigvar(w2,[]));
+%        wout = sigvar_set(wout,result);
+%    else
+        error ('Check that the numeric variable is scalar or array with same size as object signal')
+%    end
+
+elseif isa(w1,'double') && ~isa(w2,'double')
+%    if isscalar(w1) || isequal(sigvar_size(w2),size(w1))
+%        wout = w2;
+%        result = binary_op(sigvar(w1,[]), sigvar(w2));
+%        wout = sigvar_set(wout,result);
+%    else
+        error ('Check that the numeric variable is scalar or array with same size as object signal')
+%    end
+
+else
+    error ('binary operations between objects and doubles only defined')
+end
+

--- a/horace_core/sqw/@DnDBase/mask.m
+++ b/horace_core/sqw/@DnDBase/mask.m
@@ -1,0 +1,43 @@
+function wout = mask (win, mask_array)
+% Remove the bins indicated by the mask array
+%
+%   >> wout = mask (win, mask_array)
+%
+% Input:
+% ------
+%   win                 Input sqw object
+%
+%   mask_array          Array of 1 or 0 (or true or false) that indicate
+%                      which points to retain (true to retain, false to ignore)
+%                       Numeric or logical array of same number of elements
+%                      as the data.
+%                       Note: mask will be applied to the stored data array
+%                      according as the projection axes, not the display axes.
+%                      Thus permuting the display axes does not alter the
+%                      effect of masking the data.
+%
+% Output:
+% -------
+%   wout                Output dataset.
+
+% Initialise output argument
+wout = copy(win);
+
+% Trivial case of empty or no mask arguments
+if nargin==1 || isempty(mask_array)
+    return
+end
+
+% Check mask is OK
+if ~(isnumeric(mask_array) || islogical(mask_array)) || numel(mask_array) ~= numel(win.s)
+    error([upper(class(win)) ':mask'], ['Mask must provide a numeric or logical array with ' ...
+                       'same number of elements as the image data.']);
+end
+if ~islogical(mask_array)
+    mask_array=logical(mask_array);
+end
+
+% Mask signal, variance and npix arrays
+wout.data.s(~mask_array) = 0;
+wout.data.e(~mask_array) = 0;
+wout.data.npix(~mask_array) = 0;

--- a/horace_core/sqw/@DnDBase/sigvar.m
+++ b/horace_core/sqw/@DnDBase/sigvar.m
@@ -1,0 +1,7 @@
+function wout = sigvar(w)
+% Create sigvar object from sqw object
+%
+%   >> wout = sigvar (w)
+
+wout = sigvar(w.s, w.e);
+

--- a/horace_core/sqw/@DnDBase/sigvar_size.m
+++ b/horace_core/sqw/@DnDBase/sigvar_size.m
@@ -1,0 +1,7 @@
+function sz = sigvar_size(w)
+% Matlab size of signal array
+%
+%   >> sz = sigvar_size(w)
+
+sz = size(w.s);
+

--- a/horace_core/sqw/@d2d/d2d.m
+++ b/horace_core/sqw/@d2d/d2d.m
@@ -55,6 +55,7 @@ classdef d2d < DnDBase
 
     methods(Access = protected)
         wout = binary_op_manager_single(w1, w2, binary_op);
+        wout = unary_op_manager(obj, operation_handle);
     end
 
     methods(Static, Access = private)

--- a/horace_core/sqw/@d2d/d2d.m
+++ b/horace_core/sqw/@d2d/d2d.m
@@ -54,8 +54,6 @@ classdef d2d < DnDBase
     end
 
     methods(Access = protected)
-        wout = binary_op_manager_single(w1, w2, binary_op);
-        wout = unary_op_manager(obj, operation_handle);
     end
 
     methods(Static, Access = private)

--- a/horace_core/sqw/@sqw/mask.m
+++ b/horace_core/sqw/@sqw/mask.m
@@ -1,0 +1,49 @@
+function wout = mask (win, mask_array)
+% Remove the bins indicated by the mask array
+%
+%   >> wout = mask (win, mask_array)
+%
+% Input:
+% ------
+%   win                 Input sqw object
+%
+%   mask_array          Array of 1 or 0 (or true or false) that indicate
+%                      which points to retain (true to retain, false to ignore)
+%                       Numeric or logical array of same number of elements
+%                      as the data.
+%                       Note: mask will be applied to the stored data array
+%                      according as the projection axes, not the display axes.
+%                      Thus permuting the display axes does not alter the
+%                      effect of masking the data.
+%
+% Output:
+% -------
+%   wout                Output dataset.
+
+% Initialise output argument
+wout = copy(win, 'exclude_pix', true);  % pixels will be assigned later
+
+% Trivial case of empty or no mask arguments
+if nargin==1 || isempty(mask_array)
+    return
+end
+
+% Check mask is OK
+if ~(isnumeric(mask_array) || islogical(mask_array)) || numel(mask_array) ~= numel(win.data.s)
+    error('SQW:mask', ['Mask must provide a numeric or logical array with ' ...
+                       'same number of elements as the image data.']);
+end
+if ~islogical(mask_array)
+    mask_array=logical(mask_array);
+end
+
+% Mask signal, variance and npix arrays
+wout.data.s(~mask_array) = 0;
+wout.data.e(~mask_array) = 0;
+wout.data.npix(~mask_array) = 0;
+
+% Section the pix array, if non empty and update urange
+if has_pixels(win)
+    wout.data.pix = win.data.pix.mask(mask_array, win.data.npix);
+    wout.data.urange = recompute_urange(wout);
+end

--- a/horace_core/sqw/@sqw/private/header_average.m
+++ b/horace_core/sqw/@sqw/private/header_average.m
@@ -1,0 +1,28 @@
+function [header_ave, ebins_all_same]=header_average(header)
+% Get average header information from header field of sqw object
+%
+% *** Assumes that all the contributing spe files had the same lattice parameters and projection axes
+% This could be generalised later - but with repercussions in many routines
+
+if nargout>=1   % requested average header
+    if iscell(header)
+        header_ave=header{1};
+    else
+        header_ave=header;
+    end
+end
+
+if nargout>=2   % requested energy bin information
+    if iscell(header)
+        ebins_all_same=true;
+        en=header{1}.en;
+        for i=2:numel(header)
+            if numel(en)~=numel(header{i}.en) || ~all(en==header{i}.en)
+                ebins_all_same=false;
+                break
+            end
+        end
+    else
+        ebins_all_same=true;  % only one contributing dataset, so energy bins of all datasetsets are the same, by definition
+    end
+end

--- a/horace_core/sqw/@sqw/private/recompute_urange.m
+++ b/horace_core/sqw/@sqw/private/recompute_urange.m
@@ -1,0 +1,63 @@
+function urange = recompute_urange(w)
+% Recalculate urange for an sqw type object
+%
+%   >> urange = recompute_urange(w)
+%
+% Input:
+% ------
+%   w       sqw-type sqw object (i.e. has pixels)
+%
+% Output:
+% -------
+%   urange  urange as recomputed from the pix array
+%
+% Recomputing urange requires the whole of the pixel array to be processed,
+% as the pix coordinates are not the same as the projection axes coordinates.
+%
+npixtot = w.data.pix.num_pixels;
+
+% Catch trivial case of no pixels; convention for size of urange in this case
+if npixtot == 0
+    urange = [Inf, Inf, Inf, Inf; -Inf, -Inf, -Inf, -Inf];
+    return
+end
+
+% Non-zero number of pixels
+h_ave = header_average(w.header);
+pix_to_rlu = h_ave.u_to_rlu(1:3, 1:3); % pix to rlu
+pix0 = h_ave.uoffset;                  % pix offset
+u_to_rlu = w.data.u_to_rlu(1:3, 1:3);  % proj to rlu
+u0 = w.data.uoffset;                   % proj offset
+
+% matrix to transform pixel coordinates to projection frame
+pix_to_proj = u_to_rlu \ pix_to_rlu;
+
+w.data.pix.move_to_first_page();
+
+min_uq = realmax*ones(size(w.data.pix.q_coordinates));
+max_uq = -realmax*ones(size(w.data.pix.q_coordinates));
+min_dE = realmax;
+max_dE = -realmax;
+while true  % loop through pages of pixel data
+    u_q = pix_to_proj*(w.data.pix.q_coordinates);
+
+    min_uq = min(min(u_q, min_uq), [], 2);
+    max_uq = max(max(u_q, max_uq), [], 2);
+    min_dE = min(min_dE, min(w.data.pix.dE));
+    max_dE = max(max_dE, max(w.data.pix.dE));
+
+    if w.data.pix.has_more()
+        w.data.pix.advance();
+    else
+        break;
+    end
+end
+
+proj_offset = u_to_rlu\(pix0(1:3) - u0(1:3));
+dE_offset = pix0(4) - u0(4);
+
+urange = zeros(2, 4);
+urange(1, 1:3) = (min_uq + proj_offset)';
+urange(2, 1:3) = (max_uq + proj_offset)';
+urange(1, 4) = min_dE + dE_offset;
+urange(2, 4) = max_dE + dE_offset;

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -1,4 +1,4 @@
-classdef sqw < SQWDnDBase
+classdef (InferiorClasses = {?d2d}) sqw < SQWDnDBase
     %SQW Create an sqw object
     %
     % Syntax:

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -63,7 +63,7 @@ classdef sqw < SQWDnDBase
 
     methods(Access = protected)
         wout = unary_op_manager(obj, operation_handle);
-        wout = binary_op_manager_single(w1,w2,binary_op);
+        wout = binary_op_manager_single(w1, w2, binary_op);
         [ok, mess] = equal_to_tol_internal(w1, w2, name_a, name_b, varargin);
     end
 

--- a/horace_core/sqw/@sqw_old/private/binary_op_manager_single.m
+++ b/horace_core/sqw/@sqw_old/private/binary_op_manager_single.m
@@ -156,14 +156,19 @@ function wout = do_binary_op_sqw_and_non_double(w1, w2, binary_op, flip)
                 isa(w2, 'd2d_old') || isa(w2, 'd3d_old') || isa(w2, 'd4d_old')
             if isa(w2, classname)% must be a dnd-type sqw object
                 omit = logical(w2.data.npix);
+                operand = w2;
             else % must be a d0d,d1d...
                 omit = logical(w2.npix);
+                % cast the DnD object to a sigvar for processing
+                operand = sigvar(w2);
             end
             wout = mask(wout, omit);
+        else % sigvar
+            operand = w2;
         end
 
         flip = exist('flip', 'var') && flip;
-        wout.data.pix = wout.data.pix.do_binary_op(w2, binary_op, 'flip', flip, ...
+        wout.data.pix = wout.data.pix.do_binary_op(operand, binary_op, 'flip', flip, ...
                                                   'npix', wout.data.npix);
         wout = recompute_bin_data(wout);
     else

--- a/horace_core/sqw/PixelData/@PixelData/do_binary_op.m
+++ b/horace_core/sqw/PixelData/@PixelData/do_binary_op.m
@@ -15,7 +15,7 @@ function pix_out = do_binary_op(obj, operand, binary_op, varargin)
 %              - scalar double
 %              - double array, the size of the array must be equal to
 %                obj.num_pixels
-%              - object with fields 's' and 'e' (e.g. dnd or sigvar)
+%              - object with fields 's' and 'e' (e.g. sigvar)
 %              - another PixelData object with obj.num_pixels equal
 % binary_op  Function handle pointing to the desired binary operation. The
 %            function should take 2 objects with '.s' and '.e' attributes, e.g.
@@ -43,7 +43,7 @@ elseif isa(operand, 'double')
     pix_out = binary_op_double_(pix_out, operand, binary_op, flip, npix);
 elseif isa(operand, 'PixelData')
     pix_out = binary_op_pixels_(pix_out, operand, binary_op, flip);
-elseif ~isempty(regexp(class(operand), '^d[0-4]d_old$', 'ONCE')) || isa(operand, 'DnDBase') || isa(operand, 'sigvar')
+elseif isa(operand, 'sigvar')
     pix_out = binary_op_sigvar_(pix_out, operand, binary_op, flip, npix);
 end
 
@@ -67,7 +67,5 @@ end
 function is = valid_operand(operand)
     is = isa(operand, 'PixelData') || ...
          isnumeric(operand) || ...
-         isa(operand, 'DnDBase') || ...
-         ~isempty(regexp(class(operand), '^d[0-4]d_old$', 'ONCE')) || ...
          isa(operand, 'sigvar');
 end

--- a/horace_core/sqw/PixelData/@PixelData/do_binary_op.m
+++ b/horace_core/sqw/PixelData/@PixelData/do_binary_op.m
@@ -43,7 +43,7 @@ elseif isa(operand, 'double')
     pix_out = binary_op_double_(pix_out, operand, binary_op, flip, npix);
 elseif isa(operand, 'PixelData')
     pix_out = binary_op_pixels_(pix_out, operand, binary_op, flip);
-elseif ~isempty(regexp(class(operand), '^d[0-4]d_old$', 'ONCE')) || isa(operand, 'sigvar')
+elseif ~isempty(regexp(class(operand), '^d[0-4]d_old$', 'ONCE')) || isa(operand, 'DnDBase') || isa(operand, 'sigvar')
     pix_out = binary_op_sigvar_(pix_out, operand, binary_op, flip, npix);
 end
 
@@ -67,6 +67,7 @@ end
 function is = valid_operand(operand)
     is = isa(operand, 'PixelData') || ...
          isnumeric(operand) || ...
+         isa(operand, 'DnDBase') || ...
          ~isempty(regexp(class(operand), '^d[0-4]d_old$', 'ONCE')) || ...
          isa(operand, 'sigvar');
 end

--- a/horace_core/sqw/PixelData/@PixelData/private/binary_op_sigvar_.m
+++ b/horace_core/sqw/PixelData/@PixelData/private/binary_op_sigvar_.m
@@ -1,6 +1,5 @@
 function obj = binary_op_sigvar_(obj, operand, binary_op, flip, npix)
-%% BINARY_OP_SIGVAR_ perform a binary operation between this and a sigvar or
-% sigvar-like object (e.g. dnd)
+%% BINARY_OP_SIGVAR_ perform a binary operation between this and a sigvar
 %
 npix_cum_sum = validate_inputs(obj, operand, npix);
 
@@ -34,14 +33,14 @@ while true
 
     sigvar_pix = sigvar(obj.signal, obj.variance);
     if ~isequal(size(npix), [1, 1])
-        sigvar_dnd = sigvar(...
+        sigvar_obj = sigvar(...
             replicate_array(operand.s(start_idx:end_idx), npix_chunk(:))', ...
             replicate_array(operand.e(start_idx:end_idx), npix_chunk(:))' ...
         );
     end
 
     [obj.signal, obj.variance] = ...
-            sigvar_binary_op_(sigvar_pix, sigvar_dnd, binary_op, flip);
+            sigvar_binary_op_(sigvar_pix, sigvar_obj, binary_op, flip);
 
     if obj.has_more()
         obj.advance();
@@ -54,12 +53,12 @@ end % function
 
 % -----------------------------------------------------------------------------
 function npix_cum_sum = validate_inputs(pix, operand, npix)
-    dnd_size = sigvar_size(operand);
-    if ~isequal(dnd_size, [1, 1]) && ~isequal(dnd_size, size(npix))
+    operand_size = sigvar_size(operand);
+    if ~isequal(operand_size, [1, 1]) && ~isequal(operand_size, size(npix))
         error('PIXELDATA:do_binary_op', ...
-            ['dnd operand must have size [1,1] or size equal to the inputted ' ...
-            'npix array.\nFound dnd size %s, and npix size %s'], ...
-            iarray_to_matstr(dnd_size), iarray_to_matstr(size(npix)));
+            ['sigvar operand must have size [1,1] or size equal to the inputted ' ...
+            'npix array.\nFound sigvar size %s, and npix size %s'], ...
+            iarray_to_matstr(operand_size), iarray_to_matstr(size(npix)));
     end
 
     npix_cum_sum = cumsum(npix(:));


### PR DESCRIPTION
Move the binary operation manager into the DnD base class and update logic to handle DnD classes in SQW and PixelData settings.
Split binary op tests between SQW and DND test files to match use cases.

[any changes to the InferiorClasses pattern will be made under a separate PR]