### PR TITLE
Add PixelData.set_data method

### DIFF
--- a/horace_core/admin/modify_pix_ranges.m
+++ b/horace_core/admin/modify_pix_ranges.m
@@ -64,7 +64,7 @@ for i=1:n_inputs
         pix_range = ld.get_img_range();
     else
         data = ld.get_data();
-        data.pix.recalc_pix_range()
+        data.pix.recalc_pix_range();
         pix_range = data.pix.pix_range;
     end
     ld = ld.store_pix_range(pix_range);

--- a/horace_core/sqw/PixelData/@PixelData/PixelData.m
+++ b/horace_core/sqw/PixelData/@PixelData/PixelData.m
@@ -267,9 +267,10 @@ classdef PixelData < handle
         pix_out = get_pix_in_ranges(obj, abs_indices_starts, abs_indices_ends);
         pix_out = get_pixels(obj, abs_pix_indices);
         pix_out = mask(obj, mask_array, npix);
+        [page_num, total_number_of_pages] = move_to_page(obj, page_number, varargin);
         pix_out = noisify(obj, varargin);
-        [page_num,total_number_of_pages] = move_to_page(obj, page_number, varargin);
         obj = recalc_pix_range(obj);
+        set_data(obj, fields, data, abs_pix_indices);
 
         function obj = PixelData(arg, mem_alloc)
             % Construct a PixelData object from the given data. Default

--- a/horace_core/sqw/PixelData/@PixelData/get_data.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_data.m
@@ -89,20 +89,12 @@ function [pix_fields, abs_pix_indices] = parse_args(obj, varargin)
     pix_fields = parser.Results.pix_fields;
     abs_pix_indices = parser.Results.abs_pix_indices;
 
-    pix_fields = validate_pix_fields(obj, pix_fields);
+    pix_fields = cellstr(pix_fields);
+    check_pixel_fields_(obj, pix_fields);
 
     if abs_pix_indices ~= NO_INPUT_INDICES
         if islogical(abs_pix_indices)
-            if numel(abs_pix_indices) > obj.num_pixels
-                if any(abs_pix_indices(obj.num_pixels + 1:end))
-                    error('PIXELDATA:get_data', ...
-                          ['The logical indices contain a true value ' ...
-                           'outside of the array bounds.']);
-                else
-                    abs_pix_indices = abs_pix_indices(1:obj.num_pixels);
-                end
-            end
-            abs_pix_indices = find(abs_pix_indices);
+            abs_pix_indices = logical_to_normal_index_(obj, abs_pix_indices);
         end
 
         max_idx = max(abs_pix_indices);
@@ -117,22 +109,4 @@ end
 
 function is = is_positive_int_vector_or_logical_vector(vec)
     is = isvector(vec) && (islogical(vec) || (all(vec > 0 & all(floor(vec) == vec))));
-end
-
-
-function pix_fields = validate_pix_fields(obj, pix_fields)
-    if ~isa(pix_fields, 'cell')
-        pix_fields = {pix_fields};
-    end
-
-    for i = 1:numel(pix_fields)
-        field = pix_fields{i};
-        if ~obj.FIELD_INDEX_MAP_.isKey({field})
-            valid_fields = obj.FIELD_INDEX_MAP_.keys();
-            error('PIXELDATA:get_data', ...
-                  ['Given field ''%s'' is not a valid pixel field.\n' ...
-                   'Valid fields are: [''%s'']'], ...
-                  strip(evalc('disp(field)')), strjoin(valid_fields, ''', '''));
-        end
-    end
 end

