### PR TITLE
Set default values to avoid error

### DIFF
--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -202,21 +202,25 @@ properties([
       trim: true
     ),
     string(
+      defaultValue: ''
       description: 'The version of CMake to run the build with.',
       name: 'CMAKE_VERSION',
       trim: true
     ),
     string(
+      defaultValue: ''
       description: 'The version of GCC to build with.',
       name: 'GCC_VERSION',
       trim: true
     ),
     string(
+      defaultValue: ''
       description: 'The year of the version of Visual Studio to build with.',
       name: 'VS_VERSION',
       trim: true
     ),
     string(
+      defaultValue: ''
       description: 'The version of CppCheck tooling to load to provide the code-style checks.',
       name: 'CPPCHECK_VERSION',
       trim: true

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -185,6 +185,7 @@ properties([
       trim: true
     ),
     string(
+      defaultValue: '',
       description: 'The release number of the Matlab to load e.g. R2019b.',
       name: 'MATLAB_VERSION',
       trim: true
@@ -202,25 +203,25 @@ properties([
       trim: true
     ),
     string(
-      defaultValue: ''
+      defaultValue: '',
       description: 'The version of CMake to run the build with.',
       name: 'CMAKE_VERSION',
       trim: true
     ),
     string(
-      defaultValue: ''
+      defaultValue: '',
       description: 'The version of GCC to build with.',
       name: 'GCC_VERSION',
       trim: true
     ),
     string(
-      defaultValue: ''
+      defaultValue: '',
       description: 'The year of the version of Visual Studio to build with.',
       name: 'VS_VERSION',
       trim: true
     ),
     string(
-      defaultValue: ''
+      defaultValue: '',
       description: 'The version of CppCheck tooling to load to provide the code-style checks.',
       name: 'CPPCHECK_VERSION',
       trim: true


### PR DESCRIPTION
Add default values to the Jenkinsfile to avoid assigning `null` in the environment 