### PR TITLE
fixing test_refine_crystal_1 

### DIFF
--- a/_test/test_sqw_file/test_serialize_deserialize.m
+++ b/_test/test_sqw_file/test_serialize_deserialize.m
@@ -353,7 +353,7 @@ classdef test_serialize_deserialize< TestCase
             samp = IX_sample ([1,0,0],[0,1,0],'cuboid',[2,3,4]);
             [struc_pos,pos] = ser.calculate_positions(test_format,samp);
             
-            assertEqual(pos-1,1126);
+            assertEqual(pos-1,1231);
             
             bytes = ser.serialize(samp,test_format);
             assertEqual(numel(bytes),pos-1);


### PR DESCRIPTION
Change reference data which contains inf in img_db_range
Modern code should not contain such data and do not know how to treat them