### PR TITLE
Mask random pixels does not work

### DIFF
--- a/_test/test_sqw/test_PixelData_operations.m
+++ b/_test/test_sqw/test_PixelData_operations.m
@@ -164,6 +164,28 @@ methods
         assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
     end
 
+    function test_compute_bin_data_mex_rets_empty_arrays_if_num_pix_is_zero(obj)
+        cleanup_handle = ...
+            set_temporary_config_options(hor_config(), 'use_mex', true);
+
+        p = PixelData();
+        [s, e] = p.compute_bin_data([]);
+
+        assertTrue(isempty(s));
+        assertTrue(isempty(e));
+    end
+
+    function test_compute_bin_data_nomex_empty_arrays_if_npix_is_zero(obj)
+        cleanup_handle = ...
+            set_temporary_config_options(hor_config(), 'use_mex', false);
+
+        p = PixelData();
+        [s, e] = p.compute_bin_data([]);
+
+        assertTrue(isempty(s));
+        assertTrue(isempty(e));
+    end
+
     function test_do_unary_op_returns_correct_output_with_cosine_gt_1_page(obj)
         data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 50);
         npix_in_page = 11;

--- a/_test/test_sqw/test_PixelData_operations.m
+++ b/_test/test_sqw/test_PixelData_operations.m
@@ -1,546 +1,555 @@
 classdef test_PixelData_operations < TestCase
-
-properties
-    BYTES_PER_PIX = PixelData.DATA_POINT_SIZE*PixelData.DEFAULT_NUM_PIX_FIELDS;
-    SIGNAL_IDX = 8;
-    VARIANCE_IDX = 9;
-
-    ALL_IN_MEM_PG_SIZE = 1e12;
-    FLOAT_TOLERANCE = 4.75e-4;
-
-    this_dir = fileparts(mfilename('fullpath'));
-    test_sqw_file_path = '../test_sqw_file/sqw_1d_1.sqw';
-    test_sqw_2d_file_path = '../test_sqw_file/sqw_2d_1.sqw';
-    ref_npix_data = [];
-    ref_s_data = [];
-    ref_e_data = [];
-
-    pix_in_memory_base;
-    pix_in_memory;
-    pix_with_pages_base;
-    pix_with_pages;
-
-    pix_with_pages_2d;
-    ref_npix_data_2d;
-    ref_s_data_2d;
-    ref_e_data_2d;
-
-    old_warn_state;
-end
-
-methods
-
-    function obj = test_PixelData_operations(~)
-        obj = obj@TestCase('test_PixelData_operations');
-
-        addpath(fullfile(obj.this_dir, 'utils'));
-
-        % Swallow any warnings for when pixel page size set too small
-        obj.old_warn_state = warning('OFF', 'PIXELDATA:validate_mem_alloc');
-
-        % Load a 1D SQW file
-        sqw_test_obj = sqw(obj.test_sqw_file_path);
-        obj.ref_npix_data = sqw_test_obj.data.npix;
-        obj.ref_s_data = sqw_test_obj.data.s;
-        obj.ref_e_data = sqw_test_obj.data.e;
-
-        num_pix_pages = 6;
-        page_size = floor(sqw_test_obj.data.pix.num_pixels/num_pix_pages)*obj.BYTES_PER_PIX;
-        obj.pix_in_memory_base = sqw_test_obj.data.pix;
-        obj.pix_with_pages_base = PixelData(obj.test_sqw_file_path, page_size);
-
-        % Load 2D SQW file
-        sqw_2d_test_object = sqw(obj.test_sqw_2d_file_path);
-        obj.ref_npix_data_2d = sqw_2d_test_object.data.npix;
-        obj.ref_s_data_2d = sqw_2d_test_object.data.s;
-        obj.ref_e_data_2d = sqw_2d_test_object.data.e;
-
-        num_pix = sqw_2d_test_object.data.pix.num_pixels;
-        page_size_2d = floor(num_pix/num_pix_pages)*obj.BYTES_PER_PIX;
-        obj.pix_with_pages_2d = PixelData(obj.test_sqw_2d_file_path, ...
-                                          page_size_2d);
+    
+    properties
+        BYTES_PER_PIX = PixelData.DATA_POINT_SIZE*PixelData.DEFAULT_NUM_PIX_FIELDS;
+        SIGNAL_IDX = 8;
+        VARIANCE_IDX = 9;
+        
+        ALL_IN_MEM_PG_SIZE = 1e12;
+        FLOAT_TOLERANCE = 4.75e-4;
+        
+        this_dir = fileparts(mfilename('fullpath'));
+        test_sqw_file_path = '../test_sqw_file/sqw_1d_1.sqw';
+        test_sqw_2d_file_path = '../test_sqw_file/sqw_2d_1.sqw';
+        ref_npix_data = [];
+        ref_s_data = [];
+        ref_e_data = [];
+        
+        pix_in_memory_base;
+        pix_in_memory;
+        pix_with_pages_base;
+        pix_with_pages;
+        
+        pix_with_pages_2d;
+        ref_npix_data_2d;
+        ref_s_data_2d;
+        ref_e_data_2d;
+        
+        old_warn_state;
     end
-
-    function delete(obj)
-        rmpath(fullfile(obj.this_dir, 'utils'));
-        warning(obj.old_warn_state);
-    end
-
-    function setUp(obj)
-        obj.pix_in_memory = copy(obj.pix_in_memory_base);
-        obj.pix_with_pages = copy(obj.pix_with_pages_base);
-    end
-
-    function test_compute_bin_data_correct_output_in_memory_mex_1_thread(obj)
-        cleanup_handle = ...
-            set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 1);
-
-        [s, e] = obj.pix_in_memory.compute_bin_data(obj.ref_npix_data);
-
-        assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
-        assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
-    end
-
-    function test_compute_bin_data_correct_output_in_memory_mex_4_threads(obj)
-        cleanup_handle = ...
-            set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 4);
-
-        [s, e] = obj.pix_in_memory.compute_bin_data(obj.ref_npix_data);
-
-        assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
-        assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
-    end
-
-    function test_compute_bin_data_correct_output_all_data_in_memory_mex_off(obj)
-        cleanup_handle = ...
-            set_temporary_config_options(hor_config(), 'use_mex', false);
-
-        [s, e] = obj.pix_in_memory.compute_bin_data(obj.ref_npix_data);
-
-        assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
-        assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
-    end
-
-    function test_compute_bin_data_correct_output_file_backed_mex_1_thread(obj)
-        cleanup_handle = ...
-            set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 1);
-
-        [s, e] = obj.pix_with_pages.compute_bin_data(obj.ref_npix_data);
-
-        assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
-        assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
-    end
-
-    function test_compute_bin_data_correct_output_5_pages_mex_1_thread(obj)
-        cleanup_handle = ...
-            set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 1);
-
-        file_info = dir(obj.test_sqw_file_path);
-        pg_size = file_info.bytes/5;
-        pix = PixelData(obj.test_sqw_file_path, pg_size);
-        [s, e] = pix.compute_bin_data(obj.ref_npix_data);
-
-        assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
-        assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
-    end
-
-    function test_compute_bin_data_correct_output_file_backed_mex_4_threads(obj)
-        cleanup_handle = ...
-            set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 4);
-
-        [s, e] = obj.pix_with_pages.compute_bin_data(obj.ref_npix_data);
-
-        assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
-        assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
-    end
-
-    function test_compute_bin_data_file_backed_2d_data_mex_4_threads(obj)
-        cleanup_handle = ...
-            set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 4);
-
-        [s, e] = obj.pix_with_pages_2d.compute_bin_data(obj.ref_npix_data_2d);
-
-        % Scale the signal and error to account for rounding errors
-        max_s = max(s, [], 'all');
-        scaled_s = s/max_s;
-        scaled_ref_s = obj.ref_s_data_2d/max_s;
-
-        max_e = max(e, [], 'all');
-        scaled_e = e/max_e;
-        scaled_ref_e = obj.ref_e_data_2d/max_e;
-
-        assertEqual(scaled_s, scaled_ref_s, '', obj.FLOAT_TOLERANCE);
-        assertEqual(scaled_e, scaled_ref_e, '', obj.FLOAT_TOLERANCE);
-
-    end
-
-    function test_compute_bin_data_correct_output_file_backed_mex_off(obj)
-        cleanup_handle = ...
-            set_temporary_config_options(hor_config(), 'use_mex', false);
-
-        [s, e] = obj.pix_with_pages.compute_bin_data(obj.ref_npix_data);
-
-        assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
-        assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
-    end
-
-    function test_compute_bin_data_mex_rets_empty_arrays_if_num_pix_is_zero(obj)
-        cleanup_handle = ...
-            set_temporary_config_options(hor_config(), 'use_mex', true);
-
-        p = PixelData();
-        [s, e] = p.compute_bin_data([]);
-
-        assertTrue(isempty(s));
-        assertTrue(isempty(e));
-    end
-
-    function test_compute_bin_data_nomex_empty_arrays_if_npix_is_zero(obj)
-        cleanup_handle = ...
-            set_temporary_config_options(hor_config(), 'use_mex', false);
-
-        p = PixelData();
-        [s, e] = p.compute_bin_data([]);
-
-        assertTrue(isempty(s));
-        assertTrue(isempty(e));
-    end
-
-    function test_do_unary_op_returns_correct_output_with_cosine_gt_1_page(obj)
-        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 50);
-        npix_in_page = 11;
-        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-
-        pix = pix.do_unary_op(@cos_single);
-
-        % Loop back through and validate values
-        pix.move_to_first_page();
-        iter = 0;
-        while true
-            start_idx = (iter*npix_in_page) + 1;
-            end_idx = min(start_idx + npix_in_page - 1, pix.num_pixels);
-
-            original_signal = data(obj.SIGNAL_IDX, start_idx:end_idx);
-            original_variance = data(obj.VARIANCE_IDX, start_idx:end_idx);
-
-            expected_data = data;
-            % Use the formulas used in sqw.cos to get the expected sig/var data
-            expected_data(obj.SIGNAL_IDX, start_idx:end_idx) = ...
+    
+    methods
+        
+        function obj = test_PixelData_operations(~)
+            obj = obj@TestCase('test_PixelData_operations');
+            
+            addpath(fullfile(obj.this_dir, 'utils'));
+            
+            % Swallow any warnings for when pixel page size set too small
+            obj.old_warn_state = warning('OFF', 'PIXELDATA:validate_mem_alloc');
+            
+            % Load a 1D SQW file
+            sqw_test_obj = sqw(obj.test_sqw_file_path);
+            obj.ref_npix_data = sqw_test_obj.data.npix;
+            obj.ref_s_data = sqw_test_obj.data.s;
+            obj.ref_e_data = sqw_test_obj.data.e;
+            
+            num_pix_pages = 6;
+            page_size = floor(sqw_test_obj.data.pix.num_pixels/num_pix_pages)*obj.BYTES_PER_PIX;
+            obj.pix_in_memory_base = sqw_test_obj.data.pix;
+            obj.pix_with_pages_base = PixelData(obj.test_sqw_file_path, page_size);
+            
+            % Load 2D SQW file
+            sqw_2d_test_object = sqw(obj.test_sqw_2d_file_path);
+            obj.ref_npix_data_2d = sqw_2d_test_object.data.npix;
+            obj.ref_s_data_2d = sqw_2d_test_object.data.s;
+            obj.ref_e_data_2d = sqw_2d_test_object.data.e;
+            
+            num_pix = sqw_2d_test_object.data.pix.num_pixels;
+            page_size_2d = floor(num_pix/num_pix_pages)*obj.BYTES_PER_PIX;
+            obj.pix_with_pages_2d = PixelData(obj.test_sqw_2d_file_path, ...
+                page_size_2d);
+        end
+        
+        function delete(obj)
+            rmpath(fullfile(obj.this_dir, 'utils'));
+            warning(obj.old_warn_state);
+        end
+        
+        function setUp(obj)
+            obj.pix_in_memory = copy(obj.pix_in_memory_base);
+            obj.pix_with_pages = copy(obj.pix_with_pages_base);
+        end
+        
+        function test_compute_bin_data_correct_output_in_memory_mex_1_thread(obj)
+            cleanup_handle = ...
+                set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 1);
+            
+            [s, e] = obj.pix_in_memory.compute_bin_data(obj.ref_npix_data);
+            
+            assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
+            assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
+        end
+        
+        function test_compute_bin_data_correct_output_in_memory_mex_4_threads(obj)
+            cleanup_handle = ...
+                set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 4);
+            
+            [s, e] = obj.pix_in_memory.compute_bin_data(obj.ref_npix_data);
+            
+            assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
+            assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
+        end
+        
+        function test_compute_bin_data_correct_output_all_data_in_memory_mex_off(obj)
+            cleanup_handle = ...
+                set_temporary_config_options(hor_config(), 'use_mex', false);
+            
+            [s, e] = obj.pix_in_memory.compute_bin_data(obj.ref_npix_data);
+            
+            assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
+            assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
+        end
+        
+        function test_compute_bin_data_correct_output_file_backed_mex_1_thread(obj)
+            cleanup_handle = ...
+                set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 1);
+            
+            [s, e] = obj.pix_with_pages.compute_bin_data(obj.ref_npix_data);
+            
+            assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
+            assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
+        end
+        
+        function test_compute_bin_data_correct_output_5_pages_mex_1_thread(obj)
+            cleanup_handle = ...
+                set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 1);
+            
+            file_info = dir(obj.test_sqw_file_path);
+            pg_size = file_info.bytes/5;
+            pix = PixelData(obj.test_sqw_file_path, pg_size);
+            [s, e] = pix.compute_bin_data(obj.ref_npix_data);
+            
+            assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
+            assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
+        end
+        
+        function test_compute_bin_data_correct_output_file_backed_mex_4_threads(obj)
+            cleanup_handle = ...
+                set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 4);
+            
+            [s, e] = obj.pix_with_pages.compute_bin_data(obj.ref_npix_data);
+            
+            assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
+            assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
+        end
+        
+        function test_compute_bin_data_file_backed_2d_data_mex_4_threads(obj)
+            cleanup_handle = ...
+                set_temporary_config_options(hor_config(), 'use_mex', true, 'threads', 4);
+            
+            [s, e] = obj.pix_with_pages_2d.compute_bin_data(obj.ref_npix_data_2d);
+            persistent all_max;
+            if isempty(all_max)
+                try
+                    all_max = @(x)max(x,[],'all');
+                    mm = all_max(1:10);
+                catch
+                    all_max = @(x)max(reshape(x,[1,numel(x)]));
+                end
+            end
+            
+            % Scale the signal and error to account for rounding errors
+            max_s = all_max(s);
+            scaled_s = s/max_s;
+            scaled_ref_s = obj.ref_s_data_2d/max_s;
+            
+            max_e = all_max(e);
+            scaled_e = e/max_e;
+            scaled_ref_e = obj.ref_e_data_2d/max_e;
+            
+            assertEqual(scaled_s, scaled_ref_s, '', obj.FLOAT_TOLERANCE);
+            assertEqual(scaled_e, scaled_ref_e, '', obj.FLOAT_TOLERANCE);
+            
+        end
+        
+        function test_compute_bin_data_correct_output_file_backed_mex_off(obj)
+            cleanup_handle = ...
+                set_temporary_config_options(hor_config(), 'use_mex', false);
+            
+            [s, e] = obj.pix_with_pages.compute_bin_data(obj.ref_npix_data);
+            
+            assertEqual(s, obj.ref_s_data, '', obj.FLOAT_TOLERANCE);
+            assertEqual(e, obj.ref_e_data, '', obj.FLOAT_TOLERANCE);
+        end
+        
+        function test_compute_bin_data_mex_rets_empty_arrays_if_num_pix_is_zero(obj)
+            cleanup_handle = ...
+                set_temporary_config_options(hor_config(), 'use_mex', true);
+            
+            p = PixelData();
+            [s, e] = p.compute_bin_data([]);
+            
+            assertTrue(isempty(s));
+            assertTrue(isempty(e));
+        end
+        
+        function test_compute_bin_data_nomex_empty_arrays_if_npix_is_zero(obj)
+            cleanup_handle = ...
+                set_temporary_config_options(hor_config(), 'use_mex', false);
+            
+            p = PixelData();
+            [s, e] = p.compute_bin_data([]);
+            
+            assertTrue(isempty(s));
+            assertTrue(isempty(e));
+        end
+        
+        function test_do_unary_op_returns_correct_output_with_cosine_gt_1_page(obj)
+            data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 50);
+            npix_in_page = 11;
+            pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+            
+            pix = pix.do_unary_op(@cos_single);
+            
+            % Loop back through and validate values
+            pix.move_to_first_page();
+            iter = 0;
+            while true
+                start_idx = (iter*npix_in_page) + 1;
+                end_idx = min(start_idx + npix_in_page - 1, pix.num_pixels);
+                
+                original_signal = data(obj.SIGNAL_IDX, start_idx:end_idx);
+                original_variance = data(obj.VARIANCE_IDX, start_idx:end_idx);
+                
+                expected_data = data;
+                % Use the formulas used in sqw.cos to get the expected sig/var data
+                expected_data(obj.SIGNAL_IDX, start_idx:end_idx) = ...
                     cos(original_signal);
