### PR TITLE
Horace GUI nxspe check fix

### DIFF
--- a/horace_core/GUI/horace.m
+++ b/horace_core/GUI/horace.m
@@ -5126,7 +5126,7 @@ function gen_sqw_spefile_browse_pushbutton_Callback(hObject, eventdata, handles)
 % eventdata  reserved - to be defined in a future version of MATLAB
 % handles    structure with handles and user data (see GUIDATA)
 
-[spe_filename,spe_pathname,FilterIndex] = uigetfile({'*.spe; *.SPE','spe files (*.spe, *.SPE)';'*.*','All files (*.*)' },...
+[spe_filename,spe_pathname,FilterIndex] = uigetfile({'*.spe; *.SPE; *.nxspe; *.NXSPE','spe files (*.spe, *.nxspe)';'*.*','All files (*.*)' },...
     'Select spe files','Multiselect','on');
 
 if ischar(spe_pathname) && ischar(spe_filename)
@@ -5269,7 +5269,7 @@ elseif isempty(angdeg)
     set(handles.message_info_text,'String',char({mess_initialise,mess1}));
     guidata(gcbo,handles);
     return;      
-elseif isempty(parfile)
+elseif isempty(parfile) && sqw_list_not_nxspe(handles.gen_sqw_listbox)
     mess1='Ensure you have specified a par file name';
     set(handles.message_info_text,'String',char({mess_initialise,mess1}));
     guidata(gcbo,handles);
@@ -5843,3 +5843,11 @@ if button_state==get(hObject,'Max');%button is pressed
 end
 guidata(gcbo, handles);
 
+
+% --- Checks if inputfiles are all nxspe or not
+function out = sqw_list_not_nxspe(listbox_handle)
+spe_psi_list=get(listbox_handle,'String');
+for i=1:size(spe_psi_list,1)
+    spe_psi_cell{i}=strtrim(spe_psi_list(i,:));%get rid of leading and trailing white space
+end
+out = all(cellfun(@(x)isempty(strfind(x, 'nxspe')), spe_psi_cell));

--- a/horace_core/GUI/horace_fitting.m
+++ b/horace_core/GUI/horace_fitting.m
@@ -779,8 +779,8 @@ end
 %also must include background info (a little trickier):
 counter=1;
 if bgon
-    myout=['Background  = ',num2str(fitdata.bp{1}(counter)),...
-        ' +/- ',num2str(fitdata.bsig{1}(counter))];
+    myout=['Background  = ',num2str(fitdata.bp(counter)),...
+        ' +/- ',num2str(fitdata.bsig(counter))];
     mess_to_print=[mess_to_print,myout];
     counter=counter+1;
 end


### PR DESCRIPTION
This changes the checks so that if users give a list of `nxspe` files, they do not have to give a `par` file.

Also fixes a change in the output of the fitting functions.

For fitting to work in the GUI, the work-around in *Herbert* in issue #692

FIxes #693