### PR TITLE
Add ADR 23

### DIFF
--- a/documentation/adr/0020-use-c-mex-api.md
+++ b/documentation/adr/0020-use-c-mex-api.md
@@ -1,5 +1,5 @@
 [<-previous](./0019-update-release-notes-every-pr.md) |
-[next->](0021-use-keyword-args.md)
+[next->](./0021-errors-and-warnings.md)
 
 # 20 - Use C Mex API (rather than C++)
 

--- a/documentation/adr/0021-errors-and-warnings.md
+++ b/documentation/adr/0021-errors-and-warnings.md
@@ -1,12 +1,20 @@
 [<-previous](./0020-use-c-mex-api.md) |
-next->
+[next->](./0022-use-keyword-args.md)
 
-# Handling Errors and Warnings
+# 21 - Handling Errors and Warnings
+
+Date: 2021-Feb-24
+
+## Status
+
+Accepted
+
+## Overview
 
 This document seeks to address the inconsistent error handling scheme in pace and lay down rules for how
 error handling should be addressed in future development and retroactively in older code.
 
-## Current state
+## Context
 Presently in PACE, there are several different mechanisms being used which obscure traceback on errors and warnings. The key ones are:
 
 - Passing error states and messages back through arguments and optionally throwing

--- a/documentation/adr/0022-use-keyword-args.md
+++ b/documentation/adr/0022-use-keyword-args.md
@@ -1,5 +1,5 @@
 [<-previous](./0021-errors-and-warnings.md) |
-next->
+[next->](./0023-error-format.md)
 
 # 22 - Use keyword args in Python and MATLAB
 
@@ -12,11 +12,11 @@ Accepted
 ## Context
 
 As we will increasingly be calling Horace functions from both MATLAB and Python,
-introducing consistency in how arguments are passed will simplify user interaction with the toolkit in both environments. 
+introducing consistency in how arguments are passed will simplify user interaction with the toolkit in both environments.
 
 MATLAB and Python have different argument passing conventions,
 e.g. Python does not support flags such as `-flag`,
-and MATLAB and Python deal with keyword arguments in similar, but different ways. 
+and MATLAB and Python deal with keyword arguments in similar, but different ways.
 
 This document reviews this in detail, and recommends a convention for function arguments.
 
@@ -27,7 +27,7 @@ Currently, we don’t have an established syntax for Python. Because we have a c
 
 ```python
 def function_name(a, b, *args, **kwargs):
-	# body
+    # body
 
 function_name(a, b, c, d, keyword_1=val_1, keyword_2=val_2, …)
 ```
@@ -66,10 +66,10 @@ The MATLAB APIs must support positional, optional flag and keyword arguments:
 - if the same parameter is passed as both a flag and keyword argument with inconsistent values an error will be raised, otherwise the parameter is set to the passed value
 
 - support for negated flags, prefixed with `no`, will be removed.
-Flag names may include the `no` prefix to make their meaning clear, 
+Flag names may include the `no` prefix to make their meaning clear,
 e.g. passing `-nopix` will suppress pixel handling in that function
 
-- flag arguments may be truncated to the minimum unambiguous string for all flags defined on that function e.g. `-flagname`, `-flag`, `-f` are all valid. 
+- flag arguments may be truncated to the minimum unambiguous string for all flags defined on that function e.g. `-flagname`, `-flag`, `-f` are all valid.
 No other abbreviations will be supported
 - keyword arguments may not be abbreviated.
 
@@ -98,10 +98,10 @@ function_name(a, b, 'flagname', true);
 - MATLAB argument parsing will be solely responsible for the processing of arguments
 - MATLAB argument parsing will need to manage flags passed in both 'flag' and 'keyword' form
 
-- All MATLAB functions which currently support optional arguments out of order must be updated, 
-either creating a new function name with the alternate signature (e.g. `cut` with no projection) 
+- All MATLAB functions which currently support optional arguments out of order must be updated,
+either creating a new function name with the alternate signature (e.g. `cut` with no projection)
 or additional keyword arguments (e.g. `lattice` in `dispersion_plot`)