-            expected_data(obj.VARIANCE_IDX, start_idx:end_idx) = ...
+                expected_data(obj.VARIANCE_IDX, start_idx:end_idx) = ...
                     abs(1 - pix.signal.^2).*original_variance;
-
-            assertEqual(pix.data, expected_data(:, start_idx:end_idx), '', ...
-                        obj.FLOAT_TOLERANCE);
-
-            if pix.has_more()
-                pix = pix.advance();
-                iter = iter + 1;
-            else
-                break;
+                
+                assertEqual(pix.data, expected_data(:, start_idx:end_idx), '', ...
+                    obj.FLOAT_TOLERANCE);
+                
+                if pix.has_more()
+                    pix = pix.advance();
+                    iter = iter + 1;
+                else
+                    break;
+                end
             end
         end
-    end
-
-    function test_do_unary_op_with_nargout_1_doesnt_affect_called_instance(obj)
-        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 10);
-        pix = PixelData(data);
-        sin_pix = pix.do_unary_op(@sin);
-        assertEqual(pix.data, data);
-    end
-
-    function test_paged_data_returns_same_unary_op_result_as_all_in_memory(obj)
-        % the unary operation and the range the data it acts on should take
-        unary_ops = {
-            @acos, [0, 1], ...
-            @acosh, [1, 3], ...
-            @acot, [0, 1], ...
-            @acoth, [10, 15], ...
-            @acsc, [1, 3], ...
-            @acsch, [1, 3], ...
-            @asec, [1.5, 3], ...
-            @asech, [0, 1], ...
-            @asin, [0, 1], ...
-            @asinh, [1, 3], ...
-            @atan, [0, 1], ...
-            @atanh, [0, 0.5], ...
-            @cos, [0, 1], ...
-            @cosh, [0, 1], ...
-            @cot, [0, 1], ...
-            @coth, [1.5, 3], ...
-            @csc, [0.5, 2.5], ...
-            @csch, [1, 3], ...
-            @exp, [0, 1], ...
-            @log, [1, 3], ...
-            @log10, [1, 3], ...
-            @sec, [2, 4], ...
-            @sech, [0, 1.4], ...
-            @sin, [0, 3], ...
-            @sinh, [0, 3], ...
-            @sqrt, [0, 3], ...
-            @tan, [0, 1], ...
-            @tanh [0, 3], ...
-        };
-
-        % For each unary operator, perform the operation on some file-backed
-        % data and compare the result to the same operation used on the same
-        % data all held in memory
-        num_pix = 7;
-        npix_in_page = 3;
-        for i = 1:numel(unary_ops)/2
-            unary_op = unary_ops{2*i - 1};
-            data_range = unary_ops{2*i};
-
-            data = obj.get_random_data_in_range( ...
-                PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix, data_range);
+        
+        function test_do_unary_op_with_nargout_1_doesnt_affect_called_instance(obj)
+            data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 10);
+            pix = PixelData(data);
+            sin_pix = pix.do_unary_op(@sin);
+            assertEqual(pix.data, data);
+        end
+        
+        function test_paged_data_returns_same_unary_op_result_as_all_in_memory(obj)
+            % the unary operation and the range the data it acts on should take
+            unary_ops = {
+                @acos, [0, 1], ...
+                @acosh, [1, 3], ...
+                @acot, [0, 1], ...
+                @acoth, [10, 15], ...
+                @acsc, [1, 3], ...
+                @acsch, [1, 3], ...
+                @asec, [1.5, 3], ...
+                @asech, [0, 1], ...
+                @asin, [0, 1], ...
+                @asinh, [1, 3], ...
+                @atan, [0, 1], ...
+                @atanh, [0, 0.5], ...
+                @cos, [0, 1], ...
+                @cosh, [0, 1], ...
+                @cot, [0, 1], ...
+                @coth, [1.5, 3], ...
+                @csc, [0.5, 2.5], ...
+                @csch, [1, 3], ...
+                @exp, [0, 1], ...
+                @log, [1, 3], ...
+                @log10, [1, 3], ...
+                @sec, [2, 4], ...
+                @sech, [0, 1.4], ...
+                @sin, [0, 3], ...
+                @sinh, [0, 3], ...
+                @sqrt, [0, 3], ...
+                @tan, [0, 1], ...
+                @tanh [0, 3], ...
+                };
+            
+            % For each unary operator, perform the operation on some file-backed
+            % data and compare the result to the same operation used on the same
+            % data all held in memory
+            num_pix = 7;
+            npix_in_page = 3;
+            for i = 1:numel(unary_ops)/2
+                unary_op = unary_ops{2*i - 1};
+                data_range = unary_ops{2*i};
+                
+                data = obj.get_random_data_in_range( ...
+                    PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix, data_range);
+                pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+                pix.do_unary_op(unary_op);
+                
+                file_backed_data = concatenate_pixel_pages(pix);
+                
+                pix_in_mem = PixelData(data);
+                pix_in_mem = pix_in_mem.do_unary_op(unary_op);
+                in_memory_data = pix_in_mem.data;
+                
+                assertEqual( ...
+                    file_backed_data, in_memory_data, ...
+                    sprintf(['In-memory and file-backed data do not match after ' ...
+                    'operation: ''%s''.'], char(unary_op)), ...
+                    obj.FLOAT_TOLERANCE);
+            end
+        end
+        
+        function test_mask_does_nothing_if_mask_array_eq_ones_when_pix_in_memory(~)
+            data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 11);
+            pix = PixelData(data);
+            mask_array = ones(1, pix.num_pixels);
+            pix_out = pix.mask(mask_array);
+            assertEqual(pix_out.data, data);
+        end
+        
+        function test_mask_returns_empty_PixelData_if_mask_array_all_zeros(~)
+            data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 11);
+            pix = PixelData(data);
+            mask_array = zeros(1, pix.num_pixels);
+            pix_out = pix.mask(mask_array);
+            assertTrue(isa(pix_out, 'PixelData'));
+            assertTrue(isempty(pix_out));
+        end
+        
+        function test_mask_raises_if_mask_array_len_neq_to_pg_size_or_num_pixels(obj)
+            data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 30);
+            npix_in_page = 10;
             pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-            pix.do_unary_op(unary_op);
