### PR TITLE
Remove size overload on PixelData class

### DIFF
--- a/_test/test_mex_nomex/test_main_mex.m
+++ b/_test/test_mex_nomex/test_main_mex.m
@@ -148,13 +148,13 @@ classdef test_main_mex < TestCase
             hcf.use_mex = 0;
             [u_to_rlu_matl,urange_matl,pix_m]=rd.calc_projections();
 
-            assertEqual(size(pix_m,1),9)
+            assertEqual(size(pix_m.data, 1), 9);
             hcf.use_mex = 1;
             [u_to_rlu_c,urange_c,pix_c]=rd.calc_projections();
 
             assertElementsAlmostEqual(u_to_rlu_matl,u_to_rlu_c,'absolute',1.e-8);
             assertElementsAlmostEqual(urange_matl,urange_c,'absolute',1.e-8);
-            assertEqual(size(pix_c,1),9)
+            assertEqual(size(pix_c.data, 1), 9);
             assertElementsAlmostEqual(pix_m.data,pix_c.data,'absolute',1.e-8);
         end
         function test_recompute_bin_data(this)

--- a/_test/test_sqw/test_PixelData.m
+++ b/_test/test_sqw/test_PixelData.m
@@ -229,14 +229,6 @@ methods
         assertExceptionThrown(f, 'MATLAB:subsassigndimmismatch')
     end
 
-    function test_size_of_PixelData_object_returns_underlying_data_size(obj)
-        % This may no longer be true if we start adding additional columns that
-        % are not part of the underlying pixel block
-        assertEqual(size(obj.pixel_data_obj), [9, 10]);
-        assertEqual(size(obj.pixel_data_obj, 1), 9);
-        assertEqual(size(obj.pixel_data_obj, 2), 10);
-    end
-
     function test_PixelData_object_with_underlying_data_is_not_empty(obj)
         assertFalse(isempty(obj.pixel_data_obj));
     end
@@ -377,17 +369,6 @@ methods
     function test_construction_with_file_path_sets_num_pixels_in_file(obj)
         f_accessor = sqw_formats_factory.instance().get_loader(...
                 obj.test_sqw_file_path);
-        assertEqual(obj.pix_data_from_file.num_pixels, f_accessor.npixels);
-    end
-
-    function test_construction_with_file_path_sets_size(obj)
-        f_accessor = sqw_formats_factory.instance().get_loader(...
-                obj.test_sqw_file_path);
-        size_ax_1 = size(obj.pix_data_from_file, 1);
-        assertEqual(size_ax_1, 9);
-
-        size_ax_2 = size(obj.pix_data_from_file, 2);
-        assertEqual(size_ax_2, f_accessor.npixels);
         assertEqual(obj.pix_data_from_file.num_pixels, f_accessor.npixels);
     end
 

--- a/_test/test_sqw/test_sqw_dnd_eval.m
+++ b/_test/test_sqw/test_sqw_dnd_eval.m
@@ -48,8 +48,8 @@ classdef test_sqw_dnd_eval < TestCase
             
             sig = ds.data.s;
             pix = ds.data.pix;
-            assertEqual(pix.signal(2),numel(sig)+1);
-            assertEqual(size(pix,2)+numel(sig),pix.signal(1));
+            assertEqual(pix.signal(2), numel(sig) + 1);
+            assertEqual(pix.num_pixels + numel(sig), pix.signal(1));
             
             assertEqual(sig(2),2);
             assertElementsAlmostEqual(sig(1),403.0462,'absolute',0.0001);
@@ -103,7 +103,7 @@ classdef test_sqw_dnd_eval < TestCase
             sig = ds.data.s;
             pix = ds.data.pix;
             assertEqual(pix.signal(2),2);
-            assertEqual(2*size(pix,2),pix.signal(1));
+            assertEqual(2*pix.num_pixels, pix.signal(1));
             
             assertEqual(sig(2),2);
             assertElementsAlmostEqual(sig(1),386.0924,'absolute',0.0001);
@@ -134,7 +134,7 @@ classdef test_sqw_dnd_eval < TestCase
             sig = ds.data.s;
             pix = ds.data.pix;
             assertEqual(pix.signal(2),numel(sig)+1);
-            assertEqual(size(pix,2)+numel(sig),pix.signal(1));
+            assertEqual(pix.num_pixels + numel(sig), pix.signal(1));
             
             assertEqual(sig(2),2);
             assertElementsAlmostEqual(sig(1),403.0462,'absolute',0.0001);
@@ -235,7 +235,7 @@ classdef test_sqw_dnd_eval < TestCase
             assertFalse(failed,err_message);
             pix = ds.data.pix;
             assertEqual(pix.signal(2),1);
-            assertEqual(size(pix,2),pix.signal(1));
+            assertEqual(pix.num_pixels, pix.signal(1));
         end
         %
         function test_sqw_eval_dnd(obj)

