### PR TITLE
Replace uses of CMAKE_SOURCE_DIR with Horace_ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.7)
 
-file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" _version)
+set(Horace_ROOT ${CMAKE_CURRENT_LIST_DIR})
+file(READ "${Horace_ROOT}/VERSION" _version)
 string(STRIP "${_version}" _version)
 project("Horace" VERSION "${_version}")
 
 # C++11 is required for GTest
 set(CMAKE_CXX_STANDARD 11)
-set(Horace_ROOT ${CMAKE_CURRENT_LIST_DIR})
 
 # Sort our targets into folders
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 3.7)
 
-file(READ "${CMAKE_SOURCE_DIR}/VERSION" _version)
+file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" _version)
 string(STRIP "${_version}" _version)
 project("Horace" VERSION "${_version}")
 
 # C++11 is required for GTest
 set(CMAKE_CXX_STANDARD 11)
+set(Horace_ROOT ${CMAKE_CURRENT_LIST_DIR})
 
 # Sort our targets into folders
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -17,13 +18,13 @@ if(POLICY CMP0074)
 endif()
 
 # Add cmake directory to CMake's module path
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${Horace_ROOT}/cmake")
 
 # Set some useful global variables
 # This will hold herbert/horace_on.m and worker_v2.m
 set(LOCAL_INIT_DIR "${CMAKE_BINARY_DIR}/local_init")
 # This sets the destination for mex build artifacts (used in PACE_AddMex)
-set(Horace_DLL_DIRECTORY "${CMAKE_SOURCE_DIR}/horace_core/DLL")
+set(Horace_DLL_DIRECTORY "${Horace_ROOT}/horace_core/DLL")
 
 # Set our options
 option(BUILD_TESTS "Build the C++ tests" ON)

--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -61,7 +61,7 @@ foreach(_test_dir ${TEST_DIRECTORIES})
         NAME "${TEST_NAME}"
         CUSTOM_TEST_COMMAND
             "validate_horace ${_test_dir} -talkative -forcemex -exit_on_completion"
-        ADDITIONAL_PATH "${CMAKE_SOURCE_DIR}/admin"
+        ADDITIONAL_PATH "${Horace_ROOT}/admin"
         TIMEOUT ${TEST_TIMEOUT_LENGTH}
     )
     set_tests_properties("${TEST_NAME}"

--- a/admin/CMakeLists.txt
+++ b/admin/CMakeLists.txt
@@ -11,7 +11,7 @@ set(_path_regex "[a-zA-Z0-9/\\\\_\\-\\.: ]+")
 file(READ "horace_on.m.template" _horace_on_template)
 string(REGEX REPLACE
     "default_horace_path ?= ?'${_path_regex}';"
-    "default_horace_path = '${CMAKE_SOURCE_DIR}/horace_core';"
+    "default_horace_path = '${Horace_ROOT}/horace_core';"
     _horace_on_script
     "${_horace_on_template}"
 )
@@ -46,11 +46,11 @@ set(Horace_AUTO_GENERATED_FILE_WARNING
 
 # Copy horace_get_build_version template formatting it with the project version numbers
 configure_file("horace_get_build_version.m.template"
-    "${CMAKE_SOURCE_DIR}/horace_core/admin/horace_get_build_version.m")
+    "${Horace_ROOT}/horace_core/admin/horace_get_build_version.m")
 
 # Copy version.h template formatting it with the project version numbers
 configure_file("version.h.template"
-    "${CMAKE_SOURCE_DIR}/_LowLevelCode/cpp/utility/version.h")
+    "${Horace_ROOT}/_LowLevelCode/cpp/utility/version.h")
 
 # =============================================================================
 # Install commands
@@ -74,7 +74,7 @@ set(TEMPLATE_FILES
     "worker_v2.m.template"
     "worker_4tests.m.template"
     "${Herbert_ON_TEMPLATE}"
- 
+
 )
 foreach(_template_file ${TEMPLATE_FILES})
     install_template_file("${_template_file}")