-
-            file_backed_data = concatenate_pixel_pages(pix);
-
-            pix_in_mem = PixelData(data);
-            pix_in_mem = pix_in_mem.do_unary_op(unary_op);
-            in_memory_data = pix_in_mem.data;
-
-            assertEqual( ...
-                file_backed_data, in_memory_data, ...
-                sprintf(['In-memory and file-backed data do not match after ' ...
-                         'operation: ''%s''.'], char(unary_op)), ...
-                obj.FLOAT_TOLERANCE);
+            mask_array = zeros(5);
+            f = @() pix.mask(mask_array);
+            assertExceptionThrown(f, 'PIXELDATA:mask');
         end
-    end
-
-    function test_mask_does_nothing_if_mask_array_eq_ones_when_pix_in_memory(~)
-        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 11);
-        pix = PixelData(data);
-        mask_array = ones(1, pix.num_pixels);
-        pix_out = pix.mask(mask_array);
-        assertEqual(pix_out.data, data);
-    end
-
-    function test_mask_returns_empty_PixelData_if_mask_array_all_zeros(~)
-        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 11);
-        pix = PixelData(data);
-        mask_array = zeros(1, pix.num_pixels);
-        pix_out = pix.mask(mask_array);
-        assertTrue(isa(pix_out, 'PixelData'));
-        assertTrue(isempty(pix_out));
-    end
-
-    function test_mask_raises_if_mask_array_len_neq_to_pg_size_or_num_pixels(obj)
-        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 30);
-        npix_in_page = 10;
-        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        mask_array = zeros(5);
-        f = @() pix.mask(mask_array);
-        assertExceptionThrown(f, 'PIXELDATA:mask');
-    end
-
-    function test_mask_removes_in_memory_pix_if_len_mask_array_eq_num_pixels(~)
-        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 11);
-        pix = PixelData(data);
-        mask_array = ones(1, pix.num_pixels);
-        pix_to_remove = [3, 6, 7];
-        mask_array(pix_to_remove) = 0;
-
-        pix = pix.mask(mask_array);
-
-        assertEqual(pix.num_pixels, size(data, 2) - numel(pix_to_remove));
-        expected_data = data;
-        expected_data(:, pix_to_remove) = [];
-        assertEqual(pix.data, expected_data);
-    end
-
-    function test_mask_throws_PIXELDATA_if_called_with_no_output_args(~)
-        pix = PixelData(5);
-        f = @() pix.mask(zeros(1, pix.num_pixels), 'logical');
-        assertExceptionThrown(f, 'PIXELDATA:mask');
-    end
-
-    function test_mask_deletes_pixels_when_given_npix_argument_pix_in_pages(obj)
-        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
-        npix_in_page = 11;
-        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-
-        mask_array = [0, 1, 1, 0, 1, 0];
-        npix = [4, 5, 1, 2, 3, 5];
-
-        pix = pix.mask(mask_array, npix);
-
-        full_mask_array = repelem(mask_array, npix);
-        expected_data = data(:, logical(full_mask_array));
-
-        actual_data = concatenate_pixel_pages(pix);
-        assertEqual(actual_data, expected_data);
-    end
-
-    function test_mask_deletes_pix_with_npix_argument_all_pages_full(obj)
-        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
-        npix_in_page = 10;
-        pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
-
-        mask_array = [0, 1, 1, 0, 1, 0];
-        npix = [4, 5, 1, 2, 3, 5];
-
-        pix = pix.mask(mask_array, npix);
-
-        full_mask_array = repelem(mask_array, npix);
-        expected_data = data(:, logical(full_mask_array));
-
-        actual_data = concatenate_pixel_pages(pix);
-        assertEqual(actual_data, expected_data);
-    end
-
-    function test_mask_deletes_pixels_when_given_npix_argument_pix_in_mem(obj)
-        data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
-        pix = PixelData(data, obj.ALL_IN_MEM_PG_SIZE);
-
-        mask_array = [0, 1, 1, 0, 1, 0];
-        npix = [4, 5, 1, 2, 3, 5];
-
-        pix = pix.mask(mask_array, npix);
-
-        full_mask_array = repelem(mask_array, npix);
-        expected_data = data(:, logical(full_mask_array));
-
-        actual_data = concatenate_pixel_pages(pix);
-        assertEqual(actual_data, expected_data);
-    end
-
-    function test_PIXELDATA_thrown_if_sum_of_npix_ne_to_num_pixels(~)
-        pix = PixelData(5);
-        npix = [1, 2];
-        f = @() pix.mask([0, 1], npix);
-        assertExceptionThrown(f, 'PIXELDATA:mask');
-    end
-
-    function test_error_if_passing_mask_npix_and_num_pix_len_mask_array(~)
-
-        function out = f()
-            num_pix = 10;
-            pix = PixelData(rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix));
-            mask_array = randi([0, 1], [1, num_pix]);
-            npix = rand(1, 4);
-            out = pix.mask(mask_array, npix);
+        
+        function test_mask_removes_in_memory_pix_if_len_mask_array_eq_num_pixels(~)
+            data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 11);
+            pix = PixelData(data);
+            mask_array = ones(1, pix.num_pixels);
+            pix_to_remove = [3, 6, 7];
+            mask_array(pix_to_remove) = 0;
+            
+            pix = pix.mask(mask_array);
+            
+            assertEqual(pix.num_pixels, size(data, 2) - numel(pix_to_remove));
+            expected_data = data;
+            expected_data(:, pix_to_remove) = [];
+            assertEqual(pix.data, expected_data);
         end
-
-        assertExceptionThrown(@() f(), 'PIXELDATA:mask');
-    end
-
-    function test_not_enough_args_error_if_calling_mask_with_no_args(~)
-
-        function pix = f()
-            pix = PixelData(rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 10));
-            pix = pix.mask();
+        
+        function test_mask_throws_PIXELDATA_if_called_with_no_output_args(~)
+            pix = PixelData(5);
+            f = @() pix.mask(zeros(1, pix.num_pixels), 'logical');
+            assertExceptionThrown(f, 'PIXELDATA:mask');
         end
-
-        assertExceptionThrown(@() f(), 'MATLAB:minrhs');
+        
+        function test_mask_deletes_pixels_when_given_npix_argument_pix_in_pages(obj)
+            data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
+            npix_in_page = 11;
+            pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+            
+            mask_array = [0, 1, 1, 0, 1, 0];
+            npix = [4, 5, 1, 2, 3, 5];
+            
+            pix = pix.mask(mask_array, npix);
+            
+            full_mask_array = repelem(mask_array, npix);
+            expected_data = data(:, logical(full_mask_array));
+            
+            actual_data = concatenate_pixel_pages(pix);
+            assertEqual(actual_data, expected_data);
+        end
+        
+        function test_mask_deletes_pix_with_npix_argument_all_pages_full(obj)
+            data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
+            npix_in_page = 10;
+            pix = obj.get_pix_with_fake_faccess(data, npix_in_page);
+            
+            mask_array = [0, 1, 1, 0, 1, 0];
+            npix = [4, 5, 1, 2, 3, 5];
+            
+            pix = pix.mask(mask_array, npix);
+            
+            full_mask_array = repelem(mask_array, npix);
+            expected_data = data(:, logical(full_mask_array));
+            
+            actual_data = concatenate_pixel_pages(pix);
+            assertEqual(actual_data, expected_data);
+        end
+        
+        function test_mask_deletes_pixels_when_given_npix_argument_pix_in_mem(obj)
+            data = rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
+            pix = PixelData(data, obj.ALL_IN_MEM_PG_SIZE);
+            
+            mask_array = [0, 1, 1, 0, 1, 0];
+            npix = [4, 5, 1, 2, 3, 5];
+            
+            pix = pix.mask(mask_array, npix);
+            
+            full_mask_array = repelem(mask_array, npix);
+            expected_data = data(:, logical(full_mask_array));
+            
+            actual_data = concatenate_pixel_pages(pix);
+            assertEqual(actual_data, expected_data);
+        end
+        
+        function test_PIXELDATA_thrown_if_sum_of_npix_ne_to_num_pixels(~)
+            pix = PixelData(5);
+            npix = [1, 2];
+            f = @() pix.mask([0, 1], npix);
+            assertExceptionThrown(f, 'PIXELDATA:mask');
+        end
+        
+        function test_error_if_passing_mask_npix_and_num_pix_len_mask_array(~)
+            
+            function out = f()
+                num_pix = 10;
+                pix = PixelData(rand(PixelData.DEFAULT_NUM_PIX_FIELDS, num_pix));
+                mask_array = randi([0, 1], [1, num_pix]);
+                npix = rand(1, 4);
+                out = pix.mask(mask_array, npix);
+            end
+            
+            assertExceptionThrown(@() f(), 'PIXELDATA:mask');
+        end
+        
+        function test_not_enough_args_error_if_calling_mask_with_no_args(~)
+            
+            function pix = f()
+                pix = PixelData(rand(PixelData.DEFAULT_NUM_PIX_FIELDS, 10));
+                pix = pix.mask();
+            end
+            
+            assertExceptionThrown(@() f(), 'MATLAB:minrhs');
+        end
+        
+        function test_PixelData_and_raw_arrays_are_not_equal_to_tol(~)
+            raw_array = zeros(PixelData.DEFAULT_NUM_PIX_FIELDS, 10);
+            pix = PixelData(raw_array);
+            [ok, ~] = pix.equal_to_tol(raw_array);
+            assertFalse(ok);
+        end
+        
+        function test_equal_to_tol_err_msg_contains_argument_classes(~)
+            raw_array = zeros(PixelData.DEFAULT_NUM_PIX_FIELDS, 10);
+            pix = PixelData(raw_array);
+            [~, mess] = pix.equal_to_tol(raw_array);
+            assertTrue(contains(mess, 'PixelData'));
+            assertTrue(contains(mess, 'double'));
+        end
+        
+        function test_equal_to_tol_is_false_for_objects_with_unequal_num_pixels(~)
+            data = zeros(PixelData.DEFAULT_NUM_PIX_FIELDS, 10);
+            pix1 = PixelData(data);
+            pix2 = PixelData(data(:, 1:9));
+            assertFalse(pix1.equal_to_tol(pix2));
+        end
+        
+        function test_equal_to_tol_true_if_PixelData_objects_contain_same_data(~)
+            data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 10);
+            pix1 = PixelData(data);
+            pix2 = PixelData(data);
+            assertTrue(pix1.equal_to_tol(pix2));
+            assertTrue(pix2.equal_to_tol(pix1));
+        end
+        
+        function test_equal_to_tol_true_if_pixels_paged_and_contain_same_data(obj)
+            data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
+            npix_in_page = 10;
+            pix1 = obj.get_pix_with_fake_faccess(data, npix_in_page);
+            pix2 = obj.get_pix_with_fake_faccess(data, npix_in_page);
+            assertTrue(pix1.equal_to_tol(pix2));
+            assertTrue(pix2.equal_to_tol(pix1));
+        end
+        
+        function test_equal_to_tol_true_if_pixels_differ_less_than_tolerance(obj)
+            data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
+            npix_in_page = 10;
+            tol = 0.1;
+            pix1 = obj.get_pix_with_fake_faccess(data, npix_in_page);
+            pix2 = obj.get_pix_with_fake_faccess(data - (tol - 0.01), npix_in_page);
+            assertTrue(pix1.equal_to_tol(pix2, tol));
+            assertTrue(pix2.equal_to_tol(pix1, tol));
+        end
+        
+        function test_equal_to_tol_false_if_pix_paged_and_contain_unequal_data(obj)
+            data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
+            data2 = data;
+            data2(11) = 0.9;
+            npix_in_page = 10;
+            
+            pix1 = obj.get_pix_with_fake_faccess(data, npix_in_page);
+            pix2 = obj.get_pix_with_fake_faccess(data2, npix_in_page);
+            assertFalse(pix1.equal_to_tol(pix2));
+            assertFalse(pix2.equal_to_tol(pix1));
+        end
+        
+        function test_equal_to_tol_true_if_only_1_arg_paged_but_data_is_equal(obj)
+            data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
+            npix_in_page = 6;
+            
+            pix1 = PixelData(data);
+            pix2 = obj.get_pix_with_fake_faccess(data, npix_in_page);
+            assertTrue(pix1.equal_to_tol(pix2));
+            assertTrue(pix2.equal_to_tol(pix1));
+        end
+        
+        function test_equal_to_tol_false_if_only_1_arg_paged_and_data_not_equal(obj)
+            data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
+            npix_in_page = 6;
+            
+            pix1 = PixelData(data);
+            pix2 = obj.get_pix_with_fake_faccess(data - 1, npix_in_page);
+            assertFalse(pix1.equal_to_tol(pix2));
+            assertFalse(pix2.equal_to_tol(pix1));
+        end
+        
+        function test_equal_to_tol_throws_if_paged_pix_but_page_sizes_not_equal(obj)
+            data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
+            data2 = data;
+            npix_in_page = 10;
+            
+            pix1 = obj.get_pix_with_fake_faccess(data, npix_in_page);
+            pix2 = obj.get_pix_with_fake_faccess(data2, npix_in_page - 1);
+            f = @() pix1.equal_to_tol(pix2);
+            assertExceptionThrown(f, 'PIXELDATA:equal_to_tol');
+        end
+        
+        function test_equal_to_tol_true_when_comparing_NaNs_if_nan_equal_true(~)
+            data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
+            data(:, [5, 10, 15]) = nan;
+            pix1 = PixelData(data);
+            pix2 = PixelData(data);
+            
+            assertTrue(pix1.equal_to_tol(pix2, 'nan_equal', true));
+        end
+        
+        function test_equal_to_tol_false_when_comparing_NaNs_if_nan_equal_false(~)
+            data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
+            data(:, [5, 10, 15]) = nan;
+            pix1 = PixelData(data);
+            pix2 = PixelData(data);
+            
+            assertFalse(pix1.equal_to_tol(pix2, 'nan_equal', false));
+        end
+        
+        % -- Helpers --
+        function pix = get_pix_with_fake_faccess(obj, data, npix_in_page)
+            faccess = FakeFAccess(data);
+            pix = PixelData(faccess, npix_in_page*obj.BYTES_PER_PIX);
+        end
+        
     end
