### PR TITLE
disp2sqw eval bug

### DIFF
--- a/horace_core/sqw/@sqw/disp2sqw_eval.m
+++ b/horace_core/sqw/@sqw/disp2sqw_eval.m
@@ -1,7 +1,7 @@
-function wout=disp2sqw_eval(win,dispreln,pars,fwhh,opt)
+function wout=disp2sqw_eval(win,dispreln,pars,fwhh,varargin)
 % Calculate sqw for a model scattering function
 %
-%   >> wout = disp2sqw_eval(win,dispreln,pars,fwhh,opt)
+%   >> wout = disp2sqw_eval(win,dispreln,pars,fwhh,varargin)
 %
 % Input:
 % ------
@@ -56,14 +56,16 @@ function wout=disp2sqw_eval(win,dispreln,pars,fwhh,opt)
 %                           The output I has the same dimensions as the
 %                           input Emat.
 %
-%   '-all'       [option] Requests that the calculated sqw be returned over
-%              the whole of the domain of the input dataset. If not given, then
-%              the function will be returned only at those points of the dataset
-%              that contain data.
-%               Applies only to input with no pixel information - it is ignored if
-%              full sqw object.
+% Optional arguments: (varargin)
 %
-%   '-ave'       [option] Requests that the calculated sqw be computed for the
+%   '-al[l]'  Requests that the calculated sqw be returned over
+%             the whole of the domain of the input dataset. If not given, then
+%             the function will be returned only at those points of the dataset
+%             that contain data.
+%             Applies only to input with no pixel information - it is ignored if
+%             full sqw object.
+%
+%   '-av[erage]' Requests that the calculated sqw be computed for the
 %              average values of h,k,l of the pixels in a bin, not for each
 %              pixel individually. Reduces cost of expensive calculations.
 %               Applies only to the case of sqw object with pixel information - it is
@@ -75,11 +77,11 @@ function wout=disp2sqw_eval(win,dispreln,pars,fwhh,opt)
 
 
 % Check optional argument
-[ok, mess, all_bins, ave_pix] = parse_char_options({opt}, {'-all', '-average'});
+[ok, mess, all_bins, ave_pix] = parse_char_options(varargin, {'-all', '-average'});
 if ~ok
     error( ...
-        'HORACE:SQW:invalid_arguments', ...
-        '%s.\nValid values for ''opt'' are ''-all'' or ''-ave''.', ...
+        'HORACE:sqw:invalid_arguments', ...
+        '%s.\nValid values for optional arguments are ''-al[l]'' or ''-av[erage]''.', ...
         mess ...
     );
 end

--- a/horace_core/sqw/file_io/@sqw_binfile_common/sqw_binfile_common.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/sqw_binfile_common.m
@@ -33,8 +33,8 @@ classdef sqw_binfile_common < sqw_file_interface
     %
     % upgrade_file_format - upgrade current sqw file to recent file format.
     %                       May change the sqw file and always opens it in
-    %                       write or upgrade mode.    
-    %    
+    %                       write or upgrade mode.
+    %
     properties(Access=protected,Hidden=true)
         % position (in bytes from start of the file of the appropriate part
         % of Horace data information and the size of this part.

--- a/horace_core/utilities/@sqw/symmetrise_sqw.m
+++ b/horace_core/utilities/@sqw/symmetrise_sqw.m
@@ -94,7 +94,7 @@ end
 uconv=header.u_to_rlu(1:3,1:3);
 
 % TODO: Discuss with Russell the meaning of the commented code.
-% 
+%
 %convert the vectors specifying the reflection plane from rlu to the
 %orthonormal frame of the pix array:
 % do not rely on the shift of the image to define symmetry plane.
@@ -155,12 +155,12 @@ clear 'side_dot'; % MP: not needed any more
 
 coords_new=bsxfun(@plus, coords_new, vec3); % MP
 %
-% Clear existing pages range not to extend new range with existing. 
+% Clear existing pages range not to extend new range with existing.
 % Take care if this method is extended to file-based data -- needs careful
 % thinking
 wout.data.pix.set_range(PixelData.EMPTY_RANGE_);
 wout.data.pix.q_coordinates=coords_new;
-% real pix range, calculated at the assignment of new coordinates to the 
+% real pix range, calculated at the assignment of new coordinates to the
 % pixels coordinates
 clear 'coords_new';
 
@@ -172,7 +172,7 @@ clear 'coords_new';
 existing_range = wout.data.img_db_range;
 proj = win.data.get_projection();
 
-exp_range= expand_box(existing_range(1,1:3),existing_range(2,1:3));    
+exp_range= expand_box(existing_range(1,1:3),existing_range(2,1:3));
 cc_ranges = proj.transform_img_to_pix(exp_range);
 %
 %
@@ -208,7 +208,7 @@ for i=1:4
         if np>1
             step = dist/(np-1);
         else
-            step = dist;            
+            step = dist;
         end
         new_range_arg{i} = [range(1),step,range(2)];
     end
@@ -221,7 +221,7 @@ set(hor_config,'log_level',-1);
 
 % completely break relationship between bins and pixels in memory and make
 % all pixels contribute into single large bin
-wout.data.img_db_range = all_sym_range ;   
+wout.data.img_db_range = all_sym_range ;
 
 wout.data.pax = 1:4;
 wout.data.dax = 1:4;
@@ -229,6 +229,4 @@ wout.data.p  = arrayfun(@(i)(all_sym_range(:,i)),1:4,'UniformOutput',false);
 wout.data.npix = sum(reshape(wout.data.npix,1,numel(wout.data.npix)));
 %
 wout=cut(wout,proj,new_range_arg{:});
-
-
 


### PR DESCRIPTION
Simple solution for simple bug. `varargin` is empty if no optional arguments are available, so simple fix to the issue