### PR TITLE
move detpar to detector arrays

### DIFF
--- a/_test/test_sqw_class/test_equal_to_tol.m
+++ b/_test/test_sqw_class/test_equal_to_tol.m
@@ -63,7 +63,7 @@ classdef test_equal_to_tol < TestCase & common_sqw_class_state_holder
                 sqw_copy = obj.sqw_2d;
                 field_name = class_fields{idx};
                 
-                if isstruct(sqw_copy.(field_name))
+                if isstruct(sqw_copy.(field_name)) && ~isempty(sqw_copy.(field_name))
                     sqw_copy.(field_name).test_field = 'test_value';
                 elseif isstring(sqw_copy.(field_name))
                     sqw_copy.(field_name) = 'test_value';

--- a/_test/test_sqw_class/test_experiment.m
+++ b/_test/test_sqw_class/test_experiment.m
@@ -95,7 +95,7 @@ classdef test_experiment < TestCaseWithSave
             load(tmpfile, 'expt');
             assertTrue( isempty(expt.instruments));
             assertTrue( isempty(expt.samples));
-            assertEqual(expt.detector_arrays, []);
+            assertEqual(expt.detector_arrays, IX_detector_array.empty);
         end
         
         function test_instruments_setter_updates_value_for_valid_value(~)

--- a/horace_core/algorithms/head_horace.m
+++ b/horace_core/algorithms/head_horace.m
@@ -108,6 +108,7 @@ else
                 [data.main_header,exper_block,data.detpar,data.data] = ...
                     loaders{i}.get_sqw('-legacy','-nopix','-verbatim');
                 data.header = exper_block.header;
+                data.detpar = exper_block.detpar;
             else
                 data         = loaders{i}.get_data('-verbatim','-nopix');
                 if isa(data,'data_sqw_dnd')

--- a/horace_core/sqw/@Experiment/Experiment.m
+++ b/horace_core/sqw/@Experiment/Experiment.m
@@ -3,7 +3,7 @@ classdef Experiment < serializable
     
     properties(Access=private)
         instruments_ = {}; %IX_inst.empty;
-        detector_arrays_ = []
+        detector_arrays_ = IX_detector_array.empty;
         samples_ = {}; % IX_samp.empty;
         expdata_ = IX_experiment();
     end
@@ -19,6 +19,7 @@ classdef Experiment < serializable
     properties(Dependent,Hidden)
         % property providing compartibility with old header interface
         header
+        detpar
     end
     properties(Constant,Access=private)
         fields_to_save_ = {'instruments','detector_arrays','samples','expdata'};
@@ -89,6 +90,10 @@ classdef Experiment < serializable
                 error('HORACE:Experiment:invalid_argument', ...
                     'Must give all of detector_array, instrument and sample or the structure representing them')
             end
+        end
+        
+        function add_detector_array(obj,detarr)
+            obj.detector_arrays_(end+1) = detarr;
         end
         %
         function oldhdrs = convert_to_old_headers(obj,header_num)
@@ -295,6 +300,15 @@ classdef Experiment < serializable
             head = [head{:}];
             head = rmfield(head,{'instrument','sample'});
         end
+        
+        function dp = get.detpar(obj)
+            if numel(obj.detector_arrays)>0
+                dp = obj.detector_arrays(1);
+                dp = dp.convert_to_old_detpar();
+            else
+                dp = struct();
+            end
+        end 
     end
     methods(Access=protected)
         %------------------------------------------------------------------

--- a/horace_core/sqw/@Experiment/private/build_from_old_headers_.m
+++ b/horace_core/sqw/@Experiment/private/build_from_old_headers_.m
@@ -106,7 +106,7 @@ end
 
 % Construct the new header Experiment object
 % update with expdata, which maybe should go in the Experiment constructor
-obj = Experiment([], instruments, samples);
+obj = Experiment(IX_detector_array.empty, instruments, samples);
 obj.expdata = expdata;
 
 end % function build_from_old_headers

--- a/horace_core/sqw/@rundatah/private/calc_sqw_.m
+++ b/horace_core/sqw/@rundatah/private/calc_sqw_.m
@@ -134,7 +134,8 @@ end
 % ----------------------------------------------------------------------
 d.main_header=main_header;
 d.experiment_info=header;
-d.detpar=det0;
+d.experiment_info.detector_arrays(end+1) = IX_detector_array(det0);
+d.detpar=struct([]);
 d.data=data_sqw_dnd(sqw_datstr);
 w=sqw(d);
 