-- The inclusion of optional arguments alongside flags/keyword arguments allows the possibility of ambiguity in argument parsing e.g. 
+- The inclusion of optional arguments alongside flags/keyword arguments allows the possibility of ambiguity in argument parsing e.g.
 
 ```matlab
 function_name(req, opt1, opt2, varargin)

--- a/documentation/adr/0023-error-format.md
+++ b/documentation/adr/0023-error-format.md
@@ -1,0 +1,74 @@
+[<-previous](./0022-use-keyword-args.md) |
+next->
+
+# 23 - Error Format
+
+Date: 2021-Mar-24
+
+## Status
+
+Accepted
+
+## Context
+
+Currently throughout PACE, different error identifiers are used to reference the same error.
+This makes it difficult in cases of specific try-catch (as described in [ADR 21](./0021-errors-and-warnings.md)) to know what to compare against.
+
+Examples include:
+```
+herbert_core/applications/multifit/@mfclass/fit.m                                             : Herbert:mfclass:invalid_argument
+herbert_core/classes/data_loaders/@rundata/private/gen_runfiles_.m                            : GEN_GRUNFILES:invalid_arguments
+herbert_core/utilities/general/catstruct.m                                                    : catstruct:InvalidArgument
+herbert_core/classes/data_loaders/parse_arg.m                                                 : PARSE_ARG:wrong_arguments
+
+herbert_core/classes/data_loaders/@rundata/get_par.m                                          : RUNDATA:invalid_argument
+herbert_core/classes/data_loaders/@rundata/get_rundata.m                                      : RUNDATA:invalid_arguments
+
+herbert_core/utilities/maths/noisify.m                                                        : HERBERT:noisify
+herbert_core/utilities/misc/objdiff.m                                                         : YMA:OBJDIFF:NotEnoughInputs
+herbert_core/utilities/xml_io_tools/xmlwrite_xerces.m                                         : xml:FileNotFound
+herbert_core/admin/matlab_nbits.m                                                             : MATLAB:NBITS
+
+_test/shared/matlab_xunit_ISISextras/@TestCaseWithSave/private/get_ref_dataset_.m             : TestCaseWithSave:invalid_argument
+_test/shared/matlab_xunit_ISISextras/@TestCaseWithSave/private/instantiate_methods_to_save_.m : TEST_CASE_WITH_SAVE:invalid_argument
+
+erbert_core/classes/MPIFramework/@iMessagesFramework/iMessagesFramework.m                     : iMESSAGES_FRAMEWORK:invalid_argument
+herbert_core/classes/MPIFramework/@iMessagesFramework/iMessagesFramework.m                    : MESSAGES_FRAMEWORK:invalid_argument
+herbert_core/classes/MPIFramework/@iMessagesFramework/private/mix_messages_.m                 : iMESSAGES_FRAMEWOR:invalid_argument
+```
+From which it should be obvious is not a consistent scheme for error identification, even within the same set of routines.
+
+## Decision
+
+As MATLAB standards do not enforce a particular style of error statement,
+this document seeks to outline the format an error identifier should take as well as establish a list of standard common error identifiers.
+
+Following discussions it was decided that it would be useful to have a standard format with 3 components, in the following format
+expanding upon that intially outlined in [ADR 21](./0021-errors-and-warnings.md).
+
+
+```matlab
+error('(HORACE|HERBERT):(function_name|ClassName):error_identifier')
+```
+
+This scheme is based on the current (2020b) MATLAB error identifiers common to many functions.
+
+- `HORACE` or `HERBERT` should be in all caps.
+- The `function_name` and `ClassName` should exactly match that of the parent function/class, including casing.
+- The `error_identifier` should be in `lower_snake` case and should succinctly identify the error message, using one of
+     the following names if the error falls within their remit.
+
+| Identifier         | Issue                                                                                         |
+| :----------------: | :-------------------------------------------------------------------------------------------: |
+| `invalid_argument` | Argument fails validation, there are insufficient arguments or argument is an unexpected flag |
+| `invalid_output`   | Insufficient outputs                                                                          |
+| `not_implemented`  | Called function is virtual/abstract                                                           |
+| `array_mismatch`   | Array dimensions are incompatible (will usually be identified by MATLAB's error)              |
+| `file_not_found`   | File not found on system                                                                      |
+| `io_error`         | Issues with opening, reading or writing files                                                 |
+| `system_error`     | Issues when calling system (shell) functions from MATLAB                                      |
+
+## Consequences
+
+In future error identifiers should be written to follow these guidelines and in cases where surrounding code is being updated an effort should be made to
+correct error identifiers which do not fall under these rules.

--- a/documentation/adr/0023-error-format.md
+++ b/documentation/adr/0023-error-format.md
@@ -36,7 +36,7 @@ erbert_core/classes/MPIFramework/@iMessagesFramework/iMessagesFramework.m       
 herbert_core/classes/MPIFramework/@iMessagesFramework/iMessagesFramework.m                    : MESSAGES_FRAMEWORK:invalid_argument
 herbert_core/classes/MPIFramework/@iMessagesFramework/private/mix_messages_.m                 : iMESSAGES_FRAMEWOR:invalid_argument
 ```
