### PR TITLE
pix read bug

### DIFF
--- a/_test/test_sqw_file/test_file_input.m
+++ b/_test/test_sqw_file/test_file_input.m
@@ -178,9 +178,12 @@ classdef  test_file_input < TestCase
             proj2.v=[1,1,0];
             
             s1_s=cut(obj.sqw2d_arr(2),proj2,[0.5,0.02,1],[0.9,1.1],[-0.1,0.1],[170,180]);
+            s1_f_h=cut(obj.sqw2d_name{2},proj2,[0.5,0.02,1],[0.9,1.1],[-0.1,0.1],[170,180]);
+            [ok,mess] = equal_to_tol(s1_s,s1_f_h,'ignore_str',1);
+            assertTrue(ok,['Memopry based and file based cuts are different: ',mess])
+            
             s1_s_h=cut(obj.sqw2d_arr(2),proj2,[0.5,0.02,1],[0.9,1.1],[-0.1,0.1],[170,180]);
             s1_s_s=cut_sqw(obj.sqw2d_arr(2),proj2,[0.5,0.02,1],[0.9,1.1],[-0.1,0.1],[170,180]);
-            s1_f_h=cut(obj.sqw2d_name{2},proj2,[0.5,0.02,1],[0.9,1.1],[-0.1,0.1],[170,180]);
             s1_f_s=cut_sqw(obj.sqw2d_name{2},proj2,[0.5,0.02,1],[0.9,1.1],[-0.1,0.1],[170,180]);
             try
                 s1_s_d=cut_dnd(obj.sqw2d_arr(2),proj2,[0.5,0.02,1],[0.9,1.1],[-0.1,0.1],[170,180]);
@@ -188,7 +191,7 @@ classdef  test_file_input < TestCase
             catch
                 failed=true;
             end
-            if ~failed, assertTrue(false,'Should have failed!'), end
+            assertTrue(failed,'Should have failed!');
             
             try
                 s1_f_d=cut_dnd(obj.sqw2d_name{2},proj2,[0.5,0.02,1],[0.9,1.1],[-0.1,0.1],[170,180]);
@@ -196,12 +199,16 @@ classdef  test_file_input < TestCase
             catch
                 failed=true;
             end
-            if ~failed, assertTrue(false,'Should have failed!'), end
+            assertTrue(failed,'Should have failed!');
             