--- a/cmake/FindHerbert.cmake
+++ b/cmake/FindHerbert.cmake
@@ -24,8 +24,8 @@ endif()
 
 set(DIRS_TO_SEARCH
     ENV{HERBERT_ROOT}
-    ${CMAKE_SOURCE_DIR}/Herbert
-    ${CMAKE_SOURCE_DIR}/../Herbert/
+    ${Horace_ROOT}/Herbert
+    ${Horace_ROOT}/../Herbert/
     /usr/local/mprogs/Herbert
     /usr/local/Herbert
     ENV{ProgramFiles}/Herbert

--- a/cmake/horace_FindHDF5.cmake
+++ b/cmake/horace_FindHDF5.cmake
@@ -12,11 +12,11 @@ module. You'll find the file bundled with your CMake isntallation.
 
 #]=======================================================================]
 if(UNIX)
-    set(HDF5_ROOT "${CMAKE_SOURCE_DIR}/_LowLevelCode/external/HDF5_1.8.12_unix/")
+    set(HDF5_ROOT "${Horace_ROOT}/_LowLevelCode/external/HDF5_1.8.12_unix/")
     # On Linux, link to Matlab's version of HDF5
     set(HDF5_hdf5_LIBRARY_RELEASE "${Matlab_LIBRARY_DIR}/libhdf5.so.8"
         CACHE PATH "" FORCE)
 elseif(WIN32)
-    set(HDF5_ROOT "${CMAKE_SOURCE_DIR}/_LowLevelCode/external/HDF5_1.8.12_win/")
+    set(HDF5_ROOT "${Horace_ROOT}/_LowLevelCode/external/HDF5_1.8.12_win/")
 endif()
 find_package(HDF5)

--- a/documentation/adr/0004-cpp-tests-in-separate-projects.md
+++ b/documentation/adr/0004-cpp-tests-in-separate-projects.md
@@ -44,7 +44,7 @@ The test projects will include the associated function project as an explicit re
 
 ```cmake
 add_executable("functionOne.test" ${TEST_SRC_FILES} ${TEST_HDR_FILES} ${SRC_FILES} ${HDR_FILES})
-target_include_directories("functionOne.test" PRIVATE "${CMAKE_SOURCE_DIR}/_LowLevelCode/cpp")
+target_include_directories("functionOne.test" PRIVATE "${Horace_ROOT}/_LowLevelCode/cpp")
 target_link_libraries("functionOne.test" gtest_main)
 ```
 
@@ -61,6 +61,6 @@ This enables the test artifacts and dependencies to be simply excluded from syst
 * For C++ projects including a mex wrapper, the MATLAB mex libraries must be added explicitly, i.e.
 
   ```cmake
-   target_include_directories("functionOne.test" PRIVATE "${CMAKE_SOURCE_DIR}/_LowLevelCode/cpp" "${Matlab_INCLUDE_DIRS}")
+   target_include_directories("functionOne.test" PRIVATE "${Horace_ROOT}/_LowLevelCode/cpp" "${Matlab_INCLUDE_DIRS}")
    target_link_libraries("functionOne.test" gtest_main "${Matlab_MEX_LIBRARY}" "${Matlab_MX_LIBRARY}" "${Matlab_UT_LIBRARY}")
   ```


### PR DESCRIPTION
These changes in Horace reflect those made to Herbert in https://github.com/pace-neutrons/Herbert/pull/290. It will enable Horace to use the `VS_DEBUGGER_ENVIRONMENT` property on its C++ tests, so you do not need to set environment variables to run tests in Visual Studio.

The changes made to `PACE_AddCppTest.cmake` in https://github.com/pace-neutrons/Herbert/pull/290 are what will fix the Visual Studio issue. This PR defines the `Horace_ROOT` variable that `PACE_AddCppTest.cmake` uses.

Addresses https://github.com/pace-neutrons/Herbert/issues/213