### PR TITLE
Implement file to file cuts with temp files using file backed pixel data

### DIFF
--- a/_LowLevelCode/cpp/sort_pixels_by_bins/sort_pixels_by_bins.cpp
+++ b/_LowLevelCode/cpp/sort_pixels_by_bins/sort_pixels_by_bins.cpp
@@ -2,397 +2,430 @@
 #include "../utility/version.h"
 
 enum Input_Arguments {
-    Pixel_data,
-    Pixel_Indexes,
-    Pixel_Distribution,
-    N_INPUT_Arguments
+  Pixel_data,
+  Pixel_Indexes,
+  Pixel_Distribution,
+  N_INPUT_Arguments
 };
-enum Out_Arguments {
-    Pixels_Sorted,
-    N_OUTPUT_Arguments
-};
+enum Out_Arguments { Pixels_Sorted, N_OUTPUT_Arguments };
 /* What kind of input/output types the routine supports*/
 enum InputOutputTypes {
-    Pix8IndIOut8, // Double pixels, Int64 indexes, double output
-    Pix8IndDOut8, // Double pixels, Double indexes, double output
-    Pix4IndIOut8,
-    Pix4IndDOut8,
-    Pix4IndIOut4, // Float pixels Int64 indexes float output
-    Pix4IndDOut4,
-    ERROR,
-    N_InputCases
+  Pix8IndIOut8, // Double pixels, Int64 indexes, double output
+  Pix8IndDOut8, // Double pixels, Double indexes, double output
+  Pix4IndIOut8,
+  Pix4IndDOut8,
+  Pix4IndIOut4, // Float pixels Int64 indexes float output
+  Pix4IndDOut4,
+  ERROR,
+  N_InputCases
 };
 
