### PR TITLE
Bug in combine

### DIFF
--- a/horace_core/sqw/file_io/@combine_sqw_pix_job/private/read_pix_for_nbins_block_.m
+++ b/horace_core/sqw/file_io/@combine_sqw_pix_job/private/read_pix_for_nbins_block_.m
@@ -36,6 +36,16 @@ pix_tb=cell(nfiles,n_bin2_process);  % buffer for pixel information
 
 %
 bin_filled = false(n_bin2_process,1);
+if ischar(run_label)
+    if strcmpi(run_label,'nochange')
+        run_label = filenum; % will not be used, just to keep common 
+        % interface to split_pix_per_bin_
+    else
+        error('READ_PIXELS:invalid_argument',...
+        'If runlabel is a character string, it can be only "nochange". Got: %s',...
+        run_label);        
+    end
+end
 
 
 % Read pixels from input files


### PR DESCRIPTION
This is simple fix for the bug, being there for ages, and appearing if one have `nochange` mode and number of files is bigger then 8. Do not know how to write a unit test for it as our current tests are checking 6 files, 8 will be more expensive and in a way useless but separate test is difficult to derive.  Performance tests would be caching it. 