### PR TITLE
Make Horace linting ignore Herbert root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@ include(PACE_AddMex)
 include(PACE_FindMatlab)
 include(horace_FindHDF5)
 include(PACE_Version)
+
+# Make analysis ignore Herbert in case of nesting
+set(PACE_MLINT_IGNORE ${PACE_MLINT_IGNORE} "${Herbert_ROOT}/**/*.m")
+
 include(PACE_CodeAnalysis)
 if(${BUILD_TESTS})
     include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ include(horace_FindHDF5)
 include(PACE_Version)
 
 # Make analysis ignore Herbert in case of nesting
+# Needs to have found herbert for Herbert_ROOT
 set(PACE_MLINT_IGNORE ${PACE_MLINT_IGNORE} "${Herbert_ROOT}/**/*.m")
 
 include(PACE_CodeAnalysis)


### PR DESCRIPTION
In conjunction with https://github.com/pace-neutrons/Herbert/pull/300 exclude Herbert