-
-    function test_PixelData_and_raw_arrays_are_not_equal_to_tol(~)
-        raw_array = zeros(PixelData.DEFAULT_NUM_PIX_FIELDS, 10);
-        pix = PixelData(raw_array);
-        [ok, ~] = pix.equal_to_tol(raw_array);
-        assertFalse(ok);
+    
+    methods (Static)
+        
+        function data = get_random_data_in_range(cols, rows, data_range)
+            data = data_range(1) + (data_range(2) - data_range(1)).*rand(cols, rows);
+        end
+        
     end
-
-    function test_equal_to_tol_err_msg_contains_argument_classes(~)
-        raw_array = zeros(PixelData.DEFAULT_NUM_PIX_FIELDS, 10);
-        pix = PixelData(raw_array);
-        [~, mess] = pix.equal_to_tol(raw_array);
-        assertTrue(contains(mess, 'PixelData'));
-        assertTrue(contains(mess, 'double'));
-    end
-
-    function test_equal_to_tol_is_false_for_objects_with_unequal_num_pixels(~)
-        data = zeros(PixelData.DEFAULT_NUM_PIX_FIELDS, 10);
-        pix1 = PixelData(data);
-        pix2 = PixelData(data(:, 1:9));
-        assertFalse(pix1.equal_to_tol(pix2));
-    end
-
-    function test_equal_to_tol_true_if_PixelData_objects_contain_same_data(~)
-        data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 10);
-        pix1 = PixelData(data);
-        pix2 = PixelData(data);
-        assertTrue(pix1.equal_to_tol(pix2));
-        assertTrue(pix2.equal_to_tol(pix1));
-    end
-
-    function test_equal_to_tol_true_if_pixels_paged_and_contain_same_data(obj)
-        data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
-        npix_in_page = 10;
-        pix1 = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix2 = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        assertTrue(pix1.equal_to_tol(pix2));
-        assertTrue(pix2.equal_to_tol(pix1));
-    end
-
-    function test_equal_to_tol_true_if_pixels_differ_less_than_tolerance(obj)
-        data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
-        npix_in_page = 10;
-        tol = 0.1;
-        pix1 = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix2 = obj.get_pix_with_fake_faccess(data - (tol - 0.01), npix_in_page);
-        assertTrue(pix1.equal_to_tol(pix2, tol));
-        assertTrue(pix2.equal_to_tol(pix1, tol));
-    end
-
-    function test_equal_to_tol_false_if_pix_paged_and_contain_unequal_data(obj)
-        data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
-        data2 = data;
-        data2(11) = 0.9;
-        npix_in_page = 10;
-
-        pix1 = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix2 = obj.get_pix_with_fake_faccess(data2, npix_in_page);
-        assertFalse(pix1.equal_to_tol(pix2));
-        assertFalse(pix2.equal_to_tol(pix1));
-    end
-
-    function test_equal_to_tol_true_if_only_1_arg_paged_but_data_is_equal(obj)
-        data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
-        npix_in_page = 6;
-
-        pix1 = PixelData(data);
-        pix2 = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        assertTrue(pix1.equal_to_tol(pix2));
-        assertTrue(pix2.equal_to_tol(pix1));
-    end
-
-    function test_equal_to_tol_false_if_only_1_arg_paged_and_data_not_equal(obj)
-        data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
-        npix_in_page = 6;
-
-        pix1 = PixelData(data);
-        pix2 = obj.get_pix_with_fake_faccess(data - 1, npix_in_page);
-        assertFalse(pix1.equal_to_tol(pix2));
-        assertFalse(pix2.equal_to_tol(pix1));
-    end
-
-    function test_equal_to_tol_throws_if_paged_pix_but_page_sizes_not_equal(obj)
-        data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
-        data2 = data;
-        npix_in_page = 10;
-
-        pix1 = obj.get_pix_with_fake_faccess(data, npix_in_page);
-        pix2 = obj.get_pix_with_fake_faccess(data2, npix_in_page - 1);
-        f = @() pix1.equal_to_tol(pix2);
-        assertExceptionThrown(f, 'PIXELDATA:equal_to_tol');
-    end
-
-    function test_equal_to_tol_true_when_comparing_NaNs_if_nan_equal_true(~)
-        data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
-        data(:, [5, 10, 15]) = nan;
-        pix1 = PixelData(data);
-        pix2 = PixelData(data);
-
-        assertTrue(pix1.equal_to_tol(pix2, 'nan_equal', true));
-    end
-
-    function test_equal_to_tol_false_when_comparing_NaNs_if_nan_equal_false(~)
-        data = ones(PixelData.DEFAULT_NUM_PIX_FIELDS, 20);
-        data(:, [5, 10, 15]) = nan;
-        pix1 = PixelData(data);
-        pix2 = PixelData(data);
-
-        assertFalse(pix1.equal_to_tol(pix2, 'nan_equal', false));
-    end
-
-    % -- Helpers --
-    function pix = get_pix_with_fake_faccess(obj, data, npix_in_page)
-        faccess = FakeFAccess(data);
-        pix = PixelData(faccess, npix_in_page*obj.BYTES_PER_PIX);
-    end
-
-end
-
-methods (Static)
-
-    function data = get_random_data_in_range(cols, rows, data_range)
-        data = data_range(1) + (data_range(2) - data_range(1)).*rand(cols, rows);
-    end
-
-end
-
+    
 end

--- a/_test/test_sqw/test_mask.m
+++ b/_test/test_sqw/test_mask.m
@@ -1,304 +1,316 @@
 classdef test_mask < TestCase
-
-properties
-    this_dir = fileparts(mfilename('fullpath'));
-    old_warn_state;
-
-    sqw_2d_file_path = '../test_sqw_file/sqw_2d_1.sqw';
-    sqw_2d;
-    sqw_2d_paged;
-    idxs_to_mask;
-    mask_array_2d;
-    masked_2d;
-    masked_2d_paged;
-
-    sqw_3d_file_path = '../test_rebin/w3d_sqw.sqw';
-    sqw_3d;
-    sqw_3d_paged;
-    idxs_to_mask_3d;
-    mask_array_3d;
-    masked_3d;
-    masked_3d_paged;
-end
-
-methods
-
-    function obj = test_mask(~)
-        obj = obj@TestCase('test_mask');
-
-        addpath(fullfile(obj.this_dir, 'utils'));
-
-        % Swallow any warnings for when pixel page size set too small
-        obj.old_warn_state = warning('OFF', 'PIXELDATA:validate_mem_alloc');
-
-        % 2D case setup
-        obj.sqw_2d = sqw(obj.sqw_2d_file_path);
-
-        obj.idxs_to_mask = [2, 46, 91, 93, 94, 107, 123, 166];
-        obj.mask_array_2d = ones(size(obj.sqw_2d.data.npix), 'logical');
-        obj.mask_array_2d(obj.idxs_to_mask) = 0;
-
-        obj.masked_2d = mask(obj.sqw_2d, obj.mask_array_2d);
-        [obj.sqw_2d_paged, obj.masked_2d_paged] = ...
+    
+    properties
+        this_dir = fileparts(mfilename('fullpath'));
+        old_warn_state;
+        
+        sqw_2d_file_path = '../test_sqw_file/sqw_2d_1.sqw';
+        sqw_2d;
+        sqw_2d_paged;
+        idxs_to_mask;
+        mask_array_2d;
+        masked_2d;
+        masked_2d_paged;
+        
+        sqw_3d_file_path = '../test_rebin/w3d_sqw.sqw';
+        sqw_3d;
+        sqw_3d_paged;
+        idxs_to_mask_3d;
+        mask_array_3d;
+        masked_3d;
+        masked_3d_paged;
+        % function handle to compare different array ranges on different Matlab-s
+        fh_range_check
+    end
+    
+    methods
+        
+        function obj = test_mask(~)
+            obj = obj@TestCase('test_mask');
+            
+            addpath(fullfile(obj.this_dir, 'utils'));
+            
+            % Swallow any warnings for when pixel page size set too small
+            obj.old_warn_state = warning('OFF', 'PIXELDATA:validate_mem_alloc');
+            
+            % 2D case setup
+            obj.sqw_2d = sqw(obj.sqw_2d_file_path);
+            
+            obj.idxs_to_mask = [2, 46, 91, 93, 94, 107, 123, 166];
+            obj.mask_array_2d = ones(size(obj.sqw_2d.data.npix), 'logical');
+            obj.mask_array_2d(obj.idxs_to_mask) = 0;
+            
+            obj.masked_2d = mask(obj.sqw_2d, obj.mask_array_2d);
+            [obj.sqw_2d_paged, obj.masked_2d_paged] = ...
                 obj.get_paged_sqw(obj.sqw_2d_file_path, obj.mask_array_2d);