--- a/horace_core/sqw/PixelData/@PixelData/private/check_pixel_fields_.m
+++ b/horace_core/sqw/PixelData/@PixelData/private/check_pixel_fields_.m
@@ -1,0 +1,28 @@
+function check_pixel_fields_(obj, fields)
+%CHECK_PIXEL_FIELDS_ Check the given field names are valid pixel data fields
+% Raises error with ID 'HORACE:PIXELDATA:invalid_field' if any fields not valid.
+%
+%
+% Input:
+% ------
+% fields    A cellstr of field names to validate.
+%
+num_bad_fields = 0;
+bad_fields = cell(1, numel(fields));
+for i = 1:numel(fields)
+    field = fields{i};
+    if ~obj.FIELD_INDEX_MAP_.isKey({field})
+        bad_fields{num_bad_fields + 1} = field;
+        num_bad_fields = num_bad_fields + 1;
+    end
+end
+
+if num_bad_fields > 0
+    valid_fields = obj.FIELD_INDEX_MAP_.keys();
+    error( ...
+        'HORACE:PIXELDATA:invalid_field', ...
+        'Invalid pixel field(s) {''%s''}.\nValid keys are: {''%s''}', ...
+        strjoin(bad_fields(1:num_bad_fields), ''', '''), ...
+        strjoin(valid_fields, ''', ''') ...
+    );
+end

--- a/horace_core/sqw/PixelData/@PixelData/private/logical_to_normal_index_.m
+++ b/horace_core/sqw/PixelData/@PixelData/private/logical_to_normal_index_.m
@@ -1,15 +1,35 @@
-function abs_pix_indices = logical_to_normal_index_(obj, logical_indices)
-%ABS_PIX_INDICES Convert the given logical indices to normal indices
+function normal_indices = logical_to_normal_index_(obj, logical_indices)
+%LOGICAL_TO_NORMAL_INDEX_ Convert the given logical indices to normal indices
+%
+% If there are any 'true' values outside the range of pixels
+% (e.g. logical_indices(obj.num_pixels + 1) == true), an error with ID
+% 'HORACE:PIXELDATA:badsubscript' will be thrown. 'false' values outside the
+% range of pixels are ignored.
+%
+% Input:
+% ------
+% logical_indices   An array of logicals
+%
+% Outputs:
+% --------
+% normal_indices    A vector of "normal" indices i.e. positive integers.
+%
+% Examples:
+% ---------
+%
+%   >> logical_to_normal_index_(pix, [0, 1, 1, 0, 0, 1, 0, 1])
+%        ans =
+%            [2, 3, 6, 8]
 %
 if numel(logical_indices) > obj.num_pixels
     if any(logical_indices(obj.num_pixels + 1:end))
         error( ...
             'HORACE:PIXELDATA:badsubscript', ...
-            ['The logical indices contain a true value ' ...
-                'outside of the array bounds.'] ...
+            ['The logical indices contain a true value outside of the ' ...
+             'array bounds.'] ...
         );
     else
         logical_indices = logical_indices(1:obj.num_pixels);
     end
 end
-abs_pix_indices = find(logical_indices);
+normal_indices = find(logical_indices);

--- a/horace_core/sqw/PixelData/@PixelData/private/logical_to_normal_index_.m
+++ b/horace_core/sqw/PixelData/@PixelData/private/logical_to_normal_index_.m
@@ -1,0 +1,15 @@
+function abs_pix_indices = logical_to_normal_index_(obj, logical_indices)
+%ABS_PIX_INDICES Convert the given logical indices to normal indices
+%
+if numel(logical_indices) > obj.num_pixels
+    if any(logical_indices(obj.num_pixels + 1:end))
+        error( ...
+            'HORACE:PIXELDATA:badsubscript', ...
+            ['The logical indices contain a true value ' ...
+                'outside of the array bounds.'] ...
+        );
+    else
+        logical_indices = logical_indices(1:obj.num_pixels);
+    end
+end
+abs_pix_indices = find(logical_indices);

