### PR TITLE
User docs CI

### DIFF
--- a/documentation/smg/18_ci_user_docs_build.md
+++ b/documentation/smg/18_ci_user_docs_build.md
@@ -1,0 +1,35 @@
+# Automatic building of user documentation
+
+## Summary
+
+This system maintenance guide describes a change in the continuous integration workflow
+for building and publishing user documentation created by Sphinx, described in [SMG#15](15_documentation.md).
+
+* Documentation will henceforth be built using Github-Actions instead of Anvil/Jenkins.
+* Changes to `master` will cause the documentation to be built in a published in [unstable](https://pace-neutrons.github.io/Horace/unstable/).
+* Publishing a [release](https://github.com/pace-neutrons/Horace/releases/new) on Github will cause
+  documentation to be build and published to the corresponding `vX.Y.Z` folder, and linked 
+  (using `http-refresh` redirection) in the [stable](https://pace-neutrons.github.io/Horace/stable/) folder.
+
+## Previous situation
+
+Previously, the documentation was built and pushed (published) in Jenkins.
+However, the [build script](https://github.com/pace-neutrons/Horace/blob/7bc3e41d5bec4090f8ee1ebae97259cd6629823e/tools/build_config/build.sh#L96) always copies the built documentation to the `unstable` folder regardless of whether
+the build was triggered by a release or nightly build.
+The previous stable (v3.6.0) documentation was published manually.
+
+## New workflow
+
+The user documentation publishing scripts and triggers will be removed from the `build.sh` / `build.ps1` and `Jenkinsfile`.
+Instead there will be two github-action scripts,
+one for [unstable](https://github.com/pace-neutrons/Horace/blob/master/.github/workflows/push_docs_unstable.yml)
+and one for [stable](https://github.com/pace-neutrons/Horace/blob/master/.github/workflows/push_docs_stable.yml).
+
+The `unstable` script will build the documentation and publish it in the `unstable` folder.
+This will run on every push to `master` (e.g. everytime a PR is merged and `master` is updated),
+and can also be triggered manually
+(by clicking `Run workflow` on [this page](https://github.com/pace-neutrons/Horace/actions/workflows/push_docs_unstable.yml))
+by any member of the `pace-neutrons` organisation.
+
+The `stable` script will run when a release is published on Github.
+It will create a new folder for the documentation, named after that release and link this folder to the `stable` folder.

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -65,10 +65,6 @@ properties([
       description: 'If this pipeline is to build docs.',
       name: 'BUILD_DOCS'
     ),
-    booleanParam(
-      description: 'If this pipeline is to push docs.',
-      name: 'PUSH_DOCS'
-    )
   ])
 ])
 
@@ -82,9 +78,6 @@ if (env.BRANCH_NAME) {
 def base_job_name = "${env.JOB_BASE_NAME}".replace("PR-", "").replace("Branch-", "")
 Boolean run_build_stage = !(env?.PR_LABELS =~ "do-not-build")
 Boolean run_test_stage = !(env?.PR_LABELS =~ "(do-not-build|do-not-test)")
-Boolean run_push_docs_stage = (pli.matlab_release == 'R2019b' &&
-			       pli.build_type == 'Nightly_false' &&
-			       utilities.get_agent(pli.os) == 'sl7')
 
 pipeline {
 
@@ -99,7 +92,6 @@ pipeline {
     VS_VERSION = utilities.get_param('VS_VERSION', '2017')
     CPPCHECK_VERSION = utilities.get_param('CPPCHECK_VERSION', '1.77')
     BUILD_DOCS = utilities.get_param('BUILD_DOCS', 'true')
-    PUSH_DOCS = utilities.get_param('PUSH_DOCS', 'false')
   }
 
   stages {
@@ -367,26 +359,6 @@ pipeline {
       }
     }
 
-
-    stage('Push-Docs') {
-      when {
-	expression {env.BUILD_DOCS?.toBoolean() && (env.PUSH_DOCS?.toBoolean() || run_push_docs_stage)}
-      }
-      steps {
-	withCredentials([string(credentialsId: 'GitHub_API_Token',
-				variable: 'api_token')]) {
-	  script {
-	    if (isUnix()) {
-	      sh './tools/build_config/build.sh --push-docs'
-	    }
-	    else {
-	      powershell './tools/build_config/build.ps1 -push_docs'
-
-	    }
-	  }
-	}
-      }
-    }
   }
 
   post {

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -82,23 +82,6 @@ function build_docs() {
     echo_and_run "cmake --build ${build_dir} --target docs-pack"
 }
 
-function push_built_docs() {
-    build_id=$(sed -nr '/CPACK_PACKAGE_FILE_NAME/{s/.*"Horace-([^"]+)".*/\1/p};' ./build/CPackConfig.cmake)
-    git config --local user.name "PACE CI Build Agent"
-    git config --local user.email "pace.builder.stfc@gmail.com"
-    git remote set-url --push origin "https://pace-builder:"${api_token## }"@github.com/pace-neutrons/Horace"
-    git stash
-    git checkout gh-pages
-    git pull
-    echo "Bypassing Jekyll on GitHub Pages" > .nojekyll
-    git add .nojekyll
-    git rm -rf --ignore-unmatch ./unstable
-    cp -r ./documentation/user_docs/build/html ./unstable
-    git add unstable
-    git commit -m "Document build from CI ("$build_id")"
-    git push origin gh-pages
-}
-
 function print_help() {
   readonly local help_msg="Script to build, run static analysis, test and package Horace.
 
@@ -127,8 +110,6 @@ flags:
       Print the versions of libraries being used e.g. Matlab.
   -d, --docs
       Build user docs
-  --push_docs
-      Push docs up to Horace GitHub repo
   -h, --help
       Print help message and exit.
 options:
@@ -159,7 +140,6 @@ function main() {
   local analyze=$FALSE
   local package=$FALSE
   local docs=$FALSE
-  local push_docs=$FALSE
   local print_versions=$FALSE
   local build_tests="ON"
   local build_config='Release'
@@ -178,7 +158,6 @@ function main() {
         -a|--analyze) analyze=$TRUE; shift ;;
         -p|--package) package=$TRUE; shift ;;
         -d|--docs) docs=$TRUE; shift;;
-        --push-docs) push_docs=$TRUE; shift;;
         -v|--print_versions) print_versions=$TRUE; shift ;;
         -h|--help) print_help; exit 0 ;;
         # options
@@ -219,9 +198,6 @@ function main() {
     build_docs
   fi
 
-  if ((push_docs)); then
-    push_built_docs
-  fi
 }
 
 main "$@"


### PR DESCRIPTION
This PR removes the publishing of user docs from the Jenkins / Anvil CI, in preference to using github-actions, introduced in #772.

The documentation are still built in Jenkins, and the docs artifact can still be downloaded there.

The PR also adds a SMG document describing the changes.