-
-        % 3D case setup
-        obj.sqw_3d = sqw(obj.sqw_3d_file_path);
-
-        num_bins = numel(obj.sqw_3d.data.npix);
-        obj.idxs_to_mask_3d = linspace(1, num_bins/2, num_bins/2);
-        obj.mask_array_3d = ones(size(obj.sqw_3d.data.npix), 'logical');
-        obj.mask_array_3d(obj.idxs_to_mask_3d) = 0;
-
-        obj.masked_3d = mask(obj.sqw_3d, obj.mask_array_3d);
-        [obj.sqw_3d_paged, obj.masked_3d_paged] = ...
+            
+            % 3D case setup
+            obj.sqw_3d = sqw(obj.sqw_3d_file_path);
+            
+            num_bins = numel(obj.sqw_3d.data.npix);
+            obj.idxs_to_mask_3d = linspace(1, num_bins/2, num_bins/2);
+            obj.mask_array_3d = ones(size(obj.sqw_3d.data.npix), 'logical');
+            obj.mask_array_3d(obj.idxs_to_mask_3d) = 0;
+            
+            obj.masked_3d = mask(obj.sqw_3d, obj.mask_array_3d);
+            [obj.sqw_3d_paged, obj.masked_3d_paged] = ...
                 obj.get_paged_sqw(obj.sqw_3d_file_path, obj.mask_array_3d);
+            
+            try
+                obj.fh_range_check = @(data,limit)(all(data<limit,'all'));
+                is = obj.fh_range_check(zeros(2,10),0.1);
+            catch
+                obj.fh_range_check = @(data,limit)(all(reshape(data<limit,[1,numel(data)])));
+            end
+            
+        end
+        
+        function delete(obj)
+            rmpath(fullfile(obj.this_dir, 'utils'));
+            warning(obj.old_warn_state);
+        end
+        
+        function test_mask_sets_npix_in_masked_bins_to_zero(obj)
+            assertEqual(sum(obj.masked_2d.data.npix(~obj.mask_array_2d)), 0);
+        end
+        
+        function test_mask_sets_npix_in_masked_bins_to_zero_with_paged_pix(obj)
+            assertEqual(sum(obj.masked_2d_paged.data.npix(~obj.mask_array_2d)), 0);
+        end
+        
+        function test_mask_sets_signal_in_masked_bins_to_zero(obj)
+            assertEqual(sum(obj.masked_2d.data.s(~obj.mask_array_2d)), 0);
+        end
+        
+        function test_mask_sets_signal_in_masked_bins_to_zero_with_paged_pix(obj)
+            assertEqual(sum(obj.masked_2d_paged.data.s(~obj.mask_array_2d)), 0);
+        end
+        
+        function test_mask_sets_error_in_masked_bins_to_zero(obj)
+            assertEqual(sum(obj.masked_2d.data.e(~obj.mask_array_2d)), 0);
+        end
+        
+        function test_mask_sets_error_in_masked_bins_to_zero_with_paged_pix(obj)
+            assertEqual(sum(obj.masked_2d_paged.data.e(~obj.mask_array_2d)), 0);
+        end
+        
+        function test_mask_does_not_change_unmasked_bins_signal(obj)
+            assertEqual(obj.masked_2d.data.s(obj.mask_array_2d), ...
+                obj.sqw_2d.data.s(obj.mask_array_2d));
+        end
+        
+        function test_mask_does_not_change_unmasked_bins_signal_with_paged_pix(obj)
+            assertEqual(obj.masked_2d_paged.data.s(obj.mask_array_2d), ...
+                obj.sqw_2d.data.s(obj.mask_array_2d));
+        end
+        
+        function test_mask_does_not_change_unmasked_bins_error(obj)
+            assertEqual(obj.masked_2d.data.e(obj.mask_array_2d), ...
+                obj.sqw_2d.data.e(obj.mask_array_2d));
+        end
+        
+        function test_mask_does_not_change_unmasked_bins_error_with_paged_pix(obj)
+            assertEqual(obj.masked_2d_paged.data.e(obj.mask_array_2d), ...
+                obj.sqw_2d.data.e(obj.mask_array_2d));
+        end
+        
+        function test_mask_does_not_change_unmasked_bins_npix(obj)
+            assertEqual(obj.masked_2d.data.npix(obj.mask_array_2d), ...
+                obj.sqw_2d.data.npix(obj.mask_array_2d));
+        end
+        
+        function test_mask_does_not_change_unmasked_bins_npix_with_paged_pix(obj)
+            assertEqual(obj.masked_2d_paged.data.npix(obj.mask_array_2d), ...
+                obj.sqw_2d.data.npix(obj.mask_array_2d));
+        end
+        
+        function test_num_pixels_has_been_reduced_by_correct_amount(obj)
+            expected_num_pix = sum(obj.sqw_2d.data.npix(obj.mask_array_2d));
+            assertEqual(obj.masked_2d.data.pix.num_pixels, expected_num_pix);
+        end
+        
+        function test_num_pix_has_been_reduced_by_correct_amount_with_paged_pix(obj)
+            expected_num_pix = sum(obj.sqw_2d.data.npix(obj.mask_array_2d));
+            assertEqual(obj.masked_2d_paged.data.pix.num_pixels, expected_num_pix);
+        end
+        
+        function test_urange_recalculated_after_mask(obj)
+            original_urange = obj.sqw_2d.data.urange;
+            new_urange = obj.masked_2d.data.urange;
+            
+            urange_diff = abs(original_urange - new_urange);
+            assertTrue(urange_diff(1) > 0.001);
+            assertElementsAlmostEqual(original_urange(2:end), new_urange(2:end), ...
+                'absolute', 0.001);
+        end
+        
+        function test_urange_recalculated_after_mask_with_paged_pix(obj)
+            original_urange = obj.sqw_2d.data.urange;
+            new_urange = obj.masked_2d_paged.data.urange;
+            
+            urange_diff = abs(original_urange - new_urange);
+            assertTrue(urange_diff(1) > 0.001);
+            assertElementsAlmostEqual(original_urange(2:end), new_urange(2:end), ...
+                'absolute', 0.001);
+        end
+        
+        function test_urange_equal_for_paged_and_non_paged_sqw_after_mask(obj)
+            paged_urange = obj.masked_2d_paged.data.urange;
+            mem_urange = obj.masked_2d.data.urange;
+            assertElementsAlmostEqual(mem_urange, paged_urange, 'absolute', 0.001);
+        end
+        
+        function test_paged_and_non_paged_sqw_have_equivalent_pixels_after_mask(obj)
+            raw_paged_pix = concatenate_pixel_pages(obj.masked_2d_paged.data.pix);
+            assertEqual(raw_paged_pix, obj.masked_2d.data.pix.data);
+        end
+        
+        function test_mask_sets_npix_in_masked_bins_to_zero_3d(obj)
+            assertEqual(sum(obj.masked_3d.data.npix(~obj.mask_array_3d)), 0);
+        end
+        
+        function test_mask_sets_npix_in_masked_bins_to_zero_with_paged_pix_3d(obj)
+            assertEqual(sum(obj.masked_3d_paged.data.npix(~obj.mask_array_3d)), 0);
+        end
+        
+        function test_mask_sets_signal_in_masked_bins_to_zero_3d(obj)
+            assertEqual(sum(obj.masked_3d.data.s(~obj.mask_array_3d)), 0);
+        end
+        
+        function test_mask_sets_signal_in_masked_bins_to_zero_with_paged_pix_3d(obj)
+            assertEqual(sum(obj.masked_3d_paged.data.s(~obj.mask_array_3d)), 0);
+        end
+        
+        function test_mask_sets_error_in_masked_bins_to_zero_3d(obj)
+            assertEqual(sum(obj.masked_3d.data.e(~obj.mask_array_3d)), 0);
+        end
+        
+        function test_mask_sets_error_in_masked_bins_to_zero_with_paged_pix_3d(obj)
+            assertEqual(sum(obj.masked_3d_paged.data.e(~obj.mask_array_3d)), 0);
+        end
+        
+        function test_mask_does_not_change_unmasked_bins_signal_3d(obj)
+            assertEqual(obj.masked_3d.data.s(obj.mask_array_3d), ...
+                obj.sqw_3d.data.s(obj.mask_array_3d));
+        end
+        
+        function test_mask_doesnt_change_unmasked_bins_signal_with_paged_pix_3d(obj)
+            assertEqual(obj.masked_3d_paged.data.s(obj.mask_array_3d), ...
+                obj.sqw_3d.data.s(obj.mask_array_3d));
+        end
+        
+        function test_mask_does_not_change_unmasked_bins_error_3d(obj)
+            assertEqual(obj.masked_3d.data.e(obj.mask_array_3d), ...
+                obj.sqw_3d.data.e(obj.mask_array_3d));
+        end
+        
+        function test_mask_does_not_change_unmasked_bins_error_with_paged_pix_3d(obj)
+            assertEqual(obj.masked_3d_paged.data.e(obj.mask_array_3d), ...
+                obj.sqw_3d.data.e(obj.mask_array_3d));
+        end
+        
+        function test_mask_does_not_change_unmasked_bins_npix_3d(obj)
+            assertEqual(obj.masked_3d.data.npix(obj.mask_array_3d), ...
+                obj.sqw_3d.data.npix(obj.mask_array_3d));
+        end
+        
+        function test_mask_does_not_change_unmasked_bins_npix_with_paged_pix_3d(obj)
+            assertEqual(obj.masked_3d_paged.data.npix(obj.mask_array_3d), ...
+                obj.sqw_3d.data.npix(obj.mask_array_3d));
+        end
+        
+        function test_num_pixels_has_been_reduced_by_correct_amount_3d(obj)
+            expected_num_pix = sum(obj.sqw_3d.data.npix(obj.mask_array_3d));
+            assertEqual(obj.masked_3d.data.pix.num_pixels, expected_num_pix);
+        end
+        
+        function test_num_pix_has_been_reduced_by_correct_amount_paged_pix_3d(obj)
+            expected_num_pix = sum(obj.sqw_3d.data.npix(obj.mask_array_3d));
+            assertEqual(obj.masked_3d_paged.data.pix.num_pixels, expected_num_pix);
+        end
+        
+        function test_urange_recalculated_after_mask_3d(obj)
+            original_urange = obj.sqw_3d.data.urange;
+            urange_diff = abs(original_urange - obj.masked_3d.data.urange);
+            %assertTrue(~all(urange_diff < 0.001, 'all'));
+            assertTrue(~obj.fh_range_check(urange_diff,0.001));
+        end
+        
+        function test_urange_recalculated_after_mask_with_paged_pix_3d(obj)
+            original_urange = obj.sqw_3d.data.urange;
+            urange_diff = abs(original_urange - obj.masked_3d_paged.data.urange);
+            %assertTrue(~all(urange_diff < 0.001, 'all'));
+            assertTrue(~obj.fh_range_check(urange_diff,0.001));
+        end
+        
+        function test_paged_and_non_paged_sqw_have_same_pixels_after_mask_3d(obj)
+            raw_paged_pix = concatenate_pixel_pages(obj.masked_3d_paged.data.pix);
+            assertEqual(raw_paged_pix, obj.masked_3d.data.pix.data);
+        end
+        
+        function test_urange_equal_for_paged_and_non_paged_sqw_after_mask_3d(obj)
+            paged_urange = obj.masked_3d_paged.data.urange;
+            mem_urange = obj.masked_3d.data.urange;
+            assertElementsAlmostEqual(mem_urange, paged_urange, 'absolute', 0.001);
+        end
+        
+        function test_mask_pixels_removes_pixels_given_in_mask_array(obj)
+            sqw_obj = sqw(obj.sqw_2d_file_path);
+            mask_array = ones(1, sqw_obj.data.pix.num_pixels, 'logical');
+            
+            % Remove all pix where u1 greater than median u1
+            % This ensures urange will be sufficiently different
+            median_u1_range = median(sqw_obj.data.pix.u1);
+            pix_to_remove = sqw_obj.data.pix.u1 > median_u1_range;
+            
+            mask_array(pix_to_remove) = false;
+            new_sqw = mask_pixels(sqw_obj, mask_array);
+            
+            assertEqual(new_sqw.data.pix.num_pixels, sum(mask_array));
+            assertFalse(equal_to_tol(new_sqw.data.s, sqw_obj.data.s, -1e-4));
+            assertFalse(equal_to_tol(new_sqw.data.urange, sqw_obj.data.urange, -1e-4));
+        end
+        
+        function test_mask_random_fraction_pixels_removes_percentage_of_pixels(obj)
+            sqw_obj = sqw(obj.sqw_2d_file_path);
+            
+            frac_to_keep = 0.8;
+            new_sqw = mask_random_fraction_pixels(sqw_obj, frac_to_keep);
+            
+            expected_num_pix = round(frac_to_keep*sqw_obj.data.pix.num_pixels);
+            assertEqual(new_sqw.data.pix.num_pixels, expected_num_pix);
+        end
+        
+        function test_mask_random_pixels_retains_correct_number_of_pixels(obj)
+            sqw_obj = sqw(obj.sqw_2d_file_path);
+            
+            num_pix_to_keep = 5000;
+            new_sqw = mask_random_pixels(sqw_obj, num_pix_to_keep);
+            
+            assertEqual(new_sqw.data.pix.num_pixels, num_pix_to_keep);
+        end
+        
+        
     end