-            if ~equal_to_tol(s1_s,s1_s_h), assertTrue(false,'Error in functionality'), end
-            if ~equal_to_tol(s1_s,s1_s_s), assertTrue(false,'Error in functionality'), end
-            if ~equal_to_tol(s1_s,s1_f_h,'ignore_str',1), assertTrue(false,'Error in functionality'), end
-            if ~equal_to_tol(s1_s,s1_f_s,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(s1_s,s1_s_h);
+            assertTrue(ok,['Error in functionality: ',mess])
+            
+            [ok,mess] = equal_to_tol(s1_s,s1_s_s);
+            assertTrue(ok,['Error in functionality: ',mess])
+            
+            [ok,mess] = equal_to_tol(s1_s,s1_f_s,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
             
             
             
@@ -221,34 +228,46 @@ classdef  test_file_input < TestCase
             assertExceptionThrown(@() call_cut_sqw(obj.d2d_arr(2)), 'HORACE:cut_sqw');
             assertExceptionThrown(@() call_cut_sqw(obj.d2d_name{2}), 'HORACE:cut_sqw');
             
-            if ~equal_to_tol(d1_d,d1_d_h), assertTrue(false,'Error in functionality'), end
-            if ~equal_to_tol(d1_d,d1_d_d), assertTrue(false,'Error in functionality'), end
-            if ~equal_to_tol(d1_d,d1_f_h,'ignore_str',1), assertTrue(false,'Error in functionality'), end
-            if ~equal_to_tol(d1_d,d1_f_d,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(d1_d,d1_d_h);
+            assertTrue(ok,['Error in functionality: ',mess])
             
+            [ok,mess] = equal_to_tol(d1_d,d1_d_d);
+            assertTrue(ok,['Error in functionality: ',mess])
             
+            [ok,mess] = equal_to_tol(d1_d,d1_f_h,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
+            
+            [ok,mess] = equal_to_tol(d1_d,d1_f_d,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
             
             % =================================================================================================
             % Reading data
             % =================================================================================================
             
             tmp=read(sqw,obj.sqw2d_name{2});
-            if ~equal_to_tol(obj.sqw2d_arr(2),tmp,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(obj.sqw2d_arr(2),tmp,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
             
             tmp=read_sqw(obj.sqw2d_name{2});
-            if ~equal_to_tol(obj.sqw2d_arr(2),tmp,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(obj.sqw2d_arr(2),tmp,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
+            
             
             tmp=read_horace(obj.sqw2d_name{2});
-            if ~equal_to_tol(obj.sqw2d_arr(2),tmp,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(obj.sqw2d_arr(2),tmp,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
             
             tmp=read(d2d,obj.sqw2d_name{2});
-            if ~equal_to_tol(obj.d2d_arr(2),tmp,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(obj.d2d_arr(2),tmp,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
             
             tmp=read_dnd(obj.sqw2d_name{2});
-            if ~equal_to_tol(obj.d2d_arr(2),tmp,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(obj.d2d_arr(2),tmp,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
             
             tmp=read(d2d,obj.d2d_name{2});
-            if ~equal_to_tol(obj.d2d_arr(2),tmp,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(obj.d2d_arr(2),tmp,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
             
             try
                 tmp=read_sqw(obj.d2d_name{2});
@@ -256,20 +275,24 @@ classdef  test_file_input < TestCase
             catch
                 failed=true;
             end
-            if ~failed, assertTrue(false,'Should have failed!'), end
+            assertTrue(failed,'Should have failed!');
             
             tmp=read_horace(obj.d2d_name{2});
-            if ~equal_to_tol(obj.d2d_arr(2),tmp,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(obj.d2d_arr(2),tmp,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
             
             % Read array of files
             tmp=read_horace(obj.sqw2d_name);
-            if ~equal_to_tol(obj.sqw2d_arr,tmp,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(obj.sqw2d_arr,tmp,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
             
             tmp=read_dnd(obj.sqw2d_name);
-            if ~equal_to_tol(obj.d2d_arr,tmp,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(obj.d2d_arr,tmp,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
             
             tmp=read_sqw(obj.sqw2d_name);
-            if ~equal_to_tol(obj.sqw2d_arr,tmp,'ignore_str',1), assertTrue(false,'Error in functionality'), end
+            [ok,mess] = equal_to_tol(obj.sqw2d_arr,tmp,'ignore_str',1);
+            assertTrue(ok,['Error in functionality: ',mess])
         end
     end
     %banner_to_screen([mfilename,': Test(s) passed'],'bot')

--- a/_test/test_utilities/test_split_vector_max_sum_p2.m
+++ b/_test/test_utilities/test_split_vector_max_sum_p2.m
@@ -20,15 +20,34 @@ classdef test_split_vector_max_sum_p2 < TestCase
             f = @() split_data_blocks(pos,vector,100);
             assertExceptionThrown(f, 'HORACE:utilities:invalid_argument');
         end
+        function test_split_2big_blocks(~)
+            vector     = [5,34,6,10,30];
+            start_pos  = [100,200,300,400,500];
+            max_sum = 10;
+            chunks = split_data_blocks(start_pos,vector, max_sum);
+            assertEqual(numel(chunks),9);
+            ref_pos = {[100,200],206,217,[227,300],[302,400],[406,500],506,517,527};
+            ref_sizes = {[5,5],10,10,[9,1],[5,5],[5,5],10,10,5};
+            assertEqual(sum([ref_sizes{:}]),sum(vector));            
+            for i=1:9
+                ch = chunks{i};
+                pos = ch{1};
+                size = ch{2};
+                assertEqual(pos,ref_pos{i});
+                assertEqual(size,ref_sizes{i});
+            end
+        end
+        
         function test_split_big_block_in_the_middle(~)
-            vector     = [5,34,6];
+            vector     = [5,44,6];
             start_pos  = [100,200,300];
             max_sum = 10;
             chunks = split_data_blocks(start_pos,vector, max_sum);
-            assertEqual(numel(chunks),5);
-            ref_pos = {[100;200],206,216,[226;300],302};
-            ref_sizes = {[5;5];10;10;10;5};
-            for i=1:5
+            assertEqual(numel(chunks),6);
+            ref_pos = {[100,200],206,217,227,[237,300],302};
+            ref_sizes = {[5,5],10,10,10,[9,1],5};
+            assertEqual(sum([ref_sizes{:}]),sum(vector));
+            for i=1:6
                 ch = chunks{i};
                 pos = ch{1};
                 size = ch{2};
@@ -58,39 +77,21 @@ classdef test_split_vector_max_sum_p2 < TestCase
         function test_split_2p_block_pages_split(~)
             vector     = [3, 3, 4, 3, 3, 3, 5];
             %             !--------!--------!----;3 Pages
-            start_pos  = [10,20,30,40,50,60,70];
+            start_pos  = [100,200,300,400,500,600,700];
             max_sum = 10;
             chunks = split_data_blocks(start_pos,vector, max_sum);
             assertEqual(numel(chunks),3);
-            ch = chunks{1};
-            pos = ch{1};
-            size = ch{2};
-            assertEqual(sum(size),max_sum)
-            assertEqual(pos(1),start_pos(1));
-            assertEqual(pos(2),start_pos(2));
-            assertEqual(pos(3),start_pos(3));
-            assertEqual(size(1) ,vector(1));
-            assertEqual(size(2),vector(2));
-            assertEqual(size(3),vector(3));
+            ref_pos = {[100,200,300],[400,500,600,700],702};
+            ref_sizes = {[3,3,4],[3,3,3,1],4};
             
-            ch = chunks{2};
-            pos = ch{1};
-            size = ch{2};
-            assertEqual(sum(size),max_sum)
-            assertEqual(pos(1) ,start_pos(4));
-            assertEqual(pos(2) ,start_pos(5));
-            assertEqual(pos(3) ,start_pos(6));
-            assertEqual(pos(4) ,start_pos(7));
-            assertEqual(size(1),vector(4));
-            assertEqual(size(2),vector(5));
-            assertEqual(size(3),vector(6));
-            assertEqual(size(4),1);
-            
-            ch = chunks{3};
-            pos = ch{1};
-            size = ch{2};
-            assertEqual(pos(1),start_pos(7)+2);
-            assertEqual(size(1) ,vector(7)-1);
+            assertEqual(sum([ref_sizes{:}]),sum(vector));
+            for i=1:3
+                ch = chunks{i};
+                pos = ch{1};
+                size = ch{2};
+                assertEqual(pos,ref_pos{i});
+                assertEqual(size,ref_sizes{i});
+            end
             
         end
         

--- a/_test/test_utilities/test_split_vector_max_sum_p2.m
+++ b/_test/test_utilities/test_split_vector_max_sum_p2.m
@@ -1,0 +1,178 @@
+classdef test_split_vector_max_sum_p2 < TestCase
+    
+    methods
+        function obj = test_split_vector_max_sum_p2(~)
+            obj@TestCase('test_split_vector_max_sum_p-1');
+        end
+        
+        function test_outputs_are_empty_if_inputs_are_empty(~)
+            [chunks, csum] = split_data_blocks([], []);
+            assertTrue(isa(chunks, 'cell'))
+            assertTrue(isempty(chunks));
+            assertTrue(isa(csum, 'double'))
+            assertTrue(isempty(csum));
+        end
+        
+        
+        function test_error_if_different_sizes(~)
+            vector = ones(1, 10);
+            pos = ones(1,8);
+            f = @() split_data_blocks(pos,vector,100);
+            assertExceptionThrown(f, 'HORACE:utilities:invalid_argument');
+        end
+        function test_split_big_block_in_the_middle(~)
+            vector     = [5,34,6];
+            start_pos  = [100,200,300];
+            max_sum = 10;
+            chunks = split_data_blocks(start_pos,vector, max_sum);
+            assertEqual(numel(chunks),5);
+            ref_pos = {[100;200],206,216,[226;300],302};
+            ref_sizes = {[5;5];10;10;10;5};
+            for i=1:5
+                ch = chunks{i};
+                pos = ch{1};
+                size = ch{2};
+                assertEqual(pos,ref_pos{i});
+                assertEqual(size,ref_sizes{i});
+            end
+        end
+        
+        
+        function test_split_big_block(~)
+            vector     = 34;
+            start_pos  = 100;
+            max_sum = 10;
+            chunks = split_data_blocks(start_pos,vector, max_sum);
+            assertEqual(numel(chunks),4);
+            ref_pos = {100,111,121,131};
+            ref_sizes = {10,10,10,4};
+            for i=1:4
+                ch = chunks{i};
+                pos = ch{1};
+                size = ch{2};
+                assertEqual(pos,ref_pos{i});
+                assertEqual(size,ref_sizes{i});
+            end
+        end
+        
+        function test_split_2p_block_pages_split(~)
+            vector     = [3, 3, 4, 3, 3, 3, 5];
+            %             !--------!--------!----;3 Pages
+            start_pos  = [10,20,30,40,50,60,70];
+            max_sum = 10;
+            chunks = split_data_blocks(start_pos,vector, max_sum);
+            assertEqual(numel(chunks),3);
+            ch = chunks{1};
+            pos = ch{1};
+            size = ch{2};
+            assertEqual(sum(size),max_sum)
+            assertEqual(pos(1),start_pos(1));
+            assertEqual(pos(2),start_pos(2));
+            assertEqual(pos(3),start_pos(3));
+            assertEqual(size(1) ,vector(1));
+            assertEqual(size(2),vector(2));
+            assertEqual(size(3),vector(3));
+            
+            ch = chunks{2};
+            pos = ch{1};
+            size = ch{2};
+            assertEqual(sum(size),max_sum)
+            assertEqual(pos(1) ,start_pos(4));
+            assertEqual(pos(2) ,start_pos(5));
+            assertEqual(pos(3) ,start_pos(6));
+            assertEqual(pos(4) ,start_pos(7));
+            assertEqual(size(1),vector(4));
+            assertEqual(size(2),vector(5));
+            assertEqual(size(3),vector(6));
+            assertEqual(size(4),1);
+            
+            ch = chunks{3};
+            pos = ch{1};
+            size = ch{2};
+            assertEqual(pos(1),start_pos(7)+2);
+            assertEqual(size(1) ,vector(7)-1);
+            
+        end
+        
+        function test_split_2p_block_last_pages_hungs(~)
+            vector     = [5,5,5,3];
+            start_pos  = [10,25,400,700];
+            max_sum = 10;
+            chunks = split_data_blocks(start_pos,vector, max_sum);
+            assertEqual(numel(chunks),2);
+            for i=1:2
+                ch = chunks{i};
+                pos = ch{1};
+                size = ch{2};
+                assertEqual(pos(1),start_pos(2*(i-1)+1));
+                assertEqual(pos(2),start_pos(2*(i-1)+2));
+                assertEqual(size(1) ,vector(2*(i-1)+1));
+                assertEqual(size(2),vector(2*(i-1)+2));
+            end
+        end
+        %
+        function test_split_block_first_page_overruns(~)
+            vector     = 3;
+            start_pos  = 10;
+            max_sum = 5;
+            chunks = split_data_blocks(start_pos,vector, max_sum);
+            assertEqual(numel(chunks),1);
+            for i=1:1
+                ch = chunks{i};
+                pos = ch{1};
+                size = ch{2};
+                
+                assertEqual(pos,start_pos(i));
+                assertEqual(size,vector(i));
+            end
+        end
+        
+        %
+        function test_split_block_last_pages_hungs(~)
+            vector     = [5,5,3];
+            start_pos  = [10,25,400];
+            max_sum = 5;
+            chunks = split_data_blocks(start_pos,vector, max_sum);
+            assertEqual(numel(chunks),3);
+            for i=1:3
+                ch = chunks{i};
+                pos = ch{1};
+                size = ch{2};
+                
+                assertEqual(pos,start_pos(i));
+                assertEqual(size ,vector(i));
+            end
+        end
+        %
+        function test_split_block_equal_pages(~)
+            vector     = [5,5,5];
+            start_pos  = [10,25,400];
+            max_sum = 5;
+            chunks = split_data_blocks(start_pos,vector, max_sum);
+            assertEqual(numel(chunks),3);
+            for i=1:3
+                ch = chunks{i};
+                pos = ch{1};
+                size = ch{2};
+                
+                assertEqual(pos ,start_pos(i));
+                assertEqual(size,vector(i));
+            end
+        end
+        function test_split_block_large_page(~)
+            vector     = [5,5,5];
+            start_pos  = [10,25,400];
+            max_sum = 100;
+            chunks = split_data_blocks(start_pos,vector, max_sum);
+            assertEqual(numel(chunks),1);
+            
+            ch = chunks{1};
+            pos = ch{1};
+            size = ch{2};
+            assertEqual(pos,start_pos');
+            assertEqual(size,vector');
+        end
+        
+    end
+    
+end

--- a/horace_core/algorithms/cut.m
+++ b/horace_core/algorithms/cut.m
@@ -14,9 +14,10 @@ if is_string(source)
     % We expect either a .sqw or .dnd file, throw an error otherwise.
     ldr = sqw_formats_factory.instance().get_loader(source);
     if ldr.sqw_type
+        % harmonize pixel_page_size and mem_chunk_size
+        pixel_page_size = get(hor_config, 'mem_chunk_size')*ldr.pixel_size;
         % Load the .sqw file using the sqw constructor so that we can pass the
-        % pixel_page_size argument to get an sqw with file-backed pixels.
-        pixel_page_size = get(hor_config, 'pixel_page_size');
+        % pixel_page_size argument to get an sqw with file-backed pixels.        
         sqw_dnd_obj = sqw(source, 'pixel_page_size', pixel_page_size);
     else
         % In contrast to the above case, we can use the loader to get the dnd

--- a/horace_core/algorithms/cut.m
+++ b/horace_core/algorithms/cut.m
@@ -35,7 +35,12 @@ function sqw_dnd_obj=obj_from_faccessor(ldr)
 %
 if ldr.sqw_type
     % harmonize pixel_page_size and mem_chunk_size
-    pixel_page_size = get(hor_config, 'mem_chunk_size')*ldr.pixel_size;
+    [mem_chunk,page_size] = config_store.instance().get_config_field('hor_config',...
+        'mem_chunk_size','pixel_page_size');
+    pixel_page_size = mem_chunk*ldr.pixel_size;
+    if page_size<pixel_page_size % this normally for testing
+        pixel_page_size = page_size;
+    end
     % Load the .sqw file using the sqw constructor so that we can pass the
     % pixel_page_size argument to get an sqw with file-backed pixels.
     sqw_dnd_obj = sqw(ldr, 'pixel_page_size', pixel_page_size);
@@ -43,5 +48,6 @@ else
     % In contrast to the above case, we can use the loader to get the dnd
     % as no extra constructor arguments are required.
     sqw_dnd_obj = ldr.get_dnd();
+    ldr.delete();
 end
-ldr.delete();
+

--- a/horace_core/algorithms/cut.m
+++ b/horace_core/algorithms/cut.m
@@ -13,28 +13,35 @@ if is_string(source)
     % Get a loader instance that can tell us what kind of file this is
     % We expect either a .sqw or .dnd file, throw an error otherwise.
     ldr = sqw_formats_factory.instance().get_loader(source);
-    if ldr.sqw_type
-        % harmonize pixel_page_size and mem_chunk_size
-        pixel_page_size = get(hor_config, 'mem_chunk_size')*ldr.pixel_size;
-        % Load the .sqw file using the sqw constructor so that we can pass the
-        % pixel_page_size argument to get an sqw with file-backed pixels.        
-        sqw_dnd_obj = sqw(source, 'pixel_page_size', pixel_page_size);
-    else
-        % In contrast to the above case, we can use the loader to get the dnd
-        % as no extra constructor arguments are required.
-        sqw_dnd_obj = ldr.get_dnd(source);
-    end
-    ldr.delete();
+    sqw_dnd_obj=obj_from_faccessor(ldr);
+elseif isa(source,'dnd_file_interface')
+    sqw_dnd_obj=obj_from_faccessor(source);
 elseif isa(source, 'sqw') || ismember(class(source), DND_CLASSES)
     sqw_dnd_obj = source;
 else
     error('HORACE:cut', ...
-          ['Cannot take cut of object of class ''%s''.\n' ...
-           'Argument ''source'' must be sqw, dnd or a valid file path.'], ...
-          class(source));
+        ['Cannot take cut of object of class ''%s''.\n' ...
+        'Argument ''source'' must be sqw, dnd or a valid file path.'], ...
+        class(source));
 end
 if nargout > 0
     wout = cut(sqw_dnd_obj, varargin{:});
 else
     cut(sqw_dnd_obj, varargin{:});
 end
+
+function sqw_dnd_obj=obj_from_faccessor(ldr)
+% Get sqw/dnd object from appropriatly initialized file accessor
+%
+if ldr.sqw_type
+    % harmonize pixel_page_size and mem_chunk_size
+    pixel_page_size = get(hor_config, 'mem_chunk_size')*ldr.pixel_size;
+    % Load the .sqw file using the sqw constructor so that we can pass the
+    % pixel_page_size argument to get an sqw with file-backed pixels.
+    sqw_dnd_obj = sqw(ldr, 'pixel_page_size', pixel_page_size);
+else
+    % In contrast to the above case, we can use the loader to get the dnd
+    % as no extra constructor arguments are required.
+    sqw_dnd_obj = ldr.get_dnd();
+end
+ldr.delete();

--- a/horace_core/algorithms/cut_sqw.m
+++ b/horace_core/algorithms/cut_sqw.m
@@ -19,7 +19,7 @@ if ~isa(source, 'sqw')
                       'Cannot perform cut_sqw, ''%s'' is not a valid SQW file.', ...
                       source);
             end
-            ldr.delete();
+            source = ldr;
         end
     else
         error('HORACE:cut_sqw', ...

--- a/horace_core/sqw/@sqw/private/cut_accumulate_data_.m
+++ b/horace_core/sqw/@sqw/private/cut_accumulate_data_.m
@@ -77,8 +77,8 @@ for iter = 1:num_chunks
     % Get pixels that will likely contribute to the cut
     chunk = block_chunks{iter};
     pix_start = chunk{1};
-    block_size = chunk{2};    
-    pix_end = pix_start+block_size-1;
+    block_sizes = chunk{2};    
+    pix_end = pix_start+block_sizes-1;
     candidate_pix = obj.data.pix.get_pix_in_ranges( ...
         pix_start, pix_end  ...
         );

--- a/horace_core/sqw/PixelData/@PixelData/get_pix_in_ranges.m
+++ b/horace_core/sqw/PixelData/@PixelData/get_pix_in_ranges.m
@@ -15,7 +15,7 @@ function pix_out = get_pix_in_ranges(obj, abs_indices_starts, abs_indices_ends)
 %
 [ok, mess] = validate_ranges(abs_indices_starts, abs_indices_ends);
 if ~ok
-    error([upper(class(obj)), ':get_pix_in_ranges'], mess);
+    error('HORACE:PixelData:invalid_argument', mess);
 end
 
 if obj.is_file_backed_()

--- a/horace_core/sqw/file_io/@sqw_file_interface/sqw_file_interface.m
+++ b/horace_core/sqw/file_io/@sqw_file_interface/sqw_file_interface.m
@@ -51,6 +51,10 @@ classdef sqw_file_interface < dnd_binfile_common
         %
         % number of pixels, contributing into this file.
         npixels
+
+        % size of a pixel (in bytes) stored in binary file, 
+        % for the loader to read
+        pixel_size;        
     end
     properties(Constant,Access=private,Hidden=true)
         % list of field names to save on hdd to be able to recover
@@ -88,6 +92,14 @@ classdef sqw_file_interface < dnd_binfile_common
         %
         function npix = get.npixels(obj)
             npix = obj.npixels_;
+        end
+        function pix_size = get.pixel_size(~)
+            % 4 bytes x 9 columns -- default pixel size.
+            %
+            % TODO:
+            % No other size is currently supported by loaders. If this, one
+            % day, changes, the class hierarchy should be tinkered with.
+            pix_size = 4*9;
         end
         %-------------------------
         function obj = delete(obj)

--- a/horace_core/utilities/split_data_blocks.m
+++ b/horace_core/utilities/split_data_blocks.m
@@ -30,13 +30,20 @@ if isempty(block_sizes)
     cumulative_sum = [];
     return;
 end
-validateattributes(start_val, {'numeric'}, {'vector', 'nonnegative'});
-validateattributes(block_sizes, {'numeric'}, {'vector', 'nonnegative'});
+validateattributes(start_val, {'numeric'}, {'vector', 'positive'});
+validateattributes(block_sizes, {'numeric'}, {'vector', 'positive'});
 validateattributes(max_chunk_sum, {'numeric'}, {'scalar', 'positive'});
 if any(size(start_val)~=size(block_sizes))
     error('HORACE:utilities:invalid_argument',...
         'The size of start_val array and size of block_sizes array have to be the same');
 end
+if size(start_val,1)>size(start_val,2) % we want it to be rows
+    start_val = start_val';    
+end
+if size(block_sizes,1)>size(block_sizes,2) % we want it to be rows
+    block_sizes = block_sizes';    
+end
+
 
 
 cumulative_sum = cumsum(block_sizes);

--- a/horace_core/utilities/split_data_blocks.m
+++ b/horace_core/utilities/split_data_blocks.m
@@ -1,0 +1,89 @@
+function [chunks, cumulative_sum] = split_data_blocks(start_val,block_sizes, max_chunk_sum)
+% Split the array of the data blocks into the blocks, which have equal or
+% almost equal size
+%
+% Input:
+% ------
+% start_val          A vector of numeric, non-negative, values describing a
+%                    position of a block on some media
+% block_sizes        A vector of numeric, non-negative, values describing
+%                    block sizes, to process. Its assumed that the block is
+%                    continuously located on the media.
+% max_chunk_sum      A positive value specifying the maximum sum for each
+%                    sub-block, the initial values need to be split into
+%
+%
+% Output:
+% -------
+% chunks          Cell array of cells, containing parts of the start_val
+%                 and block_sizes array.
+%                 {start_val(part),block_sizes(part)}
+%                 split in such way, that sum(block_sizes(part))==max_chunk_sum
+%                 for every chunk except the final one. The final may
+%                 sum for final chunk may contain less data, i.e.
+%                 sum(block_sizes(last part))<=max_chunk_sum
+% cumulative_sum  The cumulative sum of 'block_sizes'.
+%
+
+if isempty(block_sizes)
+    chunks = {};
+    cumulative_sum = [];
+    return;
+end
+validateattributes(start_val, {'numeric'}, {'vector', 'nonnegative'});
+validateattributes(block_sizes, {'numeric'}, {'vector', 'nonnegative'});
+validateattributes(max_chunk_sum, {'numeric'}, {'scalar', 'positive'});
+if any(size(start_val)~=size(block_sizes))
+    error('HORACE:utilities:invalid_argument',...
+        'The size of start_val array and size of block_sizes array have to be the same');
+end
+
+
+cumulative_sum = cumsum(block_sizes);
+max_num_chunks = floor(cumulative_sum(end)/max_chunk_sum);
+if max_num_chunks*max_chunk_sum<cumulative_sum(end)
+    max_num_chunks = max_num_chunks+1;
+end
+
+if (max_num_chunks == 1) || (ceil(cumulative_sum(end)/max_chunk_sum) == 1)
+    % Only one chunk of data, return it
+    chunks = {{start_val',block_sizes'}};
+    return
+end
+
+chunks = cell(1, max_num_chunks);
+chunks_borders = max_chunk_sum:max_chunk_sum:max_num_chunks*max_chunk_sum;
+chunks_borders(end)=cumulative_sum(end);
+
+
+ind_end = 0;
+ind_prev = 0;
+for i=1:max_num_chunks
+    ind_start = ind_end+1;
+    ind_end = find(cumulative_sum<=chunks_borders(i),1,'last');
+    if isempty(ind_end) || ind_end < ind_start
+        ind_end = ind_start;
+    end
+    if ind_start ~= ind_prev 
+       start_pos = start_val(ind_start);                    
+    end
+    
+    overrun = chunks_borders(i)-cumulative_sum(ind_end);
+    if overrun>0
+        chunks{i} = {start_val(ind_start:ind_end+1)',...
+            [block_sizes(ind_start:ind_end),overrun]'};
+        % cut the part of the taken block from the beginning of the next
+        % block
+        start_val(ind_end+1) = start_val(ind_end+1)+overrun+1;
+        block_sizes(ind_end+1) = block_sizes(ind_end+1)-overrun;
+    elseif overrun<0 % splitting chunk in more then one block
+        chunks{i} = {start_val(ind_end),max_chunk_sum};
+        block_sizes(ind_end) = block_sizes(ind_end)-max_chunk_sum;
+        start_val(ind_end) =  start_pos+max_chunk_sum+1;        
+        ind_end = ind_start-1;
+    else
+        chunks{i} = {start_val(ind_start:ind_end)',...
+            block_sizes(ind_start:ind_end)'};
+    end
+    ind_prev = ind_start;
+end

--- a/horace_core/utilities/split_data_blocks.m
+++ b/horace_core/utilities/split_data_blocks.m
@@ -54,24 +54,31 @@ end
 chunks = cell(1, max_num_chunks);
 chunks_borders = max_chunk_sum:max_chunk_sum:max_num_chunks*max_chunk_sum;
 chunks_borders(end)=cumulative_sum(end);
-
+%[counts,~,indexes]= histcounts(chunks_borders,[0,cumulative_sum+0.1]);
 
 ind_end = 0;
 ind_prev = 0;
+border0 = 0;
 for i=1:max_num_chunks
+    
     ind_start = ind_end+1;
     ind_end = find(cumulative_sum<=chunks_borders(i),1,'last');
     if isempty(ind_end) || ind_end < ind_start
-        ind_end = ind_start;
+        ind_end  = ind_start;
     end
     if ind_start ~= ind_prev 
-       start_pos = start_val(ind_start);                    
+       start_pos   = start_val(ind_start); 
+        if i==1
+            border0 = 0;
+        else
+            border0  = chunks_borders(i-1);        
+        end       
     end
     
     overrun = chunks_borders(i)-cumulative_sum(ind_end);
     if overrun>0
-        chunks{i} = {start_val(ind_start:ind_end+1)',...
-            [block_sizes(ind_start:ind_end),overrun]'};
+        chunks{i} = {start_val(ind_start:ind_end+1),...
+            [block_sizes(ind_start:ind_end),overrun]};
         % cut the part of the taken block from the beginning of the next
         % block
         start_val(ind_end+1) = start_val(ind_end+1)+overrun+1;
@@ -79,11 +86,11 @@ for i=1:max_num_chunks
     elseif overrun<0 % splitting chunk in more then one block
         chunks{i} = {start_val(ind_end),max_chunk_sum};
         block_sizes(ind_end) = block_sizes(ind_end)-max_chunk_sum;
-        start_val(ind_end) =  start_pos+max_chunk_sum+1;        
+        start_val(ind_end) =   start_pos+chunks_borders(i)-border0+1;        
         ind_end = ind_start-1;
     else
-        chunks{i} = {start_val(ind_start:ind_end)',...
-            block_sizes(ind_start:ind_end)'};
+        chunks{i} = {start_val(ind_start:ind_end),...
+            block_sizes(ind_start:ind_end)};
     end
     ind_prev = ind_start;
 end

--- a/horace_core/utilities/split_vector_max_sum.m
+++ b/horace_core/utilities/split_vector_max_sum.m
@@ -1,4 +1,4 @@
-function [chunks, idxs, cumulative_sum] = split_vector_max_sum(numeric_vector, max_chunk_sum,varargin)
+function [chunks, idxs, cumulative_sum] = split_vector_max_sum(numeric_vector, max_chunk_sum)
 %SPLIT_VECTOR_MAX_SUM Split the given vector into a set of sub-vectors such that the
 % sum of each sub-vector has a maximum of max_chunk_sum, or the sub-vector has
 % length 1.

--- a/horace_core/utilities/split_vector_max_sum.m
+++ b/horace_core/utilities/split_vector_max_sum.m
@@ -1,4 +1,4 @@
-function [chunks, idxs, cumulative_sum] = split_vector_max_sum(numeric_vector, max_chunk_sum)
+function [chunks, idxs, cumulative_sum] = split_vector_max_sum(numeric_vector, max_chunk_sum,varargin)
 %SPLIT_VECTOR_MAX_SUM Split the given vector into a set of sub-vectors such that the
 % sum of each sub-vector has a maximum of max_chunk_sum, or the sub-vector has
 % length 1.


### PR DESCRIPTION
This is quick fix, resolving issue #669. Its not entirely legal fixture as no unit test verifying the issue is written, while the script, demonstrating the issue works on huge 70Gb file, so can not be currently automated. Performance should also be validated, and verified together with output file as this is performance critical  code. This is why I left part of the initial code commented as it is a bit nice and my modifications may be not essential for the performance. 

Despite that, it fixes Horace, you can now, as before, do cuts in any direction and the remained issues are summarized within the follow up ticket. 