-From which it should be obvious is not a consistent scheme for error identification, even within the same set of routines.
+From which it should be obvious that this is not a consistent scheme for error identification, even within the same set of routines.
 
 As MATLAB standards do not enforce a particular style of error statement 
 (though it does encourage certain forms [see here](https://uk.mathworks.com/help/matlab/ref/mexception.html#mw_e5712c7f-3862-42fa-9a8f-8de992cdc6d4)),
@@ -47,7 +47,7 @@ Also due to the fact that MATLAB has changed its method of error identification 
 ## Decision
 
 Following discussions it was decided that it would be useful to have a standard format with 3 components, in the following format
-expanding upon that intially outlined in [ADR 21](./0021-errors-and-warnings.md).
+(expanding upon that intially outlined in [ADR 21](./0021-errors-and-warnings.md)).
 
 
 ```matlab

--- a/documentation/adr/0023-error-format.md
+++ b/documentation/adr/0023-error-format.md
@@ -1,7 +1,7 @@
 [<-previous](./0022-use-keyword-args.md) |
 next->
 
-# 23 - Error Format
+# 23 - Error Identifier Format
 
 Date: 2021-Mar-24
 
@@ -59,7 +59,7 @@ This scheme is based on the current (2020b) MATLAB error identifiers common to m
      the following names if the error falls within their remit.
 
 | Identifier         | Issue                                                                                         |
-| :----------------: | :-------------------------------------------------------------------------------------------: |
+| :----------------- | :-------------------------------------------------------------------------------------------- |
 | `invalid_argument` | Argument fails validation, there are insufficient arguments or argument is an unexpected flag |
 | `invalid_output`   | Insufficient outputs                                                                          |
 | `not_implemented`  | Called function is virtual/abstract                                                           |

--- a/documentation/adr/0023-error-format.md
+++ b/documentation/adr/0023-error-format.md
@@ -38,10 +38,13 @@ herbert_core/classes/MPIFramework/@iMessagesFramework/private/mix_messages_.m   
 ```
 From which it should be obvious is not a consistent scheme for error identification, even within the same set of routines.
 
-## Decision
-
-As MATLAB standards do not enforce a particular style of error statement,
+As MATLAB standards do not enforce a particular style of error statement 
+(though it does encourage certain forms [see here](https://uk.mathworks.com/help/matlab/ref/mexception.html#mw_e5712c7f-3862-42fa-9a8f-8de992cdc6d4)),
 this document seeks to outline the format an error identifier should take as well as establish a list of standard common error identifiers.
+
+Also due to the fact that MATLAB has changed its method of error identification between versions in the past, this document establishes its scheme based on the most recent currently used version (2020b).
+
+## Decision
 
 Following discussions it was decided that it would be useful to have a standard format with 3 components, in the following format
 expanding upon that intially outlined in [ADR 21](./0021-errors-and-warnings.md).
@@ -57,6 +60,8 @@ This scheme is based on the current (2020b) MATLAB error identifiers common to m
 - The `function_name` and `ClassName` should exactly match that of the parent function/class, including casing.
 - The `error_identifier` should be in `lower_snake` case and should succinctly identify the error message, using one of
      the following names if the error falls within their remit.
+     **NB.** This is in contrast to the usual MATLAB format which uses `lowerCamelCase`, but is in keeping with the majority
+     of identifiers currently used in PACE.
 
 | Identifier         | Issue                                                                                         |
 | :----------------- | :-------------------------------------------------------------------------------------------- |
@@ -72,3 +77,12 @@ This scheme is based on the current (2020b) MATLAB error identifiers common to m
 
 In future error identifiers should be written to follow these guidelines and in cases where surrounding code is being updated an effort should be made to
 correct error identifiers which do not fall under these rules.
+
+Having a defined set of guidelines will make:
+- Aid developers with quickly identifying error source
+- Make catching errors by identifier easier
+- Aid new developers in how to contribute to PACE
+- Make conversion to any new error format standard easier
+
+It will also:
+- Require updating of legacy code


### PR DESCRIPTION
Create ADR 23 outlining decisions made around error identifiers in PACE.

Also update surrounding ADRs to match format and link correctly.