-InputOutputTypes process_types(bool float_pix,bool int_index, bool double_out)
-{
-    if(float_pix){
-        if (int_index) {
-            if (double_out){return Pix4IndIOut8;}
-            else{ return Pix4IndIOut4; }
-        }
-        else {
-            if (double_out) { return Pix4IndDOut8; }
-            else { return Pix4IndDOut4; }
-        }
+InputOutputTypes process_types(bool float_pix, bool int_index,
+                               bool double_out) {
+  if (float_pix) {
+    if (int_index) {
+      if (double_out) {
+        return Pix4IndIOut8;
+      } else {
+        return Pix4IndIOut4;
+      }
+    } else {
+      if (double_out) {
+        return Pix4IndDOut8;
+      } else {
+        return Pix4IndDOut4;
+      }
     }
-    else {
-        if (int_index) {
-            if (double_out) { return Pix8IndIOut8; }
-            else { return ERROR; }
-        }
-        else {
-            if (double_out) { return Pix8IndDOut8; }
-            else { return ERROR; }
-
-        }
-
+  } else {
+    if (int_index) {
+      if (double_out) {
+        return Pix8IndIOut8;
+      } else {
+        return ERROR;
+      }
+    } else {
+      if (double_out) {
+        return Pix8IndDOut8;
+      } else {
+        return ERROR;
+      }
     }
+  }
 }
 
-std::string  verify_pix_array(const mxArray * pix_cell_array_ptr, bool &single_precision, std::vector<size_t> &pix_block_sizes,
-    std::vector<const double *> &pPix_blocks, size_t &n_tot_pixels) {
-    /* function processes and validates cell array of input pixels
+std::string verify_pix_array(const mxArray *pix_cell_array_ptr,
+                             bool &single_precision,
+                             std::vector<size_t> &pix_block_sizes,
+                             std::vector<const double *> &pPix_blocks,
+                             size_t &n_tot_pixels) {
+  /* function processes and validates cell array of input pixels
 
-    in particular, it calculates each cell size and number of pixels, containing in each array.
-    */
+  in particular, it calculates each cell size and number of pixels, containing
+  in each array.
+  */
 
-    mxClassID   category;
-    bool array_type_is_known(false);
+  mxClassID category;
+  bool array_type_is_known(false);
 
-    category = mxGetClassID(pix_cell_array_ptr);
-    if (category != mxCELL_CLASS)return "Input pixel array has to be packed in cell array";
+  category = mxGetClassID(pix_cell_array_ptr);
+  if (category != mxCELL_CLASS)
+    return "Input pixel array has to be packed in cell array";
 
-    n_tot_pixels = 0;
+  n_tot_pixels = 0;
 
+  const mxArray *cell_element_ptr;
 
-    const mxArray *cell_element_ptr;
+  size_t num_of_cells = mxGetNumberOfElements(pix_cell_array_ptr);
+  pix_block_sizes.assign(num_of_cells, 0);
+  pPix_blocks.assign(num_of_cells, NULL);
 
-    size_t num_of_cells = mxGetNumberOfElements(pix_cell_array_ptr);
-    pix_block_sizes.assign(num_of_cells, 0);
-    pPix_blocks.assign(num_of_cells, NULL);
+  /* Each cell mxArray contains 1-by-n cells; Each of these cells
+  is an 9xNpix mxArray. */
+  for (int ind = 0; ind < num_of_cells; ind++) {
 
-    /* Each cell mxArray contains 1-by-n cells; Each of these cells
-    is an 9xNpix mxArray. */
-    for (int ind = 0; ind < num_of_cells; ind++) {
-
-        cell_element_ptr = mxGetCell(pix_cell_array_ptr, ind);
-        if (cell_element_ptr != NULL) {
-            // check if a contributing pixels have the same parameters
-            category = mxGetClassID(cell_element_ptr);
-            if (category == mxDOUBLE_CLASS) {
-                if (array_type_is_known) {
-                    if (single_precision)return "Input pixels array contains blocks with different type of pixels. Only one type of pixels (single or double) is supported";
-                }
-                else {
-                    single_precision = false;
-                }
-            }
-            else if (category == mxSINGLE_CLASS) {
-                if (array_type_is_known) {
-                    if (!single_precision)return "Input pixels array contains blocks with different type of pixels. Only one type of pixels (single or double) is supported";
-                }
-                else {
-                    single_precision = true;
-                }
-            }
-            else
-                return "Input pixels array contains unsupported type of pixels. Only single and double precision pixels are supported";
-            array_type_is_known = true;
-
-            auto number_of_dimensions = mxGetNumberOfDimensions(cell_element_ptr);
-            auto dims = mxGetDimensions(cell_element_ptr);
-            if (number_of_dimensions != 2)return "Input pixels array contains non-2D block of pixels";
-
-            if (dims[0] != pix_fields::PIX_WIDTH)return "Input pixels array contains block of pixels with dimension 1 not equal to 9. Can not process this";
-            // retrieve pixels block data
-            n_tot_pixels += dims[1];
-            pix_block_sizes[ind] = dims[1];
-            pPix_blocks[ind] = reinterpret_cast<const double *>(mxGetPr(cell_element_ptr));
+    cell_element_ptr = mxGetCell(pix_cell_array_ptr, ind);
+    if (cell_element_ptr != NULL) {
+      // check if a contributing pixels have the same parameters
+      category = mxGetClassID(cell_element_ptr);
+      if (category == mxDOUBLE_CLASS) {
+        if (array_type_is_known) {
+          if (single_precision)
+            return "Input pixels array contains blocks with different type of "
+                   "pixels. Only one type of pixels (single or double) is "
+                   "supported";
+        } else {
+          single_precision = false;
         }
+      } else if (category == mxSINGLE_CLASS) {
+        if (array_type_is_known) {
+          if (!single_precision)
+            return "Input pixels array contains blocks with different type of "
+                   "pixels. Only one type of pixels (single or double) is "
+                   "supported";
+        } else {
+          single_precision = true;
+        }
+      } else
+        return "Input pixels array contains unsupported type of pixels. Only "
+               "single and double precision pixels are supported";
+      array_type_is_known = true;
+
+      auto number_of_dimensions = mxGetNumberOfDimensions(cell_element_ptr);
+      auto dims = mxGetDimensions(cell_element_ptr);
+      if (number_of_dimensions != 2)
+        return "Input pixels array contains non-2D block of pixels";
+
+      if (dims[0] != pix_fields::PIX_WIDTH)
+        return "Input pixels array contains block of pixels with dimension 1 "
+               "not equal to 9. Can not process this";
+      // retrieve pixels block data
+      n_tot_pixels += dims[1];
+      pix_block_sizes[ind] = dims[1];
+      pPix_blocks[ind] =
+          reinterpret_cast<const double *>(mxGetPr(cell_element_ptr));
     }
+  }
 
-
-    return "";
+  return "";
 };
 
-std::string  verify_index_array(const mxArray * pix_cell_array_ptr, bool &is_integer, std::vector<size_t> &ind_block_sizes,
-    std::vector<const double *> &pInd_blocks, size_t &n_tot_pixels) {
-    /* function processes and validates cell array of input indexes
+std::string verify_index_array(const mxArray *pix_cell_array_ptr,
+                               bool &is_integer,
+                               std::vector<size_t> &ind_block_sizes,
+                               std::vector<const double *> &pInd_blocks,
+                               size_t &n_tot_pixels) {
+  /* function processes and validates cell array of input indexes
 
-    in particular, it calculates each cell size and number of indexes, retained in each cell array.
-    */
+  in particular, it calculates each cell size and number of indexes, retained in
+  each cell array.
+  */
 
-    mxClassID   category;
-    bool array_type_is_known(false);
+  mxClassID category;
+  bool array_type_is_known(false);
 
-    category = mxGetClassID(pix_cell_array_ptr);
-    if (category != mxCELL_CLASS)return "Input pixel array has to be packed in cell array";
+  category = mxGetClassID(pix_cell_array_ptr);
+  if (category != mxCELL_CLASS)
+    return "Input pixel array has to be packed in cell array";
 
-    n_tot_pixels = 0;
+  n_tot_pixels = 0;
 
+  const mxArray *cell_element_ptr;
 
-    const mxArray *cell_element_ptr;
+  size_t num_of_cells = mxGetNumberOfElements(pix_cell_array_ptr);
+  ind_block_sizes.assign(num_of_cells, 0);
+  pInd_blocks.assign(num_of_cells, NULL);
 
-    size_t num_of_cells = mxGetNumberOfElements(pix_cell_array_ptr);
-    ind_block_sizes.assign(num_of_cells, 0);
-    pInd_blocks.assign(num_of_cells, NULL);
+  /* Each cell mxArray contains n cells; Each of these cells
+  is an 1D mxArray. */
+  for (int ind = 0; ind < num_of_cells; ind++) {
 
-
-    /* Each cell mxArray contains n cells; Each of these cells
-    is an 1D mxArray. */
-    for (int ind = 0; ind < num_of_cells; ind++) {
-
-        cell_element_ptr = mxGetCell(pix_cell_array_ptr, ind);
-        if (cell_element_ptr != NULL) {
-            // check if a contributing pixels have the same parameters
-            category = mxGetClassID(cell_element_ptr);
-            if (category == mxDOUBLE_CLASS) {
-                if (array_type_is_known) {
-                    if (is_integer)return "Input indexes array contains blocks with different type of indexes. Only one type of indexes (int64 or double) is supported";
-                }
-                else {
-                    is_integer = false;
-                }
-            }
-            else if (category == mxINT64_CLASS) {
-                if (array_type_is_known) {
-                    if (!is_integer)return "Input indexes array contains blocks with different type of indexes. Only one type of indexes (int64 or double) is supported";
-                }
-                else {
-                    is_integer = true;
-                }
-            }
-            else
-                return "Input indexes array contains unsupported type of indexes. Only int64 and double precision indexes are supported";
-            array_type_is_known = true;
-
-            auto number_of_dimensions = mxGetNumberOfDimensions(cell_element_ptr);
-            auto dims = mxGetDimensions(cell_element_ptr);
-            if (number_of_dimensions != 2)return "Input pixels array contains non-2D block of pixels";
-
-            auto nInd = (dims[1] + dims[0] - 1);
-            n_tot_pixels += nInd;
-            ind_block_sizes[ind] = nInd;
-            pInd_blocks[ind] = reinterpret_cast<const double *>(mxGetPr(cell_element_ptr));
-
+    cell_element_ptr = mxGetCell(pix_cell_array_ptr, ind);
+    if (cell_element_ptr != NULL) {
+      // check if a contributing pixels have the same parameters
+      category = mxGetClassID(cell_element_ptr);
+      if (category == mxDOUBLE_CLASS) {
+        if (array_type_is_known) {
+          if (is_integer)
+            return "Input indexes array contains blocks with different type of "
+                   "indexes. Only one type of indexes (int64 or double) is "
+                   "supported";
+        } else {
+          is_integer = false;
         }
+      } else if (category == mxINT64_CLASS) {
+        if (array_type_is_known) {
+          if (!is_integer)
+            return "Input indexes array contains blocks with different type of "
+                   "indexes. Only one type of indexes (int64 or double) is "
+                   "supported";
+        } else {
+          is_integer = true;
+        }
+      } else
+        return "Input indexes array contains unsupported type of indexes. Only "
+               "int64 and double precision indexes are supported";
+      array_type_is_known = true;
 
+      auto number_of_dimensions = mxGetNumberOfDimensions(cell_element_ptr);
+      auto dims = mxGetDimensions(cell_element_ptr);
+      if (number_of_dimensions != 2)
+        return "Input pixels array contains non-2D block of pixels";
+
+      auto nInd = (dims[1] + dims[0] - 1);
+      n_tot_pixels += nInd;
+      ind_block_sizes[ind] = nInd;
+      pInd_blocks[ind] =
+          reinterpret_cast<const double *>(mxGetPr(cell_element_ptr));
     }
-    return "";
+  }
+  return "";
 };
-
 
 /**********************************************************************************************
-! the function moves the pixels information into the places which correspond to the cells,
-! to which the pixels belong to.
-! takes 3 arguments:
+! the function moves the pixels information into the places which correspond to
+the cells, ! to which the pixels belong to. ! takes 3 arguments:
 !
 ! 1 -- cellarray of arrays of pixels for sorting
-! 2 -- cellarray of arrays of indexes of pixels within cells (a cell has more then one pixel and all pixels within this cell have the same index)
-! 3 -- number of pixels in each cell  (densities)
+! 2 -- cellarray of arrays of indexes of pixels within cells (a cell has more
+then one pixel and all pixels within this cell have the same index) ! 3 --
+number of pixels in each cell  (densities)
 !
 /**********************************************************************************************/
-void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
-{
-    if (nrhs == 0 && (nlhs == 0 || nlhs == 1)) {
-        plhs[0] = mxCreateString(Horace::VERSION);
-        return ;
-    }
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
+  if (nrhs == 0 && (nlhs == 0 || nlhs == 1)) {
+    plhs[0] = mxCreateString(Horace::VERSION);
+    return;
+  }
 
-    std::stringstream buf;
-    if (nrhs != N_INPUT_Arguments) {
-        buf << "ERROR::sort_pixels_by_bins needs" << (short)N_INPUT_Arguments << "  but got " << (short)nrhs << " input arguments\n";
-        mexErrMsgTxt(buf.str().c_str());
-    }
-    if (nlhs > N_OUTPUT_Arguments) {
-        buf << "ERROR::sort_pixels_by_bins accept only " << (short)N_OUTPUT_Arguments << " but requested to return" << (short)nlhs << " arguments\n";
-        mexErrMsgTxt(buf.str().c_str());
-    }
+  std::stringstream buf;
+  if (nrhs != N_INPUT_Arguments) {
+    buf << "ERROR::sort_pixels_by_bins needs" << (short)N_INPUT_Arguments
+        << "  but got " << (short)nrhs << " input arguments\n";
+    mexErrMsgTxt(buf.str().c_str());
+  }
+  if (nlhs > N_OUTPUT_Arguments) {
+    buf << "ERROR::sort_pixels_by_bins accept only "
+        << (short)N_OUTPUT_Arguments << " but requested to return"
+        << (short)nlhs << " arguments\n";
+    mexErrMsgTxt(buf.str().c_str());
+  }
 
-    for (int i = 0; i < nrhs; i++) {
-        if (prhs[i] == NULL) {
-            buf << "ERROR::sort_pixels_by_bins=> input argument N" << i + 1 << " undefined\n";
-            mexErrMsgTxt(buf.str().c_str());
-        }
+  for (int i = 0; i < nrhs; i++) {
+    if (prhs[i] == NULL) {
+      buf << "ERROR::sort_pixels_by_bins=> input argument N" << i + 1
+          << " undefined\n";
+      mexErrMsgTxt(buf.str().c_str());
     }
-    // check if routine should keep input type
-    const mxArray *pKeep_inputType = mexGetVariablePtr("caller","keep_type");
-    bool keep_input_type  = *(reinterpret_cast<const bool *>(pKeep_inputType));
+  }
+  // check if routine should keep input type
+  const mxArray *pKeep_inputType = mexGetVariablePtr("caller", "keep_type");
+  bool keep_input_type = *(reinterpret_cast<const bool *>(pKeep_inputType));
 
-    // evaluate input pixels cell array
-    bool pix_single_precision(false);
-    std::vector<size_t> pix_sizes;
-    std::vector<const double *> pPix_blocks;
-    size_t n_Input_pixels;
-    std::string err_code = verify_pix_array(prhs[Pixel_data], pix_single_precision, pix_sizes, pPix_blocks, n_Input_pixels);
-    if (err_code.size() > 0) {
-        mexErrMsgTxt(err_code.c_str());
-    }
-    // evaluate input indexes cell array
-    bool index_is_integer(false);
-    std::vector<size_t> index_sizes;
-    std::vector<const double *> pIndex_blocks;
-    size_t nPixelsSorted;
-    err_code = verify_index_array(prhs[Pixel_Indexes], index_is_integer, index_sizes, pIndex_blocks, nPixelsSorted);
-    if (err_code.size() > 0) {
-        mexErrMsgTxt(err_code.c_str());
-    }
-    //Get  npix  array
-    double  *pCellDens = (double *)mxGetPr(prhs[Pixel_Distribution]);
-    size_t distribution_size = mxGetNumberOfElements(prhs[Pixel_Distribution]);
+  // evaluate input pixels cell array
+  bool pix_single_precision(false);
+  std::vector<size_t> pix_sizes;
+  std::vector<const double *> pPix_blocks;
+  size_t n_Input_pixels;
+  std::string err_code =
+      verify_pix_array(prhs[Pixel_data], pix_single_precision, pix_sizes,
+                       pPix_blocks, n_Input_pixels);
+  if (err_code.size() > 0) {
+    mexErrMsgTxt(err_code.c_str());
+  }
+  // evaluate input indexes cell array
+  bool index_is_integer(false);
+  std::vector<size_t> index_sizes;
+  std::vector<const double *> pIndex_blocks;
+  size_t nPixelsSorted;
+  err_code = verify_index_array(prhs[Pixel_Indexes], index_is_integer,
+                                index_sizes, pIndex_blocks, nPixelsSorted);
+  if (err_code.size() > 0) {
+    mexErrMsgTxt(err_code.c_str());
+  }
+  // Get  npix  array
+  double *pCellDens = (double *)mxGetPr(prhs[Pixel_Distribution]);
+  size_t distribution_size = mxGetNumberOfElements(prhs[Pixel_Distribution]);
 
-    //mexWarnMsgTxt("entering allocation routines");
-    bool double_output(false);
+  // mexWarnMsgTxt("entering allocation routines");
+  bool double_output(false);
+  try {
+    std::vector<mwSize> dimVec(2, 9);
+    dimVec[1] = nPixelsSorted;
+    const mwSize *dims = &dimVec[0];
+    if (pix_single_precision && keep_input_type) {
+      plhs[Pixels_Sorted] =
+          mxCreateNumericArray(2, dims, mxSINGLE_CLASS, mxREAL);
+      double_output = false;
+    } else {
+      plhs[Pixels_Sorted] =
+          mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
+      double_output = true;
+    }
+    if (!plhs[Pixels_Sorted]) {
+      mexErrMsgTxt("Sort_pixels_by_bins: can not allocate memory for output "
+                   "pixels array");
+    }
+  } catch (...) {
+    mexErrMsgTxt(
+        "Sort_pixels_by_bins: can not allocate memory for output pixels array");
+  }
+  /*
+    mwSize  *const ppInd   = new mwSize[distribution_size]; //working array of
+    indexes for transformed pixels if(!ppInd){ mexErrMsgTxt(" can not allocate
+    memory for working array");
+    }
+  */
+  InputOutputTypes type_requested =
+      process_types(pix_single_precision, index_is_integer, double_output);
+  if (type_requested == ERROR) {
+    mexErrMsgTxt(
+        "Sort_pixels_by_bins: unsupported combination of input/output types");
+  }
+
+  try {
+    size_t array_size = distribution_size;
+    if (array_size == 0)
+      array_size = 1;
+    void *ppInd = mxMalloc(
+        array_size *
+        sizeof(size_t)); // working array of indexes for transformed pixels
+    if (!ppInd) {
+      mexErrMsgTxt("Sort_pixels_by_bins: memory allocation error for auxiliary "
+                   "array of indexes");
+    }
+    //---------------------------------------------------------------------------------------------
+
     try {
-        std::vector<mwSize> dimVec(2, 9);
-        dimVec[1] = nPixelsSorted;
-        const mwSize  *dims = &dimVec[0];
-        if (pix_single_precision && keep_input_type) {
-            plhs[Pixels_Sorted] = mxCreateNumericArray(2, dims, mxSINGLE_CLASS, mxREAL);
-            double_output = false;
+      switch (type_requested) {
+      case Pix8IndIOut8: {
+        double *const pPixelSorted = (double *)mxGetPr(plhs[Pixels_Sorted]);
+        std::vector<const int64_t *> piIndex_blocks(pIndex_blocks.size());
+        for (int i = 0; i < pIndex_blocks.size(); i++) {
+          piIndex_blocks[i] =
+              reinterpret_cast<const int64_t *>(pIndex_blocks[i]);
         }
-        else {
-            plhs[Pixels_Sorted] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
-            double_output = true;
-        }
-        if (!plhs[Pixels_Sorted]) {
-            mexErrMsgTxt("Sort_pixels_by_bins: can not allocate memory for output pixels array");
-        }
-    }
-    catch (...) {
-        mexErrMsgTxt("Sort_pixels_by_bins: can not allocate memory for output pixels array");
-    }
-    /*
-      mwSize  *const ppInd   = new mwSize[distribution_size]; //working array of indexes for transformed pixels
-      if(!ppInd){
-            mexErrMsgTxt(" can not allocate memory for working array");
+
+        sort_pixels_by_bins<double, int64_t, double>(
+            pPixelSorted, nPixelsSorted, pPix_blocks, pix_sizes, piIndex_blocks,
+            index_sizes, pCellDens, distribution_size,
+            reinterpret_cast<size_t *>(ppInd));
+
+        break;
       }
-    */
-    InputOutputTypes type_requested = process_types(pix_single_precision, index_is_integer, double_output);
-    if (type_requested == ERROR){
-        mexErrMsgTxt("Sort_pixels_by_bins: unsupported combination of input/output types");
-    }
+      case Pix8IndDOut8: {
+        double *const pPixelSorted = (double *)mxGetPr(plhs[Pixels_Sorted]);
+        std::vector<const int64_t *> piIndex_blocks(pIndex_blocks.size());
 
-    try {
-        size_t array_size = distribution_size;
-        if (array_size == 0)array_size = 1;
-        void * ppInd = mxMalloc(array_size*sizeof(size_t)); //working array of indexes for transformed pixels
-        if (!ppInd) {
-            mexErrMsgTxt("Sort_pixels_by_bins: memory allocation error for auxiliary array of indexes");
+        sort_pixels_by_bins<double, double, double>(
+            pPixelSorted, nPixelsSorted, pPix_blocks, pix_sizes, pIndex_blocks,
+            index_sizes, pCellDens, distribution_size,
+            reinterpret_cast<size_t *>(ppInd));
+
+        break;
+      }
+      case Pix4IndIOut8: {
+        double *const pPixelSorted = (double *)mxGetPr(plhs[Pixels_Sorted]);
+        std::vector<const float *> psPix_blocks(pPix_blocks.size());
+        std::vector<const int64_t *> piIndex_blocks(pIndex_blocks.size());
+        for (int i = 0; i < pPix_blocks.size(); i++) {
+          psPix_blocks[i] = reinterpret_cast<const float *>(pPix_blocks[i]);
+          piIndex_blocks[i] =
+              reinterpret_cast<const int64_t *>(pIndex_blocks[i]);
         }
-        //---------------------------------------------------------------------------------------------
+        //
+        sort_pixels_by_bins<float, int64_t, double>(
+            pPixelSorted, nPixelsSorted, psPix_blocks, pix_sizes,
+            piIndex_blocks, index_sizes, pCellDens, distribution_size,
+            reinterpret_cast<size_t *>(ppInd));
 
-        try {
-            switch (type_requested){
-            case Pix8IndIOut8: {
-                double * const pPixelSorted = (double *)mxGetPr(plhs[Pixels_Sorted]);
-                std::vector<const int64_t *> piIndex_blocks(pIndex_blocks.size());
-                for (int i = 0; i < pIndex_blocks.size(); i++) {
-                    piIndex_blocks[i] = reinterpret_cast<const int64_t *>(pIndex_blocks[i]);
-                }
-
-                sort_pixels_by_bins<double, int64_t, double>(pPixelSorted, nPixelsSorted, pPix_blocks, pix_sizes,
-                    piIndex_blocks, index_sizes,
-                    pCellDens, distribution_size,
-                    reinterpret_cast<size_t  *>(ppInd));
-
-                break;
-            }
-            case Pix8IndDOut8:{
-                double * const pPixelSorted = (double *)mxGetPr(plhs[Pixels_Sorted]);
-                std::vector<const int64_t *> piIndex_blocks(pIndex_blocks.size());
-
-                sort_pixels_by_bins<double, double, double>(pPixelSorted, nPixelsSorted, pPix_blocks, pix_sizes,
-                    pIndex_blocks, index_sizes,
-                    pCellDens, distribution_size,
-                    reinterpret_cast<size_t  *>(ppInd));
-
-                break;
-            }
-            case Pix4IndIOut8:{
-                double * const pPixelSorted = (double *)mxGetPr(plhs[Pixels_Sorted]);
-                std::vector<const float *> psPix_blocks(pPix_blocks.size());
-                std::vector<const int64_t *> piIndex_blocks(pIndex_blocks.size());
-                for (int i = 0; i < pPix_blocks.size(); i++) {
-                    psPix_blocks[i] = reinterpret_cast<const float *>(pPix_blocks[i]);
-                    piIndex_blocks[i] = reinterpret_cast<const int64_t *>(pIndex_blocks[i]);
-                }
-                //
-                sort_pixels_by_bins<float, int64_t, double>(pPixelSorted, nPixelsSorted, psPix_blocks, pix_sizes,
-                    piIndex_blocks, index_sizes,
-                    pCellDens, distribution_size,
-                    reinterpret_cast<size_t  *>(ppInd));
-
-
-                break;
-            }
-            case Pix4IndDOut8:{
-                double * const pPixelSorted = (double *)mxGetPr(plhs[Pixels_Sorted]);
-                std::vector<const float *> psPix_blocks(pPix_blocks.size());
-                for (int i = 0; i < pPix_blocks.size(); i++) {
-                    psPix_blocks[i] = reinterpret_cast<const float *>(pPix_blocks[i]);
-                }
-                //
-                sort_pixels_by_bins<float, double, double>(pPixelSorted, nPixelsSorted, psPix_blocks, pix_sizes,
-                    pIndex_blocks, index_sizes,
-                    pCellDens, distribution_size,
-                    reinterpret_cast<size_t  *>(ppInd));
-
-                break;
-            }
-            case Pix4IndIOut4: {
-                float * const pPixelSorted = (float *)mxGetPr(plhs[Pixels_Sorted]);
-                std::vector<const float *> psPix_blocks(pPix_blocks.size());
-                std::vector<const int64_t *> piIndex_blocks(pIndex_blocks.size());
-
-                for (int i = 0; i < pPix_blocks.size(); i++) {
-                    psPix_blocks[i] = reinterpret_cast<const float *>(pPix_blocks[i]);
-                    piIndex_blocks[i] = reinterpret_cast<const int64_t *>(pIndex_blocks[i]);
-                }
-                //
-                sort_pixels_by_bins<float, int64_t, float>(pPixelSorted, nPixelsSorted, psPix_blocks, pix_sizes,
-                    piIndex_blocks, index_sizes,
-                    pCellDens, distribution_size,
-                    reinterpret_cast<size_t  *>(ppInd));
-
-                break;
-            }
-            case Pix4IndDOut4: {
-                float * const pPixelSorted = (float *)mxGetPr(plhs[Pixels_Sorted]);
-                std::vector<const float *> psPix_blocks(pPix_blocks.size());
-
-                for (int i = 0; i < pPix_blocks.size(); i++) {
-                    psPix_blocks[i] = reinterpret_cast<const float *>(pPix_blocks[i]);
-                }
-                //
-                sort_pixels_by_bins<float, double, float>(pPixelSorted, nPixelsSorted, psPix_blocks, pix_sizes,
-                    pIndex_blocks, index_sizes,
-                    pCellDens, distribution_size,
-                    reinterpret_cast<size_t  *>(ppInd));
-
-                break;
-
-            }
-            case ERROR:
-                mexErrMsgTxt("Sort_pixels_by_bins: Got unsupported combination of input/output types");
-            case N_InputCases:
-                mexErrMsgTxt("Sort_pixels_by_bins: Got unsupported combination of input/output types");
-            default:
-                mexErrMsgTxt("Sort_pixels_by_bins: Got unsupported combination of input/output types");
-            }
-        }catch (const char *err) {
-            mxFree(ppInd);
-            mexErrMsgTxt(err);
+        break;
+      }
+      case Pix4IndDOut8: {
+        double *const pPixelSorted = (double *)mxGetPr(plhs[Pixels_Sorted]);
+        std::vector<const float *> psPix_blocks(pPix_blocks.size());
+        for (int i = 0; i < pPix_blocks.size(); i++) {
+          psPix_blocks[i] = reinterpret_cast<const float *>(pPix_blocks[i]);
         }
-        mxFree(ppInd);
+        //
+        sort_pixels_by_bins<float, double, double>(
+            pPixelSorted, nPixelsSorted, psPix_blocks, pix_sizes, pIndex_blocks,
+            index_sizes, pCellDens, distribution_size,
+            reinterpret_cast<size_t *>(ppInd));
+
+        break;
+      }
+      case Pix4IndIOut4: {
+        float *const pPixelSorted = (float *)mxGetPr(plhs[Pixels_Sorted]);
+        std::vector<const float *> psPix_blocks(pPix_blocks.size());
+        std::vector<const int64_t *> piIndex_blocks(pIndex_blocks.size());
+
+        for (int i = 0; i < pPix_blocks.size(); i++) {
+          psPix_blocks[i] = reinterpret_cast<const float *>(pPix_blocks[i]);
+          piIndex_blocks[i] =
+              reinterpret_cast<const int64_t *>(pIndex_blocks[i]);
+        }
+        //
+        sort_pixels_by_bins<float, int64_t, float>(
+            pPixelSorted, nPixelsSorted, psPix_blocks, pix_sizes,
+            piIndex_blocks, index_sizes, pCellDens, distribution_size,
+            reinterpret_cast<size_t *>(ppInd));
+
+        break;
+      }
+      case Pix4IndDOut4: {
+        float *const pPixelSorted = (float *)mxGetPr(plhs[Pixels_Sorted]);
+        std::vector<const float *> psPix_blocks(pPix_blocks.size());
+
+        for (int i = 0; i < pPix_blocks.size(); i++) {
+          psPix_blocks[i] = reinterpret_cast<const float *>(pPix_blocks[i]);
+        }
+        //
+        sort_pixels_by_bins<float, double, float>(
+            pPixelSorted, nPixelsSorted, psPix_blocks, pix_sizes, pIndex_blocks,
+            index_sizes, pCellDens, distribution_size,
+            reinterpret_cast<size_t *>(ppInd));
+
+        break;
+      }
+      case ERROR:
+        mexErrMsgTxt("Sort_pixels_by_bins: Got unsupported combination of "
+                     "input/output types");
+      case N_InputCases:
+        mexErrMsgTxt("Sort_pixels_by_bins: Got unsupported combination of "
+                     "input/output types");
+      default:
+        mexErrMsgTxt("Sort_pixels_by_bins: Got unsupported combination of "
+                     "input/output types");
+      }
     } catch (const char *err) {
-        mexErrMsgTxt(err);
-    } catch (...) {
-        mexErrMsgTxt("Sort_pixels_by_bins: unhandled exception in sort_pixels_by_bins procedure, location 3");
+      mxFree(ppInd);
+      mexErrMsgTxt(err);
     }
-
+    mxFree(ppInd);
+  } catch (const char *err) {
+    mexErrMsgTxt(err);
+  } catch (...) {
+    mexErrMsgTxt("Sort_pixels_by_bins: unhandled exception in "
+                 "sort_pixels_by_bins procedure, location 3");
+  }
 }
-
-
-
-

--- a/_LowLevelCode/cpp/sort_pixels_by_bins/sort_pixels_by_bins.h
+++ b/_LowLevelCode/cpp/sort_pixels_by_bins/sort_pixels_by_bins.h
@@ -1,54 +1,55 @@
 #ifndef H_SORT_PIXELS_BY_BINS
 #define H_SORT_PIXELS_BY_BINS
 
-
 #include "../CommonCode.h"
 
+#define iRound(x) (int)floor((x) + 0.5)
 
-#define iRound(x)  (int)floor((x)+0.5)
-
-#define  PIXEL_DATA_WIDTH  9
-
+#define PIXEL_DATA_WIDTH 9
 
 // $Revision$ $Date$
-template<class T, class N, class K>
-void sort_pixels_by_bins( K * const pPixelSorted, size_t nPixelsSorted, std::vector<const T *> &PixelData, std::vector<size_t> &NPixels,
-    std::vector<const N *> &PixelIndexes, std::vector<size_t> NIndexes,
-    double const *const pCellDens, size_t distribution_size,
-    size_t *const ppInd) {
+template <class T, class N, class K>
+void sort_pixels_by_bins(K *const pPixelSorted, size_t nPixelsSorted,
+                         std::vector<const T *> &PixelData,
+                         std::vector<size_t> &NPixels,
+                         std::vector<const N *> &PixelIndexes,
+                         std::vector<size_t> NIndexes,
+                         double const *const pCellDens,
+                         size_t distribution_size, size_t *const ppInd) {
 
+  ppInd[0] = 0;
+  // calculate the ranges of the cell arrays
+  for (size_t i = 1; i < distribution_size; i++) {
+    // the next cell starts from the the previous one
+    ppInd[i] = ppInd[i - 1] + (size_t)pCellDens[i - 1];
+  }; // plus the number of pixels in the cell previous cell
+  auto nCellDistributions =
+      ppInd[distribution_size - 1] + (size_t)pCellDens[distribution_size - 1];
+  if (nCellDistributions != nPixelsSorted) {
+    throw("Sort_pixels_by_bins: pixels data and their cell distributions are "
+          "inconsistent ");
+  }
 
-    ppInd[0] = 0;
-    for (size_t i = 1; i < distribution_size; i++) {   // calculate the ranges of the cell arrays
-        ppInd[i] = ppInd[i - 1] + (size_t)pCellDens[i - 1]; // the next cell starts from the the previous one
-    };                                      // plus the number of pixels in the cell previous cell
-    if (ppInd[distribution_size - 1] + (size_t)pCellDens[distribution_size - 1] != nPixelsSorted) {
-        throw("Sort_pixels_by_bins: pixels data and their cell distributions are inconsistent ");
+  //#pragma omp parallel
+  for (size_t nblock = 0; nblock < PixelIndexes.size(); nblock++) {
+    size_t nBlockInd = NIndexes[nblock];
+    const N *pCellInd = PixelIndexes[nblock];
+
+    const T *pPixData = PixelData[nblock];
+
+    for (size_t j = 0; j < nBlockInd; j++) { // sort pixels according to cells
+      size_t i0 = j * pix_fields::PIX_WIDTH;
+      size_t ind =
+          (size_t)(pCellInd[j] - 1); // -1 as Matlab arrays start from one;
+      size_t jBase = ppInd[ind] * pix_fields::PIX_WIDTH;
+      ppInd[ind]++;
+
+      for (size_t i = 0; i < pix_fields::PIX_WIDTH;
+           i++) { // copy all pixel data into the location requested
+        pPixelSorted[jBase + i] = static_cast<K>(pPixData[i0 + i]);
+      }
     }
-
-
-    //#pragma omp parallel
-    for(size_t nblock=0; nblock < PixelIndexes.size();nblock++)
-    {
-        size_t nBlockInd = NIndexes[nblock];
-        const N* pCellInd = PixelIndexes[nblock];
-
-        const T* pPixData= PixelData[nblock];
-
-        for (size_t j = 0; j < nBlockInd ; j++) {    // sort pixels according to cells
-            size_t i0 = j*pix_fields::PIX_WIDTH;
-            size_t ind = (size_t)(pCellInd[j] - 1); // -1 as Matlab arrays start from one;
-            size_t jBase = ppInd[ind] * pix_fields::PIX_WIDTH;
-            ppInd[ind]++;
-
-            for (size_t i = 0; i < pix_fields::PIX_WIDTH; i++) {  // copy all pixel data into the location requested
-                pPixelSorted[jBase + i] = static_cast<K>(pPixData[i0 + i]);
-            }
-        }
-    }
-
-
+  }
 }
 
-
-#endif
+#endif // H_SORT_PIXELS_BY_BINS

--- a/_test/test_algorithms/test_cut.m
+++ b/_test/test_algorithms/test_cut.m
@@ -325,6 +325,7 @@ methods
         outfile = fullfile(tmp_dir, 'tmp_outfile.sqw');
         cut(obj.sqw_file, proj, u_axis_lims, v_axis_lims, w_axis_lims, ...
             en_axis_lims, outfile, '-nopix')
+        cleanup = onCleanup(@() cleanup_file(outfile));
 
         assertTrue(logical(exist(outfile, 'file')));
         ldr = sqw_formats_factory.instance().get_loader(outfile);

--- a/_test/test_algorithms/test_cut.m
+++ b/_test/test_algorithms/test_cut.m
@@ -6,6 +6,7 @@ properties
     old_warn_state;
 
     sqw_file = '../test_sym_op/test_cut_sqw_sym.sqw';
+    ref_file = 'test_cut_ref_sqw.sqw'
     sqw_4d;
 end
 
@@ -311,6 +312,26 @@ methods
         f = @() cut(obj.sqw_file, proj, u_axis_lims, v_axis_lims, ...
                     w_axis_lims, en_axis_lims);
         assertExceptionThrown(f, 'CUT_SQW:invalid_arguments');
+    end
+
+    function test_you_can_take_a_cut_with_nopix_arg_and_output_to_file(obj)
+        proj = projaxes([1, -1 ,0], [1, 1, 0], 'uoffset', [1, 1, 0], 'type', 'paa');
+
+        u_axis_lims = [-0.1, 0.025, 0.1];
+        v_axis_lims = [-0.1, 0.025, 0.1];
+        w_axis_lims = [-0.1, 0.1];
+        en_axis_lims = [105, 1, 114];
+
+        outfile = fullfile(tmp_dir, 'tmp_outfile.sqw');
+        cut(obj.sqw_file, proj, u_axis_lims, v_axis_lims, w_axis_lims, ...
+            en_axis_lims, outfile, '-nopix')
+
+        assertTrue(logical(exist(outfile, 'file')));
+        ldr = sqw_formats_factory.instance().get_loader(outfile);
+        output_obj = ldr.get_dnd();
+        ref_object = d3d(obj.ref_file);
+
+        assertEqualToTol(output_obj, ref_object, 'ignore_str', true);
     end
 
 end

--- a/_test/test_algorithms/test_cut.m
+++ b/_test/test_algorithms/test_cut.m
@@ -1,6 +1,8 @@
 classdef test_cut < TestCase
 
 properties
+    FLOAT_TOL = 1e-5;
+
     old_warn_state;
 
     sqw_file = '../test_sym_op/test_cut_sqw_sym.sqw';
@@ -53,7 +55,7 @@ methods
         sqw_cut = cut(sqw_obj, proj, u_axis_lims, v_axis_lims, w_axis_lims, en_axis_lims);
 
         ref_sqw = sqw('test_cut_ref_sqw.sqw');
-        assertEqualToTol(sqw_cut, ref_sqw, 1e-4, 'ignore_str', true);
+        assertEqualToTol(sqw_cut, ref_sqw, obj.FLOAT_TOL, 'ignore_str', true);
     end
 
     function test_you_can_take_a_cut_with_nopix_argument(obj)
@@ -132,7 +134,7 @@ methods
 
         loaded_cut = sqw(outfile);
 
-        assertEqualToTol(ret_sqw, loaded_cut, 1e-5, 'ignore_str', true);
+        assertEqualToTol(ret_sqw, loaded_cut, obj.FLOAT_TOL, 'ignore_str', true);
     end
 
     function test_you_can_take_a_cut_from_an_sqw_object_to_an_sqw_file(obj)
@@ -153,7 +155,7 @@ methods
 
         loaded_sqw = sqw(outfile);
         ref_sqw = sqw('test_cut_ref_sqw.sqw');
-        assertEqualToTol(loaded_sqw, ref_sqw, 1e-4, 'ignore_str', true);
+        assertEqualToTol(loaded_sqw, ref_sqw, obj.FLOAT_TOL, 'ignore_str', true);
     end
 
     function test_you_can_take_a_cut_from_a_dnd_object(obj)
@@ -296,7 +298,7 @@ methods
         ref_sqw = sqw('test_cut_ref_sqw.sqw');
         output_sqw = sqw(outfile);
 
-        assertEqualToTol(output_sqw, ref_sqw, 1e-5, 'ignore_str', true);
+        assertEqualToTol(output_sqw, ref_sqw, obj.FLOAT_TOL, 'ignore_str', true);
     end
 
 end

--- a/_test/test_algorithms/test_cut.m
+++ b/_test/test_algorithms/test_cut.m
@@ -274,6 +274,31 @@ methods
         assertExceptionThrown(f, 'HORACE:cut');
     end
 
+    function test_you_can_take_an_out_of_memory_cut_with_tmp_files(obj)
+        conf = hor_config();
+        old_conf = conf.get_data_to_store();
+        conf.pixel_page_size = 5e5;
+        cleanup = onCleanup(@() set(hor_config, old_conf));
+
+        proj = projaxes([1, -1 ,0], [1, 1, 0], 'uoffset', [1, 1, 0], 'type', 'paa');
+        u_axis_lims = [-0.1, 0.025, 0.1];
+        v_axis_lims = [-0.1, 0.025, 0.1];
+        w_axis_lims = [-0.1, 0.1];
+        en_axis_lims = [105, 1, 114];
+
+        outfile = fullfile(tmp_dir, 'tmp_outfile.sqw');
+        cut( ...
+            obj.sqw_file, proj, u_axis_lims, v_axis_lims, w_axis_lims, ...
+            en_axis_lims, outfile ...
+        );
+        cleanup2 = onCleanup(@() cleanup_file(outfile));
+
+        ref_sqw = sqw('test_cut_ref_sqw.sqw');
+        output_sqw = sqw(outfile);
+
+        assertEqualToTol(output_sqw, ref_sqw, 1e-5, 'ignore_str', true);
+    end
+
 end
 
 end

--- a/_test/test_algorithms/test_cut.m
+++ b/_test/test_algorithms/test_cut.m
@@ -300,6 +300,19 @@ methods
         assertEqualToTol(output_sqw, ref_sqw, obj.FLOAT_TOL, 'ignore_str', true);
     end
 
+    function test_calling_cut_with_no_outfile_and_no_nargout_throws_error(obj)
+        proj = projaxes([1, -1 ,0], [1, 1, 0], 'uoffset', [1, 1, 0], 'type', 'paa');
+
+        u_axis_lims = [-0.1, 0.025, 0.1];
+        v_axis_lims = [-0.1, 0.025, 0.1];
+        w_axis_lims = [-0.1, 0.1];
+        en_axis_lims = [105, 1, 114];
+
+        f = @() cut(obj.sqw_file, proj, u_axis_lims, v_axis_lims, ...
+                    w_axis_lims, en_axis_lims);
+        assertExceptionThrown(f, 'CUT_SQW:invalid_arguments');
+    end
+
 end
 
 methods (Static)

--- a/_test/test_algorithms/test_cut.m
+++ b/_test/test_algorithms/test_cut.m
@@ -39,7 +39,7 @@ methods
         sqw_cut = cut(...
             obj.sqw_file, proj, u_axis_lims, v_axis_lims, w_axis_lims, en_axis_lims);
 
-        ref_sqw = sqw('test_cut_ref_sqw.sqw');
+        ref_sqw = sqw(obj.ref_file);
         assertEqualToTol(sqw_cut, ref_sqw, 1e-5, 'ignore_str', true);
     end
 
@@ -55,7 +55,7 @@ methods
 
         sqw_cut = cut(sqw_obj, proj, u_axis_lims, v_axis_lims, w_axis_lims, en_axis_lims);
 
-        ref_sqw = sqw('test_cut_ref_sqw.sqw');
+        ref_sqw = sqw(obj.ref_file);
         assertEqualToTol(sqw_cut, ref_sqw, obj.FLOAT_TOL, 'ignore_str', true);
     end
 
@@ -77,7 +77,7 @@ methods
             '-nopix' ...
         );
 
-        ref_sqw = d3d('test_cut_ref_sqw.sqw');
+        ref_sqw = d3d(obj.ref_file);
         assertEqualToTol(sqw_cut, ref_sqw, 1e-5, 'ignore_str', true);
     end
 
@@ -155,7 +155,7 @@ methods
         cleanup = onCleanup(@() cleanup_file(outfile));
 
         loaded_sqw = sqw(outfile);
-        ref_sqw = sqw('test_cut_ref_sqw.sqw');
+        ref_sqw = sqw(obj.ref_file);
         assertEqualToTol(loaded_sqw, ref_sqw, obj.FLOAT_TOL, 'ignore_str', true);
     end
 
@@ -283,7 +283,7 @@ methods
         outfile = fullfile(tmp_dir, 'tmp_outfile.sqw');
         cleanup = obj.do_out_of_mem_cut(obj.sqw_file, outfile, pix_pg_size, use_mex);
 
-        ref_sqw = sqw('test_cut_ref_sqw.sqw');
+        ref_sqw = sqw(obj.ref_file);
         output_sqw = sqw(outfile);
 
         assertEqualToTol(output_sqw, ref_sqw, obj.FLOAT_TOL, 'ignore_str', true);
@@ -295,7 +295,7 @@ methods
         outfile = fullfile(tmp_dir, 'tmp_outfile.sqw');
         cleanup = obj.do_out_of_mem_cut(obj.sqw_file, outfile, pix_pg_size, use_mex);
 
-        ref_sqw = sqw('test_cut_ref_sqw.sqw');
+        ref_sqw = sqw(obj.ref_file);
         output_sqw = sqw(outfile);
 
         assertEqualToTol(output_sqw, ref_sqw, obj.FLOAT_TOL, 'ignore_str', true);

--- a/_test/test_rebin/test_rebin.m
+++ b/_test/test_rebin/test_rebin.m
@@ -110,7 +110,8 @@ classdef test_rebin < TestCase
             w2d_qq_sqw_reb_check.data.e=w2d_qq_sqw_reb.data.e;
             w2d_qq_sqw_reb_check.data.pix.variance=w2d_qq_sqw_reb.data.pix.variance;
             
-            [ok,mess]=equal_to_tol(w2d_qq_sqw_reb_check,w2d_qq_sqw_reb,-1e-6,'ignore_str', 1);
+            rel_tol = 9e-5;
+            [ok,mess]=equal_to_tol(w2d_qq_sqw_reb_check,w2d_qq_sqw_reb,-rel_tol,'ignore_str', 1);
             assertTrue(ok,['rebin sqw using template object fails: ',mess])
         end
         

--- a/horace_core/algorithms/@cut_data_from_file_job/cut_data_from_file_job.m
+++ b/horace_core/algorithms/@cut_data_from_file_job/cut_data_from_file_job.m
@@ -166,6 +166,9 @@ classdef cut_data_from_file_job < JobExecutor
                 v, proj, pax);
         end
 
+        function pix_comb_info = accumulate_pix_to_file(varargin)
+            pix_comb_info = accumulate_pix_to_file_(varargin{:});
+        end
 
         function [common_par,loop_par] = pack_job_pars(sqw_loaders)
             % Pack the the job parameters into the form, suitable

--- a/horace_core/algorithms/cut.m
+++ b/horace_core/algorithms/cut.m
@@ -32,5 +32,8 @@ else
            'Argument ''source'' must be sqw, dnd or a valid file path.'], ...
           class(source));
 end
-
-wout = cut(sqw_dnd_obj, varargin{:});
+if nargout > 0
+    wout = cut(sqw_dnd_obj, varargin{:});
+else
+    cut(sqw_dnd_obj, varargin{:});
+end

--- a/horace_core/sqw/@sqw/private/cut_accumulate_data_.m
+++ b/horace_core/sqw/@sqw/private/cut_accumulate_data_.m
@@ -204,20 +204,27 @@ end
 function pci = init_pix_combine_info(nfiles, nbins)
     % Create a pix_combine_info object to manage temporary files of pixels
     wk_dir = get(parallel_config, 'working_directory');
-    gen_fpath = @(x) fullfile( ...
-        wk_dir, ['horace_subcut_', rand_digit_string(16), '.tmp'] ...
-    );
-    tmp_file_names = cellfun(gen_fpath, cell(1, nfiles), 'UniformOutput', false);
+    tmp_file_names = gen_array_of_tmp_file_paths(nfiles, wk_dir);
     pci = pix_combine_info(tmp_file_names, nbins);
 end
 
 
-function str = rand_digit_string(n)
-    % Create string of n random digits
-    rand_ints = randi([0, 9], [1, n]);
-    str = blanks(n);
-    for i=1:n
-        str(i) = int2str(rand_ints(i));
+function paths = gen_array_of_tmp_file_paths(nfiles, base_dir)
+    % Generate a cell array of paths for temporary files to be written to
+    % Format of the file names follows:
+    %   horace_cut_<UUID>_<counter_with_padded_zeros>.tmp
+    if nfiles < 1
+        error('CUT:cut_accumulate_data_', ...
+              ['Cannot create temporary file paths for less than 1 file.' ...
+               '\nFound %i.'], nfiles);
+    end
+    prefix = 'horace_cut';
+    uuid = char(java.util.UUID.randomUUID());
+    counter_padding = floor(log10(nfiles)) + 1;
+    format_str = sprintf('%s_%s_%%0%ii.tmp', prefix, uuid, counter_padding);
+    paths = cell(1, nfiles);
+    for i = 1:nfiles
+        paths{i} = fullfile(base_dir, sprintf(format_str, i));
     end
 end
 

--- a/horace_core/sqw/@sqw/private/cut_single.m
+++ b/horace_core/sqw/@sqw/private/cut_single.m
@@ -70,7 +70,7 @@ if exist('outfile', 'var') && ~isempty(outfile)
         disp(['Writing cut to output file ', outfile, '...']);
     end
     try
-        save_sqw(wout, outfile);
+        save(wout, outfile);
     catch ME
         warning('CUT_SQW:io_error', ...
                 'Error writing to file ''%s''.\n%s: %s', ...
@@ -91,14 +91,6 @@ end  % function
 
 
 % -----------------------------------------------------------------------------
-function save_sqw(sqw_obj, file_path)
-    loader = sqw_formats_factory.instance().get_pref_access();
-    loader = loader.init(sqw_obj, file_path);
-    loader.put_sqw();
-    loader.delete();
-end
-
-
 function data_out = compile_sqw_data(data, proj, s, e, npix, pix_out, ...
                                      pix_comb_info, urange_pix, ubins, keep_pix)
     ppax = ubins.plot_ax_bounds(1:length(ubins.plot_ax_idx));

--- a/horace_core/sqw/@sqw/private/cut_single.m
+++ b/horace_core/sqw/@sqw/private/cut_single.m
@@ -78,6 +78,15 @@ if exist('outfile', 'var') && ~isempty(outfile)
     end
 end
 
+% Manually clean-up temporary files created by a pix_combine_info object
+if isa(wout.data.pix, 'pix_combine_info')
+    pix_comb_info = wout.data.pix;
+    for i = 1:numel(wout.data.pix)
+        tmp_fpath = pix_comb_info.infiles{i};
+        delete(tmp_fpath);
+    end
+end
+
 end  % function
 
 
@@ -122,7 +131,12 @@ function data_out = compile_sqw_data(data, proj, s, e, npix, pix_out, ...
 
     if keep_pix
         data_out.urange = urange_pix;
-        if isa(pix_comb_info, 'pix_combine_info')
+        % If pix_comb_info is not empty then we've been working with temp files
+        % for pixels. We can replace the PixelData object that's normally in
+        % sqw.data with this pix_combine_info object.
+        % When the object is passed to 'put_sqw' (it's saved), 'put_sqw' will
+        % combine the linked tmp files into the new sqw file.
+        if ~isempty(pix_comb_info) && isa(pix_comb_info, 'pix_combine_info')
             data_out.pix = pix_comb_info;
         else
             data_out.pix = pix_out;

--- a/horace_core/sqw/@sqw/private/cut_single.m
+++ b/horace_core/sqw/@sqw/private/cut_single.m
@@ -79,7 +79,7 @@ if exist('outfile', 'var') && ~isempty(outfile)
 end
 
 % Manually clean-up temporary files created by a pix_combine_info object
-if isa(wout.data.pix, 'pix_combine_info')
+if isa(wout, 'sqw') && isa(wout.data.pix, 'pix_combine_info')
     pix_comb_info = wout.data.pix;
     for i = 1:numel(wout.data.pix)
         tmp_fpath = pix_comb_info.infiles{i};

--- a/horace_core/sqw/@sqw/private/cut_single.m
+++ b/horace_core/sqw/@sqw/private/cut_single.m
@@ -24,6 +24,7 @@ function wout = cut_single(w, proj, pbin, pin, en, keep_pix, outfile)
 
 DND_CONSTRUCTORS = {@d0d, @d1d, @d2d, @d3d, @d4d};
 log_level = get(hor_config, 'log_level');
+return_cut = nargout > 0;
 
 wout = copy(w, 'exclude_pix', true);
 
@@ -45,11 +46,14 @@ proj = proj.set_proj_binning( ...
 );
 
 % Accumulate image and pixel data for cut
-[s, e, npix, pix_out, urange_pix] = cut_accumulate_data_(w, proj, keep_pix, log_level);
+[s, e, npix, pix_out, urange_pix, pix_comb_info] = cut_accumulate_data_( ...
+    w, proj, keep_pix, log_level, return_cut ...
+);
 
 % Compile the accumulated cut and projection data into a data_sqw_dnd object
-data_out = compile_sqw_data(w.data, proj, s, e, npix, pix_out, urange_pix, ...
-                            ubins, keep_pix);
+data_out = compile_sqw_data( ...
+    w.data, proj, s, e, npix, pix_out, pix_comb_info, urange_pix, ubins, keep_pix ...
+);
 
 % Assign the new data_sqw_dnd object to the output SQW object, or create a new
 % dnd.
@@ -87,7 +91,7 @@ end
 
 
 function data_out = compile_sqw_data(data, proj, s, e, npix, pix_out, ...
-                                     urange_pix, ubins, keep_pix)
+                                     pix_comb_info, urange_pix, ubins, keep_pix)
     ppax = ubins.plot_ax_bounds(1:length(ubins.plot_ax_idx));
     if isempty(ppax)
         nbin_as_size = [1, 1];
@@ -118,6 +122,10 @@ function data_out = compile_sqw_data(data, proj, s, e, npix, pix_out, ...
 
     if keep_pix
         data_out.urange = urange_pix;
-        data_out.pix = pix_out;
+        if isa(pix_comb_info, 'pix_combine_info')
+            data_out.pix = pix_comb_info;
+        else
+            data_out.pix = pix_out;
+        end
     end
 end


### PR DESCRIPTION
This PR restores the ability to take out-of-memory cuts from an SQW file. This is useful when taking cuts where the output cut is too large to fit in memory. I've not implemented a new process for these types of cut, I've simply dropped in the old method using a `pix_combine_info` object.

The out-of-memory cuts work by:
1) Looping over input file's pixels
2) Retaining only the pixels in the range of the cut
3) Saving the pixels to be retained in a temporary file, along with an `npix` array that specifies which pixels belong in which bin (of the output cut)
4) Generating an SQW object (`sqw_cut_obj`) whose pixels are replaced with a `pix_combine_info` object (this holds a reference to the temp files and info required to combine them)
5) When `sqw_cut_obj` is saved, `put_sqw_data_pix_from_file_` iterates over the image bins of `sqw_cut_obj` and over the temporary files, loading pixels for the given bin from each temporary file and writing them to the output file (this is a very similar process to `gen_sqw`).
6) The temporary files can be deleted once the cut is complete.

To take an out-of-memory cut, you should call `cut` with no output arguments whilst specifying an output file to write the output cut to:
```matlab
cut(infile, proj, u_axis_lims, v_axis_lims, w_axis_lims, en_axis_lims, outfile);
```

_Note that you cannot perform an out-of-memory cut if you call `cut` with an output argument, hence `cut` can never return an SQW whose pixels are replaced with a `pix_combine_info` object._

I've also applied `clang-format` to a couple of C++ files, but have not changed their content otherwise (apologies for the extra files in the PR).

Addresses #514 