--- a/_test/test_sqw/utils/concatenate_pixel_pages.m
+++ b/_test/test_sqw/utils/concatenate_pixel_pages.m
@@ -5,7 +5,7 @@ function data = concatenate_pixel_pages(pix)
 %
 pix = pix.move_to_first_page();
 base_pg_size = pix.page_size;
-num_cols_in_pix_block = size(pix, 1);
+num_cols_in_pix_block = size(pix.data, 1);
 
 data = zeros(num_cols_in_pix_block, pix.num_pixels);
 iter = 0;

--- a/_test/test_sqw_file/test_faccess_sqw_prototype.m
+++ b/_test/test_sqw_file/test_faccess_sqw_prototype.m
@@ -93,7 +93,7 @@ classdef test_faccess_sqw_prototype< TestCase
             assertEqual(numel(det.group),28160)
 
             data = to.get_data();
-            assertEqual(size(data.pix),[9,16])
+            assertEqual(data.pix.num_pixels,16)
             assertEqual(size(data.s,1),numel(data.p{1})-1)
             assertEqual(size(data.e,2),numel(data.p{2})-1)
             assertEqual(size(data.npix,3),numel(data.p{3})-1)

--- a/_test/test_sqw_file/test_faccess_sqw_v2.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v2.m
@@ -96,7 +96,7 @@ classdef test_faccess_sqw_v2< TestCase
             assertEqual(numel(det.group),58880)
 
             data = to.get_data();
-            assertEqual(size(data.pix),[9,1164180])
+            assertEqual(data.pix.num_pixels,1164180)
             assertEqual(size(data.s,1),numel(data.p{1})-1)
             assertEqual(size(data.e,2),numel(data.p{2})-1)
             assertEqual(size(data.npix,3),numel(data.p{3})-1)
@@ -125,7 +125,7 @@ classdef test_faccess_sqw_v2< TestCase
             assertEqual(numel(det.group),36864)
 
             data = to.get_data();
-            assertEqual(size(data.pix),[9,179024])
+            assertEqual(data.pix.num_pixels,179024)
             assertEqual(size(data.s,1),numel(data.p{1})-1)
             assertEqual(size(data.e,2),numel(data.p{2})-1)
             assertEqual(size(data.npix),size(data.e))

--- a/_test/test_sqw_file/test_faccess_sqw_v3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3.m
@@ -91,7 +91,7 @@ classdef test_faccess_sqw_v3< TestCase
             assertEqual(numel(det.group),96)
 
             data = to.get_data();
-            assertEqual(size(data.pix),[9,7680])
+            assertEqual(data.pix.num_pixels,7680)
             assertEqual(size(data.s,1),numel(data.p{1})-1)
             assertEqual(size(data.e,2),numel(data.p{2})-1)
             assertEqual(size(data.npix,3),numel(data.p{3})-1)

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -358,27 +358,6 @@ methods
         is_empty = obj.num_pixels == 0;
     end
 
-    function s = size(obj, varargin)
-        % Return the size of the PixelData
-        %   Axis 1 gives the number of columns, axis 2 gives the number of
-        %   pixels. Along with Matlab convention, any other axis returns 1.
-        if nargin == 1
-            s = [obj.PIXEL_BLOCK_COLS_, obj.num_pixels];
-        else
-            s = ones(1, numel(varargin));
-            for i = 1:numel(varargin)
-                dim = varargin{i};
-                if dim == 1
-                    s(i) = obj.PIXEL_BLOCK_COLS_;
-                elseif dim == 2
-                    s(i) = obj.num_pixels;
-                else
-                    s(i) = size(obj.data, dim);
-                end
-            end
-        end
-    end
-
     function nel = numel(obj)
         % Return the number of data points in the pixel data block
         %   If the data is file backed, this returns the number of values in

--- a/horace_core/sqw/PixelData/@PixelData/equal_to_tol.m
+++ b/horace_core/sqw/PixelData/@PixelData/equal_to_tol.m
@@ -105,11 +105,11 @@ function [ok, mess] = validate_other_pix(obj, other_pix)
         return
     end
 
-    if ~all(size(obj) == size(other_pix))
+    if obj.num_pixels ~= other_pix.num_pixels
         ok = false;
         mess = sprintf(['PixelData objects are not equal. ' ...
-                        'Argument 1 has size [%s] , argument 2 has size [%s]'], ...
-                       num2str(size(obj)), num2str(size(other_pix)));
+                        'Argument 1 has %i pixels, argument 2 has %s.'], ...
+                       obj.num_pixels, other_pix.num_pixels);
         return
     end
 end


### PR DESCRIPTION
This PR removes the `size` overload from the `PixelData` class.

I did a grep through code to try and find all the calls to `size` on `PixelData` objects - hopefully I've caught them. Most of them were in tests anyway.

Alternatives to using `size`:
```matlab
size(pix, 1) == size(pix.data, 1);  % should be avoided in production code as structure of `.data` is not guaranteed
size(pix, 2) == pix.num_pixels;
```
At the point we need it, we will want to add a method like `pix.num_fields` (which would usually be 9), so we can avoid doing `size(pix.data, 1)`.

Addresses #481 