@@ -187,7 +188,7 @@ if all(isempty(obj.sample)) || isempty(fieldnames(obj.sample)) || any(isempty(ob
 else
     sample = obj.sample;
 end
-header = Experiment([],obj.instrument,sample);
+header = Experiment(IX_detector_array.empty,instrument,sample);
 
 
 uoffset = [0;0;0;0];

--- a/horace_core/sqw/@sqw/spe.m
+++ b/horace_core/sqw/@sqw/spe.m
@@ -51,7 +51,7 @@ if isa(w.experiment_info,'Experiment')
 else
     ne=numel(w.experiment_info.en)-1;    % number of energy bins
 end
-ndet0=numel(w.detpar.group);% number of detectors
+ndet0=numel(w.experiment_info.detector_arrays(1).id);% number of detectors
 
 tmp=w.data.pix.get_data({'detector_idx', 'energy_idx', 'signal', 'variance'})';
 tmp=sortrows(tmp,[1,2]);    % order by detector group number, then energy
@@ -63,7 +63,7 @@ if size(tmp,1)~=ne*numel(group)
 end
 
 % Get the indexing of detector group in the detector information
-[lia,ind]=ismember(group,w.detpar.group);
+[lia,ind]=ismember(group,w.experiment_info.detector_arrays(1).id);
 
 signal=NaN(ne,ndet0);
 err=zeros(ne,ndet0);

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -88,7 +88,11 @@ classdef (InferiorClasses = {?d0d, ?d1d, ?d2d, ?d3d, ?d4d}) sqw < SQWDnDBase & s
         wout = noisify(w,varargin);
         
         function dtp = my_detpar(obj)
-            dtp = obj.detpar_x;
+            if ~isempty(obj.detpar_x)
+                dtp = obj.detpar_x;
+            elseif ~isempty(obj.experiment_info.detector_arrays)
+                dtp = obj.experiment_info.detector_arrays(1).convert_to_old_detpar();
+            end
         end
         
         function obj = change_detpar(obj,dtp)
@@ -226,8 +230,19 @@ classdef (InferiorClasses = {?d0d, ?d1d, ?d2d, ?d3d, ?d4d}) sqw < SQWDnDBase & s
     
     methods(Static)
         function obj = loadobj(S)
-            % boilerplate loadobj method, calling generic method of
+            % modified boilerplate loadobj method, calling generic method of
             % saveable class
+            % the generic code is preceded by the conversion of old-style
+            % detpar info into the new detector arrays. This allows loading
+            % of .mat files without converting them on disk..
+            if isfield(S,'experiment_info') && isfield(S,'detpar')
+                if ~isempty(S.detpar) && isempty(S.experiment_info.detector_arrays)
+                    dd = IX_detector_array(S.detpar);
+                    S.experiment_info.detector_arrays = IX_detector_array.empty;
+                    S.experiment_info.detector_arrays(end+1) = dd;
+                    S.detpar = struct([]);
+                end
+            end
             obj = sqw();
             obj = loadobj@serializable(S,obj);
         end
@@ -272,6 +287,18 @@ classdef (InferiorClasses = {?d0d, ?d1d, ?d2d, ?d3d, ?d4d}) sqw < SQWDnDBase & s
                         end
                         ss = rmfield(ss,'header');
                     end
+                    
+                    % assuming that detpar exists and is not empty, convert
+                    % its contents into a detector array. There are test
+                    % datasets with empty detpar and those should be left
+                    % unconverted, they seem to be testing other items in
+                    % the sqw and ignoring the detpar.
+                    if isfield(ss,'experiment_info') && isfield(ss,'detpar') && ~isempty(ss.detpar)
+                        dd = IX_detector_array(ss.detpar);
+                        ss.experiment_info.detector_arrays(end+1) = dd;
+                        ss = rmfield(ss,'detpar');
+                    end
+                    
                     if isfield(ss,'data_')
                         ss.data = ss.data_;
                         ss = rmfield(ss,'data_');

--- a/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
+++ b/horace_core/sqw/file_io/@dnd_binfile_common/dnd_binfile_common.m
@@ -253,7 +253,8 @@ classdef dnd_binfile_common < dnd_file_interface
         function check_error_report_fail_(obj,pos_mess)
             % check if error occured during io operation and throw if it does happened
             [mess,res] = ferror(obj.file_id_);
-            if res ~= 0; error('SQW_FILE_IO:io_error',...
+            if res ~= 0
+                error('SQW_FILE_IO:io_error',...
                     '%s -- Reason: %s',pos_mess,mess);
             end
         end

--- a/horace_core/sqw/file_io/@sqw_binfile_common/get_sqw.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/get_sqw.m
@@ -72,7 +72,14 @@ headers  = obj.get_header('-all');
 % Get detector parameters
 % -----------------------
 if ~(opts.head||opts.his)
-    sqw_struc.detpar = obj.get_detpar();
+    dp = obj.get_detpar();
+    if isa(headers, 'Experiment')
+        dp = obj.get_detpar();
+        headers.detector_arrays(end+1) = IX_detector_array(dp);
+        sqw_struc.detpar = struct([]);
+    else
+        sqw_struc.detpar = obj.get_detpar();
+    end
 end
 
 % Get data


### PR DESCRIPTION
It is planned to move the detector info from the separate detpar field in sqw with an array of IX_detector_arrays in the experiment_info field. This PR does this for Horace, initially with one IX_detector_array only. The parallel Herbert PR completes the process.