--- a/horace_core/sqw/PixelData/@PixelData/set_data.m
+++ b/horace_core/sqw/PixelData/@PixelData/set_data.m
@@ -1,0 +1,112 @@
+function set_data(obj, pix_fields, data, varargin)
+%SET_PIXELS Update the data on the given pixel data fields
+%
+% The number of columns in 'data' must be equal to the number of fields in
+% 'pix_fields'. The number of rows in 'data' must be equal to the number of
+% elements in 'abs_pix_indices'.
+%
+% Examples:
+% ---------
+%
+% Set the first 100 pixels' signal and variance to zero
+%   >> set_data({'signal', 'variance'}, zeros(2, 100), 1:100);
+%
+% Input:
+% ------
+% pix_fields       The name of a field, or a cell array of field names.
+% data             The data with which to set the given fields.
+% abs_pix_indices  The indices to set data on. If not specified all indices are
+%                  updated and 'size(data, 2)' must equal to obj.num_pixels.
+%
+NO_INPUT_INDICES = -1;
+
+[pix_fields, abs_pix_indices] = parse_args(obj, pix_fields, data, varargin{:});
+
+field_indices = cell2mat(obj.FIELD_INDEX_MAP_.values(pix_fields));
+
+if obj.is_file_backed_()
+    base_pg_size = obj.base_page_size;
+
+    if abs_pix_indices == NO_INPUT_INDICES
+        first_required_page = 1;
+    else
+        first_required_page = ceil(min(abs_pix_indices)/base_pg_size);
+    end
+    obj.move_to_page(first_required_page);
+
+    set_page_data(obj, field_indices, data, abs_pix_indices);
+    while obj.has_more()
+        obj.advance();
+        set_page_data(obj, field_indices, data, abs_pix_indices);
+    end
+else
+    if abs_pix_indices == NO_INPUT_INDICES
+        obj.data_(field_indices, 1:end) = data;
+    else
+        obj.data_(field_indices, abs_pix_indices) = data;
+    end
+end
+
+end  % function
+
+
+% -----------------------------------------------------------------------------
+function [pix_fields, abs_pix_indices] = parse_args(obj, pix_fields, data, varargin)
+    NO_INPUT_INDICES = -1;
+
+    validateattributes(pix_fields, {'cell', 'char', 'string'}, {'nonempty'});
+    validateattributes(data, {'numeric'}, {});
+
+    parser = inputParser();
+    parser.addOptional( ...
+        'abs_pix_indices', ...
+        NO_INPUT_INDICES, ...
+        @(x) validateattributes(x, {'numeric', 'logical'}, {'integer', 'nonnegative'}) ...
+    );
+    parser.parse(varargin{:});
+    abs_pix_indices = parser.Results.abs_pix_indices;
+
+    pix_fields = cellstr(pix_fields);
+    check_pixel_fields_(obj, pix_fields);
+
+    if islogical(abs_pix_indices)
+        abs_pix_indices = logical_to_normal_index_(obj, abs_pix_indices);
+    end
+
+    if size(data, 1) ~= numel(pix_fields)
+        error( ...
+            'HORACE:PIXELDATA:incorrect_num_rows', ...
+            ['Number of fields in ''pix_fields'' must be equal to number ' ...
+             'of columns in ''data''.\nFound %i and %i.'], ...
+            numel(pix_fields), size(data, 1) ...
+        );
+    end
+    if ~isequal(abs_pix_indices, NO_INPUT_INDICES) && size(data, 2) ~= numel(abs_pix_indices)
+        error( ...
+            'HORACE:PIXELDATA:incorrect_num_cols', ...
+            ['Number of indices in ''abs_pix_indices'' must be equal to ' ...
+            'number of rows in ''data''.\nFound %i and %i.'], ...
+            numel(abs_pix_indices), size(data, 2) ...
+        );
+    end
+end
+
+
+function set_page_data(obj, field_indices, data, abs_indices)
+    % Set the values on the given fields on the current page of data.
+    NO_INPUT_INDICES = -1;
+    base_pg_size = obj.base_page_size;
+
+    if abs_indices == NO_INPUT_INDICES
+        start_idx = (obj.page_number_ - 1)*base_pg_size + 1;
+        end_idx = min(obj.page_number_*base_pg_size, obj.num_pixels);
+        obj.data(field_indices, :) = data(:, start_idx:end_idx);
+    else
+        [pg_idxs, data_idxs] = get_pg_idx_from_absolute_( ...
+            obj, abs_indices, obj.page_number_ ...
+        );
+        if ~isempty(pg_idxs)
+            obj.data(field_indices, pg_idxs) = data(:, data_idxs);
+        end
+    end
+end


### PR DESCRIPTION
As part of my work on #550 I need a `set_` method on pixels that can set field data across page boundaries. This method is the inverse of `PixelData.get_data` so they share a fair amount of logic.

refs #550 