-
-    function delete(obj)
-        rmpath(fullfile(obj.this_dir, 'utils'));
-        warning(obj.old_warn_state);
+    
+    methods (Static)
+        
+        % -- Helpers --
+        function [paged_sqw, masked_sqw] = get_paged_sqw(file_path, mask_array)
+            old_pg_size = get(hor_config, 'pixel_page_size');
+            clean_up = onCleanup(@() set(hor_config, 'pixel_page_size', old_pg_size));
+            
+            file_info = dir(file_path);
+            new_pg_size = file_info.bytes/6;
+            set(hor_config, 'pixel_page_size', new_pg_size);
+            
+            paged_sqw = sqw(file_path);
+            masked_sqw = mask(paged_sqw, mask_array);
+            
+            % make sure we're actually paging the pixel data
+            assertTrue(paged_sqw.data.pix.page_size < paged_sqw.data.pix.num_pixels);
+        end
+        
     end
-
-    function test_mask_sets_npix_in_masked_bins_to_zero(obj)
-        assertEqual(sum(obj.masked_2d.data.npix(~obj.mask_array_2d)), 0);
-    end
-
-    function test_mask_sets_npix_in_masked_bins_to_zero_with_paged_pix(obj)
-        assertEqual(sum(obj.masked_2d_paged.data.npix(~obj.mask_array_2d)), 0);
-    end
-
-    function test_mask_sets_signal_in_masked_bins_to_zero(obj)
-        assertEqual(sum(obj.masked_2d.data.s(~obj.mask_array_2d)), 0);
-    end
-
-    function test_mask_sets_signal_in_masked_bins_to_zero_with_paged_pix(obj)
-        assertEqual(sum(obj.masked_2d_paged.data.s(~obj.mask_array_2d)), 0);
-    end
-
-    function test_mask_sets_error_in_masked_bins_to_zero(obj)
-        assertEqual(sum(obj.masked_2d.data.e(~obj.mask_array_2d)), 0);
-    end
-
-    function test_mask_sets_error_in_masked_bins_to_zero_with_paged_pix(obj)
-        assertEqual(sum(obj.masked_2d_paged.data.e(~obj.mask_array_2d)), 0);
-    end
-
-    function test_mask_does_not_change_unmasked_bins_signal(obj)
-        assertEqual(obj.masked_2d.data.s(obj.mask_array_2d), ...
-                    obj.sqw_2d.data.s(obj.mask_array_2d));
-    end
-
-    function test_mask_does_not_change_unmasked_bins_signal_with_paged_pix(obj)
-        assertEqual(obj.masked_2d_paged.data.s(obj.mask_array_2d), ...
-                    obj.sqw_2d.data.s(obj.mask_array_2d));
-    end
-
-    function test_mask_does_not_change_unmasked_bins_error(obj)
-        assertEqual(obj.masked_2d.data.e(obj.mask_array_2d), ...
-                    obj.sqw_2d.data.e(obj.mask_array_2d));
-    end
-
-    function test_mask_does_not_change_unmasked_bins_error_with_paged_pix(obj)
-        assertEqual(obj.masked_2d_paged.data.e(obj.mask_array_2d), ...
-                    obj.sqw_2d.data.e(obj.mask_array_2d));
-    end
-
-    function test_mask_does_not_change_unmasked_bins_npix(obj)
-        assertEqual(obj.masked_2d.data.npix(obj.mask_array_2d), ...
-                    obj.sqw_2d.data.npix(obj.mask_array_2d));
-    end
-
-    function test_mask_does_not_change_unmasked_bins_npix_with_paged_pix(obj)
-        assertEqual(obj.masked_2d_paged.data.npix(obj.mask_array_2d), ...
-                    obj.sqw_2d.data.npix(obj.mask_array_2d));
-    end
-
-    function test_num_pixels_has_been_reduced_by_correct_amount(obj)
-        expected_num_pix = sum(obj.sqw_2d.data.npix(obj.mask_array_2d));
-        assertEqual(obj.masked_2d.data.pix.num_pixels, expected_num_pix);
-    end
-
-    function test_num_pix_has_been_reduced_by_correct_amount_with_paged_pix(obj)
-        expected_num_pix = sum(obj.sqw_2d.data.npix(obj.mask_array_2d));
-        assertEqual(obj.masked_2d_paged.data.pix.num_pixels, expected_num_pix);
-    end
-
-    function test_urange_recalculated_after_mask(obj)
-        original_urange = obj.sqw_2d.data.urange;
-        new_urange = obj.masked_2d.data.urange;
-
-        urange_diff = abs(original_urange - new_urange);
-        assertTrue(urange_diff(1) > 0.001);
-        assertElementsAlmostEqual(original_urange(2:end), new_urange(2:end), ...
-                                  'absolute', 0.001);
-    end
-
-    function test_urange_recalculated_after_mask_with_paged_pix(obj)
-        original_urange = obj.sqw_2d.data.urange;
-        new_urange = obj.masked_2d_paged.data.urange;
-
-        urange_diff = abs(original_urange - new_urange);
-        assertTrue(urange_diff(1) > 0.001);
-        assertElementsAlmostEqual(original_urange(2:end), new_urange(2:end), ...
-                                  'absolute', 0.001);
-    end
-
-    function test_urange_equal_for_paged_and_non_paged_sqw_after_mask(obj)
-        paged_urange = obj.masked_2d_paged.data.urange;
-        mem_urange = obj.masked_2d.data.urange;
-        assertElementsAlmostEqual(mem_urange, paged_urange, 'absolute', 0.001);
-    end
-
-    function test_paged_and_non_paged_sqw_have_equivalent_pixels_after_mask(obj)
-        raw_paged_pix = concatenate_pixel_pages(obj.masked_2d_paged.data.pix);
-        assertEqual(raw_paged_pix, obj.masked_2d.data.pix.data);
-    end
-
-    function test_mask_sets_npix_in_masked_bins_to_zero_3d(obj)
-        assertEqual(sum(obj.masked_3d.data.npix(~obj.mask_array_3d)), 0);
-    end
-
-    function test_mask_sets_npix_in_masked_bins_to_zero_with_paged_pix_3d(obj)
-        assertEqual(sum(obj.masked_3d_paged.data.npix(~obj.mask_array_3d)), 0);
-    end
-
-    function test_mask_sets_signal_in_masked_bins_to_zero_3d(obj)
-        assertEqual(sum(obj.masked_3d.data.s(~obj.mask_array_3d)), 0);
-    end
-
-    function test_mask_sets_signal_in_masked_bins_to_zero_with_paged_pix_3d(obj)
-        assertEqual(sum(obj.masked_3d_paged.data.s(~obj.mask_array_3d)), 0);
-    end
-
-    function test_mask_sets_error_in_masked_bins_to_zero_3d(obj)
-        assertEqual(sum(obj.masked_3d.data.e(~obj.mask_array_3d)), 0);
-    end
-
-    function test_mask_sets_error_in_masked_bins_to_zero_with_paged_pix_3d(obj)
-        assertEqual(sum(obj.masked_3d_paged.data.e(~obj.mask_array_3d)), 0);
-    end
-
-    function test_mask_does_not_change_unmasked_bins_signal_3d(obj)
-        assertEqual(obj.masked_3d.data.s(obj.mask_array_3d), ...
-                    obj.sqw_3d.data.s(obj.mask_array_3d));
-    end
-
-    function test_mask_doesnt_change_unmasked_bins_signal_with_paged_pix_3d(obj)
-        assertEqual(obj.masked_3d_paged.data.s(obj.mask_array_3d), ...
-                    obj.sqw_3d.data.s(obj.mask_array_3d));
-    end
-
-    function test_mask_does_not_change_unmasked_bins_error_3d(obj)
-        assertEqual(obj.masked_3d.data.e(obj.mask_array_3d), ...
-                    obj.sqw_3d.data.e(obj.mask_array_3d));
-    end
-
-    function test_mask_does_not_change_unmasked_bins_error_with_paged_pix_3d(obj)
-        assertEqual(obj.masked_3d_paged.data.e(obj.mask_array_3d), ...
-                    obj.sqw_3d.data.e(obj.mask_array_3d));
-    end
-
-    function test_mask_does_not_change_unmasked_bins_npix_3d(obj)
-        assertEqual(obj.masked_3d.data.npix(obj.mask_array_3d), ...
-                    obj.sqw_3d.data.npix(obj.mask_array_3d));
-    end
-
-    function test_mask_does_not_change_unmasked_bins_npix_with_paged_pix_3d(obj)
-        assertEqual(obj.masked_3d_paged.data.npix(obj.mask_array_3d), ...
-                    obj.sqw_3d.data.npix(obj.mask_array_3d));
-    end
-
-    function test_num_pixels_has_been_reduced_by_correct_amount_3d(obj)
-        expected_num_pix = sum(obj.sqw_3d.data.npix(obj.mask_array_3d));
-        assertEqual(obj.masked_3d.data.pix.num_pixels, expected_num_pix);
-    end
-
-    function test_num_pix_has_been_reduced_by_correct_amount_paged_pix_3d(obj)
-        expected_num_pix = sum(obj.sqw_3d.data.npix(obj.mask_array_3d));
-        assertEqual(obj.masked_3d_paged.data.pix.num_pixels, expected_num_pix);
-    end
-
-    function test_urange_recalculated_after_mask_3d(obj)
-        original_urange = obj.sqw_3d.data.urange;
-        urange_diff = abs(original_urange - obj.masked_3d.data.urange);
-        assertTrue(~all(urange_diff < 0.001, 'all'));
-    end
-
-    function test_urange_recalculated_after_mask_with_paged_pix_3d(obj)
-        original_urange = obj.sqw_3d.data.urange;
-        urange_diff = abs(original_urange - obj.masked_3d_paged.data.urange);
-        assertTrue(~all(urange_diff < 0.001, 'all'));
-    end
-
-    function test_paged_and_non_paged_sqw_have_same_pixels_after_mask_3d(obj)
-        raw_paged_pix = concatenate_pixel_pages(obj.masked_3d_paged.data.pix);
-        assertEqual(raw_paged_pix, obj.masked_3d.data.pix.data);
-    end
-
-    function test_urange_equal_for_paged_and_non_paged_sqw_after_mask_3d(obj)
-        paged_urange = obj.masked_3d_paged.data.urange;
-        mem_urange = obj.masked_3d.data.urange;
-        assertElementsAlmostEqual(mem_urange, paged_urange, 'absolute', 0.001);
-    end
-
-    function test_mask_pixels_removes_pixels_given_in_mask_array(obj)
-        sqw_obj = sqw(obj.sqw_2d_file_path);
-        mask_array = ones(1, sqw_obj.data.pix.num_pixels, 'logical');
-
-        % Remove all pix where u1 greater than median u1
-        % This ensures urange will be sufficiently different
-        median_u1_range = median(sqw_obj.data.pix.u1);
-        pix_to_remove = sqw_obj.data.pix.u1 > median_u1_range;
-
-        mask_array(pix_to_remove) = false;
-        new_sqw = mask_pixels(sqw_obj, mask_array);
-
-        assertEqual(new_sqw.data.pix.num_pixels, sum(mask_array));
-        assertFalse(equal_to_tol(new_sqw.data.s, sqw_obj.data.s, -1e-4));
-        assertFalse(equal_to_tol(new_sqw.data.urange, sqw_obj.data.urange, -1e-4));
-    end
-
-    function test_mask_random_fraction_pixels_removes_percentage_of_pixels(obj)
-        sqw_obj = sqw(obj.sqw_2d_file_path);
-
-        frac_to_keep = 0.8;
-        new_sqw = mask_random_fraction_pixels(sqw_obj, frac_to_keep);
-
-        expected_num_pix = round(frac_to_keep*sqw_obj.data.pix.num_pixels);
-        assertEqual(new_sqw.data.pix.num_pixels, expected_num_pix);
-    end
-
-    function test_mask_random_pixels_retains_correct_number_of_pixels(obj)
-        sqw_obj = sqw(obj.sqw_2d_file_path);
-
-        num_pix_to_keep = 5000;
-        new_sqw = mask_random_pixels(sqw_obj, num_pix_to_keep);
-
-        assertEqual(new_sqw.data.pix.num_pixels, num_pix_to_keep);
-    end
-
-
-end
-
-methods (Static)
-
-    % -- Helpers --
-    function [paged_sqw, masked_sqw] = get_paged_sqw(file_path, mask_array)
-        old_pg_size = get(hor_config, 'pixel_page_size');
-        clean_up = onCleanup(@() set(hor_config, 'pixel_page_size', old_pg_size));
-
-        file_info = dir(file_path);
-        new_pg_size = file_info.bytes/6;
-        set(hor_config, 'pixel_page_size', new_pg_size);
-
-        paged_sqw = sqw(file_path);
-        masked_sqw = mask(paged_sqw, mask_array);
-
-        % make sure we're actually paging the pixel data
-        assertTrue(paged_sqw.data.pix.page_size < paged_sqw.data.pix.num_pixels);
-    end
-
-end
-
+    
 end

