### PR TITLE
figing test_cuts_performance in production (jenkins) mode

### DIFF
--- a/_test/common_functions/@SQW_GENCUT_perf_tester/large_cut_nopix_task_performance.m
+++ b/_test/common_functions/@SQW_GENCUT_perf_tester/large_cut_nopix_task_performance.m
@@ -3,7 +3,7 @@ function  [perf_res,sqw1,sqw2,sqw3,sqw4] = large_cut_nopix_task_performance(obj,
 test_fld_names = field_names_map('big_cut_nopix');
 
 hs = head_sqw(obj.sqw_file);
-if horace_version('-num') < 360
+if horace_version('-num') < 306
     urng = hs.urange;
 else
     urng = hs.img_db_range;

--- a/_test/common_functions/@SQW_GENCUT_perf_tester/large_cut_nopix_task_performance.m
+++ b/_test/common_functions/@SQW_GENCUT_perf_tester/large_cut_nopix_task_performance.m
@@ -3,7 +3,7 @@ function  [perf_res,sqw1,sqw2,sqw3,sqw4] = large_cut_nopix_task_performance(obj,
 test_fld_names = field_names_map('big_cut_nopix');
 
 hs = head_sqw(obj.sqw_file);
-if horace_version('-num') < 400
+if horace_version('-num') < 360
     urng = hs.urange;
 else
     urng = hs.img_db_range;

--- a/_test/common_functions/@SQW_GENCUT_perf_tester/large_cut_pix_fbased_task_perfornance.m
+++ b/_test/common_functions/@SQW_GENCUT_perf_tester/large_cut_pix_fbased_task_perfornance.m
@@ -1,7 +1,7 @@
 function perf_res = large_cut_pix_fbased_task_perfornance(obj,field_names_map)
 hs = head_sqw(obj.sqw_file);
 
-if horace_version('-num') < 400
+if horace_version('-num') < 306
     urng = hs.urange;
 else
     urng = hs.img_db_range;

--- a/_test/test_gen_sqw_workflow/CUTS_PERF_PerfRez.xml
+++ b/_test/test_gen_sqw_workflow/CUTS_PERF_PerfRez.xml
@@ -576,34 +576,74 @@
    </host_172_16_114_142_parpool_nf20>
    <host_172_16_114_55_parpool_nf10>
       <gen_tmp_nwk_0_parpool>
-         <time_sec>101.296522</time_sec>
+         <time_sec>62.06158</time_sec>
          <comment>whole sqw file generation</comment>
-         <completed_on>[2021 9 29 20 13 26.986004]</completed_on>
+         <completed_on>[2021 9 29 21 1 3.913975]</completed_on>
       </gen_tmp_nwk_0_parpool>
       <comb_tmp_nwk_0_matlab>
-         <time_sec>28.327142</time_sec>
+         <time_sec>14.388947</time_sec>
          <comment>calc headers and combine all tmp files</comment>
-         <completed_on>[2021 9 29 20 13 56.840482]</completed_on>
+         <completed_on>[2021 9 29 21 1 18.303111]</completed_on>
       </comb_tmp_nwk_0_matlab>
       <cutH1D_Small_nwk0_nomex>
-         <time_sec>0.480439</time_sec>
+         <time_sec>0.162506</time_sec>
          <comment>small memory based 1D cut in non-axis aligned direction 1</comment>
-         <completed_on>[2021 9 29 20 18 35.742212]</completed_on>
+         <completed_on>[2021 9 29 21 3 41.924471]</completed_on>
       </cutH1D_Small_nwk0_nomex>
       <cutK1D_Small_nwk0_nomex>
-         <time_sec>0.214121</time_sec>
+         <time_sec>0.19402</time_sec>
          <comment>small memory based 1D cut in non-axis aligned direction 2</comment>
-         <completed_on>[2021 9 29 20 18 35.95713]</completed_on>
+         <completed_on>[2021 9 29 21 3 42.252315]</completed_on>
       </cutK1D_Small_nwk0_nomex>
       <cutL1D_Small_nwk0_nomex>
-         <time_sec>0.215012</time_sec>
+         <time_sec>0.203779</time_sec>
          <comment>small memory based 1D cut in non-axis aligned direction 3</comment>
-         <completed_on>[2021 9 29 20 18 36.383182]</completed_on>
+         <completed_on>[2021 9 29 21 3 42.456347]</completed_on>
       </cutL1D_Small_nwk0_nomex>
       <cutE_Small_nwk0_nomex>
-         <time_sec>0.173626</time_sec>
+         <time_sec>0.141437</time_sec>
          <comment>small memory based 1D cut along energy direction (q are not axis aligned)</comment>
-         <completed_on>[2021 9 29 20 4 53.895825]</completed_on>
+         <completed_on>[2021 9 29 21 3 42.59802]</completed_on>
       </cutE_Small_nwk0_nomex>
+      <cutH1D_AllInt_nopix_nwk0_nomex>
+         <time_sec>6.289809</time_sec>
+         <comment>large 1D cut direction 1 with whole dataset integration along 3 other directions. -nopix mode</comment>
+         <completed_on>[2021 9 29 21 3 20.778487]</completed_on>
+      </cutH1D_AllInt_nopix_nwk0_nomex>
+      <cutK1D_AllInt_nopix_nwk0_nomex>
+         <time_sec>6.777505</time_sec>
+         <comment>large 1D cut direction 2 with whole dataset integration along 3 other directions. -nopix mode</comment>
+         <completed_on>[2021 9 29 21 3 27.556139]</completed_on>
+      </cutK1D_AllInt_nopix_nwk0_nomex>
+      <cutL1D_AllInt_nopix_nwk0_nomex>
+         <time_sec>8.065166</time_sec>
+         <comment>large 1D cut direction 3 with whole dataset integration along 3 other directions. -nopix mode</comment>
+         <completed_on>[2021 9 29 21 3 35.621466]</completed_on>
+      </cutL1D_AllInt_nopix_nwk0_nomex>
+      <cutE_AllInt_nopix_nwk0_nomex>
+         <time_sec>6.091914</time_sec>
+         <comment>large 1D cut along energy direction with whole dataset integration along 3 other directions. -nopix mode</comment>
+         <completed_on>[2021 9 29 21 3 41.713504]</completed_on>
+      </cutE_AllInt_nopix_nwk0_nomex>
+      <cutH1D_AllInt_flBsd_nwk0_comb_matlab>
+         <time_sec>29.611639</time_sec>
+         <comment>large file-based 1D cut. Direction 1; Whole dataset integration along 3 other directions</comment>
+         <completed_on>[2021 9 29 21 1 48.111284]</completed_on>
+      </cutH1D_AllInt_flBsd_nwk0_comb_matlab>
+      <cutK1D_AllInt_flBsd_nwk0_comb_matlab>
+         <time_sec>29.369126</time_sec>
+         <comment>large file-based 1D cut. Direction 2; Whole dataset integration along 3 other directions</comment>
+         <completed_on>[2021 9 29 21 2 17.615103]</completed_on>
+      </cutK1D_AllInt_flBsd_nwk0_comb_matlab>
+      <cutL1D_AllInt_flBsd_nwk0_comb_matlab>
+         <time_sec>33.330065</time_sec>
+         <comment>large file-based 1D cut. Direction 3; Whole dataset integration along 3 other directions</comment>
+         <completed_on>[2021 9 29 21 2 51.078973]</completed_on>
+      </cutL1D_AllInt_flBsd_nwk0_comb_matlab>
+      <cutE_AllInt_flBsd_nwk0_comb_matlab>
+         <time_sec>22.934129</time_sec>
+         <comment>large file-based 1D cut. Energy direction; Whole dataset integration along 3 other directions</comment>
+         <completed_on>[2021 9 29 21 3 14.152757]</completed_on>
+      </cutE_AllInt_flBsd_nwk0_comb_matlab>
    </host_172_16_114_55_parpool_nf10>
 </test_cuts_performance>

--- a/_test/test_gen_sqw_workflow/CUTS_PERF_PerfRez.xml
+++ b/_test/test_gen_sqw_workflow/CUTS_PERF_PerfRez.xml
@@ -574,4 +574,36 @@
          <completed_on>[2021 9 20 11 20 58.266837]</completed_on>
       </cutE_Small_nwk0_mex>
    </host_172_16_114_142_parpool_nf20>
+   <host_172_16_114_55_parpool_nf10>
+      <gen_tmp_nwk_0_parpool>
+         <time_sec>101.296522</time_sec>
+         <comment>whole sqw file generation</comment>
+         <completed_on>[2021 9 29 20 13 26.986004]</completed_on>
+      </gen_tmp_nwk_0_parpool>
+      <comb_tmp_nwk_0_matlab>
+         <time_sec>28.327142</time_sec>
+         <comment>calc headers and combine all tmp files</comment>
+         <completed_on>[2021 9 29 20 13 56.840482]</completed_on>
+      </comb_tmp_nwk_0_matlab>
+      <cutH1D_Small_nwk0_nomex>
+         <time_sec>0.480439</time_sec>
+         <comment>small memory based 1D cut in non-axis aligned direction 1</comment>
+         <completed_on>[2021 9 29 20 18 35.742212]</completed_on>
+      </cutH1D_Small_nwk0_nomex>
+      <cutK1D_Small_nwk0_nomex>
+         <time_sec>0.214121</time_sec>
+         <comment>small memory based 1D cut in non-axis aligned direction 2</comment>
+         <completed_on>[2021 9 29 20 18 35.95713]</completed_on>
+      </cutK1D_Small_nwk0_nomex>
+      <cutL1D_Small_nwk0_nomex>
+         <time_sec>0.215012</time_sec>
+         <comment>small memory based 1D cut in non-axis aligned direction 3</comment>
+         <completed_on>[2021 9 29 20 18 36.383182]</completed_on>
+      </cutL1D_Small_nwk0_nomex>
+      <cutE_Small_nwk0_nomex>
+         <time_sec>0.173626</time_sec>
+         <comment>small memory based 1D cut along energy direction (q are not axis aligned)</comment>
+         <completed_on>[2021 9 29 20 4 53.895825]</completed_on>
+      </cutE_Small_nwk0_nomex>
+   </host_172_16_114_55_parpool_nf10>
 </test_cuts_performance>

--- a/_test/test_gen_sqw_workflow/test_cuts_performance.m
+++ b/_test/test_gen_sqw_workflow/test_cuts_performance.m
@@ -26,6 +26,18 @@ classdef test_cuts_performance < SQW_GENCUT_perf_tester
             if nerrors> 0
                 obj.skip_mex_tests = true;
             end
+            if ~obj.build_sqw_file_directly
+                % source sqw file has not been generated
+                % we need to build it now
+                if obj.skip_mex_tests
+                    build_mode = 'nomex';
+                else
+                    build_mode = 'mex';
+                end
+                names_map = obj.build_default_test_names(0,build_mode);
+                obj.gen_sqw_task_performance(names_map)
+            end
+            
         end
         
         function setUp(obj)


### PR DESCRIPTION
this small bug should not affect anybody, as the test performance should  be run automatically anywhere at the moment. 
Despite that, the mode when the test verifies the gen_sqw performance was disabled so I have enabled it. 

It does not mean it should not be fixed to simplify development in a future