--- a/_test/test_sqw/test_mask.m
+++ b/_test/test_sqw/test_mask.m
@@ -242,6 +242,43 @@ methods
         assertElementsAlmostEqual(mem_urange, paged_urange, 'absolute', 0.001);
     end
 
+    function test_mask_pixels_removes_pixels_given_in_mask_array(obj)
+        sqw_obj = sqw(obj.sqw_2d_file_path);
+        mask_array = ones(1, sqw_obj.data.pix.num_pixels, 'logical');
+
+        % Remove all pix where u1 greater than median u1
+        % This ensures urange will be sufficiently different
+        median_u1_range = median(sqw_obj.data.pix.u1);
+        pix_to_remove = sqw_obj.data.pix.u1 > median_u1_range;
+
+        mask_array(pix_to_remove) = false;
+        new_sqw = mask_pixels(sqw_obj, mask_array);
+
+        assertEqual(new_sqw.data.pix.num_pixels, sum(mask_array));
+        assertFalse(equal_to_tol(new_sqw.data.s, sqw_obj.data.s, -1e-4));
+        assertFalse(equal_to_tol(new_sqw.data.urange, sqw_obj.data.urange, -1e-4));
+    end
+
+    function test_mask_random_fraction_pixels_removes_percentage_of_pixels(obj)
+        sqw_obj = sqw(obj.sqw_2d_file_path);
+
+        frac_to_keep = 0.8;
+        new_sqw = mask_random_fraction_pixels(sqw_obj, frac_to_keep);
+
+        expected_num_pix = round(frac_to_keep*sqw_obj.data.pix.num_pixels);
+        assertEqual(new_sqw.data.pix.num_pixels, expected_num_pix);
+    end
+
+    function test_mask_random_pixels_retains_correct_number_of_pixels(obj)
+        sqw_obj = sqw(obj.sqw_2d_file_path);
+
+        num_pix_to_keep = 5000;
+        new_sqw = mask_random_pixels(sqw_obj, num_pix_to_keep);
+
+        assertEqual(new_sqw.data.pix.num_pixels, num_pix_to_keep);
+    end
+
+
 end
 
 methods (Static)

--- a/documentation/release_notes/v3.5.1.md
+++ b/documentation/release_notes/v3.5.1.md
@@ -1,18 +1,7 @@
 # Release Notes v3.5.1
 
-## What's New?
-
-
-### Critical changes
-
--
-
-
-### Enhancements
-
--
-
-### Bugfixes
+## Bugfixes
 
 - A bug that was causing an error when `mask_random_pixels` or
-  `mask_random_fraction_pixels` was called has been fixed. ([#500](https://github.com/pace-neutrons/Horace/issues/500)).
+  `mask_random_fraction_pixels` was called has been fixed.
+  ([#500](https://github.com/pace-neutrons/Horace/issues/500)).

--- a/documentation/release_notes/v3.5.1.md
+++ b/documentation/release_notes/v3.5.1.md
@@ -8,11 +8,11 @@
 -
 
 
-## Enhancements
+### Enhancements
 
 -
 
-## Bugfixes
+### Bugfixes
 
 - A bug that was causing an error when `mask_random_pixels` or
-  `mask_random_fraction_pixels` was called has been fixed.
+  `mask_random_fraction_pixels` was called has been fixed. ([#500](https://github.com/pace-neutrons/Horace/issues/500)).

--- a/documentation/release_notes/v3.5.1.md
+++ b/documentation/release_notes/v3.5.1.md
@@ -1,0 +1,18 @@
+# Release Notes v3.5.1
+
+## What's New?
+
+
+### Critical changes
+
+-
+
+
+## Enhancements
+
+-
+
+## Bugfixes
+
+- A bug that was causing an error when `mask_random_pixels` or
+  `mask_random_fraction_pixels` was called has been fixed.

--- a/horace_core/sqw/@sqw/mask_pixels.m
+++ b/horace_core/sqw/@sqw/mask_pixels.m
@@ -82,7 +82,6 @@ end
 ibin = replicate_array(1:prod(sz),win.data.npix);   % (linear) bin number for each pixel
 npix=accumarray(ibin(mask_array),ones(1,sum(mask_array)),[prod(sz),1]);
 wout.data.npix=reshape(npix,sz);
-wout.data.pix.data=win.data.pix.get_pixels(mask_array).data;
+wout.data.pix=win.data.pix.mask(mask_array);
 wout.data.urange=recompute_urange(wout);
 wout=recompute_bin_data(wout);
-

--- a/horace_core/sqw/@sqw/mask_random_fraction_pixels.m
+++ b/horace_core/sqw/@sqw/mask_random_fraction_pixels.m
@@ -24,7 +24,7 @@ function wout = mask_random_fraction_pixels(win,npix)
 % Original author: S. Toth
 % Modifications: R. A. Ewings
 
-if ~is_sqw_type(win);
+if ~is_sqw_type(win)
     error('Can mask pixels only in an sqw-type object')
 end
 

--- a/horace_core/sqw/@sqw/mask_random_pixels.m
+++ b/horace_core/sqw/@sqw/mask_random_pixels.m
@@ -24,7 +24,7 @@ function wout = mask_random_pixels(win,npix)
 % Original author: S. Toth
 % Modifications: R. A. Ewings
 
-if ~is_sqw_type(win);
+if ~is_sqw_type(win)
     error('Can mask pixels only in an sqw-type object')
 end
 

--- a/horace_core/sqw/PixelData/@PixelData/compute_bin_data.m
+++ b/horace_core/sqw/PixelData/@PixelData/compute_bin_data.m
@@ -1,6 +1,7 @@
 function [mean_signal, mean_variance] = compute_bin_data(obj, npix)
 % Compute the mean signal and variance given the number of contributing
 % pixels for each bin
+% Returns empty arrays if obj contains no pixels.
 %
 %   >> [mean_signal, mean_variance] = compute_bin_data(obj, npix)
 %

--- a/horace_core/sqw/PixelData/@PixelData/mask.m
+++ b/horace_core/sqw/PixelData/@PixelData/mask.m
@@ -26,6 +26,10 @@ function pix_out = mask(obj, mask_array, varargin)
 %              the same dimensions as 'mask_array' i.e.
 %              all(size(mask_array) == size(npix)).
 %
+% Output:
+% -------
+% pix_out      A PixelData object containing only non-masked pixels.
+%
 if nargout ~= 1
     error('PIXELDATA:mask', ['Bad number of output arguments.\n''mask'' must be ' ...
                              'called with exactly one output argument.']);

--- a/horace_core/sqw/PixelData/@PixelData/mask.m
+++ b/horace_core/sqw/PixelData/@PixelData/mask.m
@@ -32,7 +32,7 @@ function pix_out = mask(obj, mask_array, varargin)
 %
 if nargout ~= 1
     error('PIXELDATA:mask', ['Bad number of output arguments.\n''mask'' must be ' ...
-                             'called with exactly one output argument.']);
+        'called with exactly one output argument.']);
 else
     [mask_array, npix] = validate_input_args(obj, mask_array, varargin{:});
 end
@@ -46,22 +46,22 @@ elseif numel(mask_array) == obj.num_pixels && ~any(mask_array)
 end
 
 if numel(mask_array) == obj.num_pixels
-
+    
     if obj.is_file_backed_()
         pix_out = do_mask_file_backed_with_full_mask_array(obj, mask_array);
     else
         pix_out = do_mask_in_memory_with_full_mask_array(obj, mask_array);
     end
-
+    
 elseif ~isempty(npix)
-
+    
     if obj.is_file_backed_()
         pix_out = do_mask_file_backed_with_npix(obj, mask_array, npix);
     else
         full_mask_array = repelem(mask_array, npix);
         pix_out = do_mask_in_memory_with_full_mask_array(obj, full_mask_array);
     end
-
+    
 end
 
 end
@@ -69,121 +69,131 @@ end
 
 % -----------------------------------------------------------------------------
 function pix_out = do_mask_in_memory_with_full_mask_array(obj, mask_array)
-    % Perform a mask of an all in-memory PixelData object with a mask array as
-    % long as the PixelData array i.e. numel(mask_array) == pix.num_pixels
-    %
-    pix_out = obj.get_pixels(mask_array);
+% Perform a mask of an all in-memory PixelData object with a mask array as
+% long as the PixelData array i.e. numel(mask_array) == pix.num_pixels
+%
+pix_out = obj.get_pixels(mask_array);
 end
 
 function pix_out = do_mask_file_backed_with_full_mask_array(obj, mask_array)
-    % Perfrom a mask of a file-backed PixelData object with a mask array as
-    % long as the full PixelData array i.e. numel(mask_array) == pix.num_pixels
-    %
-    obj.move_to_first_page();
+% Perfrom a mask of a file-backed PixelData object with a mask array as
+% long as the full PixelData array i.e. numel(mask_array) == pix.num_pixels
+%
+obj.move_to_first_page();
 
-    pix_out = PixelData();
-    end_idx = 0;
-    while true
-        start_idx = end_idx + 1;
-        end_idx = start_idx + obj.page_size - 1;
-        mask_array_chunk = mask_array(start_idx:end_idx);
-
-        pix_out.append(PixelData(obj.data(:, mask_array_chunk)));
-
-        if obj.has_more()
-            obj = obj.advance();
-        else
-            break;
-        end
+pix_out = PixelData();
+end_idx = 0;
+while true
+    start_idx = end_idx + 1;
+    end_idx = start_idx + obj.page_size - 1;
+    mask_array_chunk = mask_array(start_idx:end_idx);
+    
+    pix_out.append(PixelData(obj.data(:, mask_array_chunk)));
+    
+    if obj.has_more()
+        obj = obj.advance();
+    else
+        break;
     end
+end
 end
 
 function pix_out = do_mask_file_backed_with_npix(obj, mask_array, npix)
-    % Perform a mask of a file-backed PixelData object with a mask array and
-    % an npix array. The npix array should account for the full range of pixels
-    % in the PixelData instance i.e. sum(npix) == pix.num_pixels.
-    %
-    % The mask_array and npix array should have equal dimensions.
-    %
-    obj.move_to_first_page();
-    pix_out = PixelData();
+% Perform a mask of a file-backed PixelData object with a mask array and
+% an npix array. The npix array should account for the full range of pixels
+% in the PixelData instance i.e. sum(npix) == pix.num_pixels.
+%
+% The mask_array and npix array should have equal dimensions.
+%
+obj.move_to_first_page();
+pix_out = PixelData();
 
-    end_idx = 1;
-    npix_cum_sum = cumsum(npix(:));
-    while true
-        start_idx = (end_idx - 1) + find(npix_cum_sum(end_idx:end) > 0, 1);
-        leftover_begin = npix_cum_sum(start_idx);
-        npix_cum_sum = npix_cum_sum - obj.page_size;
-        end_idx = (start_idx - 1) + find(npix_cum_sum(start_idx:end) > 0, 1);
-        if isempty(end_idx)
-            end_idx = numel(npix);
-        end
-
-        if start_idx == end_idx
-            % All pixels in page
-            if ~exist('leftover_end', 'var')
-                leftover_end = 0;
-            end
-            npix_chunk = min(obj.page_size, npix(start_idx) - leftover_end);
-        else
-            % Leftover_end = number of pixels to allocate to final bin n,
-            % there will be more pixels to allocate to bin n in the next iteration
-            leftover_end = ...
-                obj.page_size - (leftover_begin + sum(npix(start_idx + 1:end_idx - 1)));
-            npix_chunk = npix(start_idx + 1:end_idx - 1);
-            npix_chunk = [leftover_begin, npix_chunk(:).', leftover_end];
-        end
-
-        mask_array_chunk = repelem(mask_array(start_idx:end_idx), npix_chunk);
-
-        pix_out.append(PixelData(obj.data(:, mask_array_chunk)));
-
-        if obj.has_more()
-            obj.advance();
-        else
-            break;
-        end
+end_idx = 1;
+npix_cum_sum = cumsum(npix(:));
+while true
+    start_idx = (end_idx - 1) + find(npix_cum_sum(end_idx:end) > 0, 1);
+    leftover_begin = npix_cum_sum(start_idx);
+    npix_cum_sum = npix_cum_sum - obj.page_size;
+    end_idx = (start_idx - 1) + find(npix_cum_sum(start_idx:end) > 0, 1);
+    if isempty(end_idx)
+        end_idx = numel(npix);
     end
+    
+    if start_idx == end_idx
+        % All pixels in page
+        if ~exist('leftover_end', 'var')
+            leftover_end = 0;
+        end
+        npix_chunk = min(obj.page_size, npix(start_idx) - leftover_end);
+    else
+        % Leftover_end = number of pixels to allocate to final bin n,
+        % there will be more pixels to allocate to bin n in the next iteration
+        leftover_end = ...
+            obj.page_size - (leftover_begin + sum(npix(start_idx + 1:end_idx - 1)));
+        npix_chunk = npix(start_idx + 1:end_idx - 1);
+        npix_chunk = [leftover_begin, npix_chunk(:).', leftover_end];
+    end
+    
+    mask_array_chunk = repelem(mask_array(start_idx:end_idx), npix_chunk);
+    
+    pix_out.append(PixelData(obj.data(:, mask_array_chunk)));
+    
+    if obj.has_more()
+        obj.advance();
+    else
+        break;
+    end
+end
 end
 
 function [mask_array, npix] = validate_input_args(obj, mask_array, varargin)
-    parser = inputParser();
-    parser.addRequired('obj');
-    parser.addRequired('mask_array');
-    parser.addOptional('npix', []);
-    parser.parse(obj, mask_array, varargin{:});
+parser = inputParser();
+parser.addRequired('obj');
+parser.addRequired('mask_array');
+parser.addOptional('npix', []);
+parser.parse(obj, mask_array, varargin{:});
 
-    mask_array = parser.Results.mask_array;
-    npix = parser.Results.npix;
+mask_array = parser.Results.mask_array;
+npix = parser.Results.npix;
+persistent sum_all;
+if isempty(sum_all)
+    % versions lower then 2018b do not accept 'all' option
+    try
+        sum_all = @(x)sum(x,'all');
+        s = sum_all(1:10);
+    catch
+        sum_all = @(x)sum(reshape(x,[1,numel(x)]));
+    end
+end
 
-    if numel(mask_array) ~= obj.num_pixels && isempty(npix)
+if numel(mask_array) ~= obj.num_pixels && isempty(npix)
+    error('PIXELDATA:mask', ...
+        ['Error masking pixel data.\nThe input mask_array must have ' ...
+        'number of elements equal to the number of pixels or must ' ...
+        ' be accompanied by the npix argument. Found ''%i'' ' ...
+        'elements, ''%i'' or ''%i'' elements required.'], ...
+        numel(mask_array), obj.num_pixels, obj.page_size);
+elseif ~isempty(npix)
+    if any(numel(npix) ~= numel(mask_array))
         error('PIXELDATA:mask', ...
-              ['Error masking pixel data.\nThe input mask_array must have ' ...
-               'number of elements equal to the number of pixels or must ' ...
-               ' be accompanied by the npix argument. Found ''%i'' ' ...
-               'elements, ''%i'' or ''%i'' elements required.'], ...
-              numel(mask_array), obj.num_pixels, obj.page_size);
-    elseif ~isempty(npix)
-        if any(numel(npix) ~= numel(mask_array))
-            error('PIXELDATA:mask', ...
-                  ['Number of elements in mask_array and npix must be equal.' ...
-                   '\nFound %i and %i elements'], numel(mask_array), numel(npix));
-        elseif sum(npix, 'all') ~= obj.num_pixels
-            error('PIXELDATA:mask', ...
-                ['The sum of npix must be equal to number of pixels.\n' ...
-                'Found sum(npix) = %i, %i pixels required.'], ...
-                sum(npix, 'all'), obj.num_pixels);
-        end
+            ['Number of elements in mask_array and npix must be equal.' ...
+            '\nFound %i and %i elements'], numel(mask_array), numel(npix));
+    elseif sum_all(npix) ~= obj.num_pixels
+        error('PIXELDATA:mask', ...
+            ['The sum of npix must be equal to number of pixels.\n' ...
+            'Found sum(npix) = %i, %i pixels required.'], ...
+            sum(npix, 'all'), obj.num_pixels);
     end
+end
 
-    if ~isvector(mask_array)
-        mask_array = mask_array(:);
-    end
-    if ~isa(mask_array, 'logical')
-        mask_array = logical(mask_array);
-    end
+if ~isvector(mask_array)
+    mask_array = mask_array(:);
+end
+if ~isa(mask_array, 'logical')
+    mask_array = logical(mask_array);
+end
 
-    if ~isempty(npix) && ~isvector(npix)
-        npix = npix(:);
-    end
+if ~isempty(npix) && ~isvector(npix)
+    npix = npix(:);
+end
 end

--- a/horace_core/sqw/PixelData/@PixelData/private/compute_bin_data_matlab_.m
+++ b/horace_core/sqw/PixelData/@PixelData/private/compute_bin_data_matlab_.m
@@ -14,6 +14,8 @@ try
     bin_indices = bin_indices(allocatable);
 
     if isempty(bin_indices)
+        mean_signal = [];
+        mean_variance = [];
         return;
     end
 

--- a/horace_core/sqw/PixelData/@PixelData/private/compute_bin_data_mex_.m
+++ b/horace_core/sqw/PixelData/@PixelData/private/compute_bin_data_mex_.m
@@ -5,6 +5,8 @@ function [mean_signal, mean_variance] = compute_bin_data_mex_(obj, npix, n_threa
 %
 
 if isempty(obj)
+    mean_signal = [];
+    mean_variance = [];
     return;
 end
 


### PR DESCRIPTION
This PR fixes and adds tests for `sqw.mask_pixels` which was failing as it had not been adapted to use `PixelData.mask` (see 
eae2783).

I also noticed that `PixelData.compute_bin_data` was throwing an unexpected error if the `PixelData` object contained no pixels. I took the decision to just return empty arrays in this case, another option was to throw an error - what do you think?

Addresses #500 

_Once this PR is merged into `rel_3_5` I'll open another PR to merge it into `master`_