### PR TITLE
Sanitise relative paths

### DIFF
--- a/_test/common_functions/@SQW_GENCUT_perf_tester/SQW_GENCUT_perf_tester.m
+++ b/_test/common_functions/@SQW_GENCUT_perf_tester/SQW_GENCUT_perf_tester.m
@@ -38,10 +38,10 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
         % (test_nameN(nWorkergs) above)
         default_test_names
     end
-    
+
     properties
         % if true, when number of test files changes, (n_files_to_use)
-        % build sqw file directly, writing and combining tmp files, 
+        % build sqw file directly, writing and combining tmp files,
         % not building contributing nxspe files for testing gen_sqw performance
         % Also keep this file for future usage
         build_sqw_file_directly = false;
@@ -57,7 +57,7 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
         % number of energy transfer bins used by test files generation routine
         num_energy_bins = 220;
     end
-    
+
     properties(Access=protected)
         % list of source files to process
         test_source_files_list_
@@ -121,7 +121,7 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
             % completed.
             obj.add_to_files_cleanList(obj.sqw_file);
         end
-        
+
         %------------------------------------------------------------------
         % Interface defining existing perfornance tests
         %
@@ -131,7 +131,7 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
         [perf,varargout]=large_cut_pix_fbased_task_perfornance(obj,field_names_map);
         %
         [perf,varargout]=combine_task_performance(obj,varargin);
-        
+
         %------------------------------------------------------------------
         function nf = get.n_files_to_use(obj)
             % number of test files, used in performance tests
@@ -141,6 +141,7 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
         function [psi,efix,alatt,angdeg,u,v,omega,dpsi,gl,gs,...
                 en,par_file,alatt_true,angdeg_true,qfwhh,efwhh,rotvec]=...
                 gen_sqw_parameters(obj)
+            pths = horace_paths;
             % return list of the parameters, used for sqw file generation
             % set up the exactly the same parameters as defined below
             % in test_gensqw_performance method.
@@ -153,17 +154,17 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
             dpsi=-1.8464+(0.9246);
             gl=-3.1871+(-0.1634);
             gs=-1.7047+(0.0028);
-            
+
             nfiles=obj.n_files_to_use_;
             %psi angles (in degrees). Should be the same number of these as there are runs
             %also the first element of irun must correspond to the first element of psi, and so on.
             psi= 0.5*(1:nfiles);
-            
+
             %  parameters, used at fake sqw files generation
             step = (21+1)/obj.num_energy_bins;
             en=-1:step:21;
-            par_file = fullfile(horace_root,'_test','common_data',obj.par_file);
-            
+            par_file = fullfile(pths.test_common,obj.par_file);
+
             alatt_true=[10.5,10.5,10.5];
             angdeg_true=[90,90,90];
             qfwhh=0.1;                  % Spread of Bragg peaks
@@ -171,7 +172,7 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
             rotvec=[10,10,0]*(pi/180);  % orientation of the true lattice w.r.t reference lattice
         end
         %-------------------------------------------------------------
-        
+
         function set.n_files_to_use(obj,val)
             % change number of files to use and modify all related
             % internal properties which depends on this number
@@ -194,7 +195,7 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
             [~,fb] = fileparts(obj.sqw_file);
             [~,fb] = fileparts(fb);
             obj.sqw_file = fullfile(obj.source_data_dir,sprintf('%s.%dFiles.sqw',fb,obj.n_files_to_use_));
-            
+
             %
             [filelist,smpl_data_size] = obj.generate_source_test_files();
             obj.sample_data_size_ = smpl_data_size;
@@ -202,7 +203,7 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
             % delete generated files after the test completed.
             obj.add_to_files_cleanList(filelist);
             obj.test_source_files_list_ = filelist;
-            
+
             obj.data_size_ = obj.n_files_to_use_*smpl_data_size*(4*9)/ ... %numWords*word_size = bytes
                 (1024*1024*1024); %Convert to GB
         end
@@ -247,7 +248,7 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
             ds = pc.get_data_to_store();
             clob_par_config = onCleanup(@()set(pc,ds));
             pc.working_directory=pwd;
-            
+
             if nargin <= 2
                 n_workers = 0;
             else
@@ -278,7 +279,7 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
                 targ_file = fullfile(obj.working_dir,obj.sqw_file);
                 obj.sqw_file = targ_file;
             end
-            
+
             % define location of the sqw file to be the same as working
             % directory
             fp = fileparts(obj.sqw_file);
@@ -286,25 +287,25 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
                 targ_file = fullfile(obj.working_dir,obj.sqw_file);
                 obj.sqw_file = targ_file;
             end
-            
+
             obj.add_to_files_cleanList(obj.sqw_file)
             if tests_to_run(1)
                 perf_res=obj.gen_sqw_task_performance(field_names_map);
             end
-            
+
             if tests_to_run(2)
                 perf_res = obj.small_cut_task_performance(field_names_map);
             end
-            
+
             % check nopix performance -- read and integrate the whole file from the HDD
             if tests_to_run(3)
                 perf_res = obj.large_cut_nopix_task_performance(field_names_map);
             end
-            
+
             if tests_to_run(4)
                 perf_res = obj.large_cut_pix_fbased_task_perfornance(field_names_map);
             end
-            
+
             % spurious check to ensure the cleanup object is not deleted
             % before the end of the test
             assertTrue(isa(clob_wk,'onCleanup'))
@@ -313,11 +314,11 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
         function names = build_default_test_names(obj,nwk,varargin)
             % generate default test names to use as keys for performance
             % database structure
-            
+
             % Inputs:
             % nwk      -- Number of parallel workers used to run the algorithm
             % addinfo  -- char array, describing other properties of the algorithm.
-            
+
             % Returns:
             % map in the form key=test name, value -- cellarray of subtests
             % to run for the given test.
@@ -360,7 +361,7 @@ classdef SQW_GENCUT_perf_tester < TestPerformance
             else
                 nwkc = num2str(n_workers);
             end
-            
+
             an = hc.parallel_workers_number;
             if bsp && an > 1
                 clob = onCleanup(@()set(hc,'build_sqw_in_parallel',bsp,'parallel_workers_number',an));

--- a/_test/common_functions/common_state_holder.m
+++ b/_test/common_functions/common_state_holder.m
@@ -3,7 +3,7 @@ classdef common_state_holder < handle
     % completed
     properties
     end
-    
+
     methods
         function obj = common_state_holder()
             %
@@ -16,10 +16,11 @@ classdef common_state_holder < handle
                     'state',{'off','off'});
                 old_warn_state = warning(ws);
                 obj.store_holder(old_warn_state);
-                
+
                 % add path for deterministic pseudorandom sequence and
                 % common Herbert utilities
-                search_path_herbert_shared = fullfile(herbert_root, '_test/shared');
+                pths = horace_paths;
+                search_path_herbert_shared = fullfile(pths.test, 'shared');
                 obj.store_holder(search_path_herbert_shared);
                 addpath(search_path_herbert_shared);
             end
@@ -70,14 +71,14 @@ classdef common_state_holder < handle
                 stor_val = '';
                 return
             end
-            
+
             if isfield(storage,field_name)
                 stor_val = storage.(field_name);
             else
                 stor_val  = '';
             end
             storage.(field_name) = var_to_store;
-            
+
         end
         function count = call_count(direction)
             % return persistent call counter
@@ -110,4 +111,3 @@ classdef common_state_holder < handle
         end
     end
 end
-

--- a/_test/test_TF_let/test_tobyfit_let_1.m
+++ b/_test/test_TF_let/test_tobyfit_let_1.m
@@ -40,7 +40,8 @@ end
 datafile='test_tobyfit_let_1_data.mat';   % filename where saved results are written
 savefile='test_tobyfit_let_1_out.mat';   % filename where saved results are written
 
-test_tobyfit_dir = fullfile(horace_root(), '_test', 'test_tobyfit');
+pths = horace_paths;
+test_tobyfit_dir = fullfile(pths.root, '_test', 'test_tobyfit');
 addpath(test_tobyfit_dir)
 cleanup = onCleanup(@() rmpath(test_tobyfit_dir));
 

--- a/_test/test_TF_let/test_tobyfit_let_1.m
+++ b/_test/test_TF_let/test_tobyfit_let_1.m
@@ -41,7 +41,7 @@ datafile='test_tobyfit_let_1_data.mat';   % filename where saved results are wri
 savefile='test_tobyfit_let_1_out.mat';   % filename where saved results are written
 
 pths = horace_paths;
-test_tobyfit_dir = fullfile(pths.root, '_test', 'test_tobyfit');
+test_tobyfit_dir = fullfile(pths.test, 'test_tobyfit');
 addpath(test_tobyfit_dir)
 cleanup = onCleanup(@() rmpath(test_tobyfit_dir));
 

--- a/_test/test_TF_let/test_tobyfit_let_resfun_1.m
+++ b/_test/test_TF_let/test_tobyfit_let_resfun_1.m
@@ -40,7 +40,8 @@ end
 datafile='test_tobyfit_let_resfun_1_data.mat';      % filename where saved results are written
 savefile='test_tobyfit_let_resfun_1_out.mat';       % filename where saved results are written
 
-test_tobyfit_dir = fullfile(horace_root(), '_test', 'test_tobyfit');
+pths = horace_paths;
+test_tobyfit_dir = fullfile(pths.test, 'test_tobyfit');
 addpath(test_tobyfit_dir)
 cleanup = onCleanup(@() rmpath(test_tobyfit_dir));
 

--- a/_test/test_TF_refine_crystal/test_tobyfit_refine_crystal_1.m
+++ b/_test/test_TF_refine_crystal/test_tobyfit_refine_crystal_1.m
@@ -68,7 +68,8 @@ datafile='test_tobyfit_refine_crystal_1_data.mat';
 % File to which to save results of refinement
 savefile='test_tobyfit_refine_crystal_1_out.mat';   % filename where saved results are written
 
-test_tobyfit_dir = fullfile(horace_root(), '_test', 'test_tobyfit');
+pths = horace_paths;
+test_tobyfit_dir = fullfile(pths.test, 'test_tobyfit');
 addpath(test_tobyfit_dir)
 cleanup = onCleanup(@() rmpath(test_tobyfit_dir));
 
@@ -86,7 +87,7 @@ fprintf('RNG seed: %i\n', rng_state.Seed);
 efix=45;
 emode=1;
 en=-0.75:0.5:0.75;
-par_file=fullfile(horace_root,'_test','common_data','map_4to1_dec09.par');
+par_file=fullfile(pths.test_common,'map_4to1_dec09.par');
 
 % Parameters for reference lattice (i.e. what we think we have)
 alatt=[5,5,5];
@@ -366,4 +367,3 @@ for i=1:numel(flname)
         disp(['Unable to delete temporary file: ',flname{i}])
     end
 end
-

--- a/_test/test_algorithms/test_nsqw2sqw_combine_job.m
+++ b/_test/test_algorithms/test_nsqw2sqw_combine_job.m
@@ -20,7 +20,8 @@ classdef test_nsqw2sqw_combine_job < TestCase & common_state_holder
             class_dir = fileparts(which('test_nsqw2sqw_combine_job.m'));
             obj.this_tests_dir = fileparts(class_dir);
 
-            source_test_dir = fullfile(horace_root(),'_test','common_data');
+            pths = horace_paths;
+            source_test_dir = pths.test_common;
             source_file = fullfile(source_test_dir,'MAP11014.nxspe');
 
             psi = [0,2,20]; %-- test settings;

--- a/_test/test_change_crystal/test_change_crystal_1.m
+++ b/_test/test_change_crystal/test_change_crystal_1.m
@@ -9,8 +9,8 @@ banner_to_screen(mfilename)
 
 % -----------------------------------------------------------------------------
 % Add common functions folder to path, and get location of common data
-HORACE_ROOT = horace_root();
-common_data_dir=fullfile(HORACE_ROOT,'_test','common_data');
+pths = horace_paths;
+common_data_dir = pths.test_common;
 % -----------------------------------------------------------------------------
 
 dir_out=tmp_dir;

--- a/_test/test_change_crystal/test_change_crystal_1a.m
+++ b/_test/test_change_crystal/test_change_crystal_1a.m
@@ -48,8 +48,8 @@ classdef test_change_crystal_1a < TestCase
 
             % -----------------------------------------------------------------------------
             % Add common functions folder to path, and get location of common data
-            hor_root = horace_root();
-            common_data_dir=fullfile(hor_root,'_test','common_data');
+            pths = horace_paths;
+            common_data_dir = pths.test_common;
             % -----------------------------------------------------------------------------
             % generate shifted sqw file
             obj.par_file=fullfile(common_data_dir,'map_4to1_dec09.par');

--- a/_test/test_data_loaders/test_a_loader.m
+++ b/_test/test_data_loaders/test_a_loader.m
@@ -13,7 +13,7 @@ classdef test_a_loader< TestCase
             end
             this = this@TestCase(name);
             pths = horace_paths;
-            this.test_data_path = paths.test_common;
+            this.test_data_path = pths.test_common;
         end
 
         function test_abstract_methods(~)

--- a/_test/test_data_loaders/test_a_loader.m
+++ b/_test/test_data_loaders/test_a_loader.m
@@ -12,8 +12,8 @@ classdef test_a_loader< TestCase
                 name = 'test_a_loader';
             end
             this = this@TestCase(name);
-            [~,tdp] = herbert_root();
-            this.test_data_path =tdp;
+            pths = horace_paths;
+            this.test_data_path = paths.test_common;
         end
 
         function test_abstract_methods(~)
@@ -336,4 +336,3 @@ classdef test_a_loader< TestCase
         end
     end
 end
-

--- a/_test/test_data_loaders/test_asciipar_loader.m
+++ b/_test/test_data_loaders/test_asciipar_loader.m
@@ -8,8 +8,8 @@ classdef test_asciipar_loader< TestCase
         %
         function obj=test_asciipar_loader(name)
             obj = obj@TestCase(name);
-            [~,tdp] = herbert_root();
-            obj.test_data_path = tdp;
+            pths = horace_paths;
+            obj.test_data_path = paths.test_common;
         end
 
         function test_constructors(obj)
@@ -330,4 +330,3 @@ classdef test_asciipar_loader< TestCase
         end
     end
 end
-

--- a/_test/test_data_loaders/test_asciipar_loader.m
+++ b/_test/test_data_loaders/test_asciipar_loader.m
@@ -9,7 +9,7 @@ classdef test_asciipar_loader< TestCase
         function obj=test_asciipar_loader(name)
             obj = obj@TestCase(name);
             pths = horace_paths;
-            obj.test_data_path = paths.test_common;
+            obj.test_data_path = pths.test_common;
         end
 
         function test_constructors(obj)

--- a/_test/test_data_loaders/test_gen_runfiles.m
+++ b/_test/test_data_loaders/test_gen_runfiles.m
@@ -29,8 +29,8 @@ classdef test_gen_runfiles< TestCase
                 name = 'test_gen_runfiles';
             end
             this = this@TestCase(name);
-            [~,tdp] = herbert_root();
-            this.test_data_path = tdp;
+            pths = horace_paths;
+            this.test_data_path = paths.test_common;
             this.wk_dir = tmp_dir;
 
             this.par_file = fullfile(this.test_data_path,'demo_par.par');
@@ -95,7 +95,7 @@ classdef test_gen_runfiles< TestCase
                 rd.ERR = ones(nen ,ndet);
                 rd.par_file_name = this.par_file;
                 rd.det_par = det_ld;
-                rd.do_check_combo_arg= true;                
+                rd.do_check_combo_arg= true;
                 rd = rd.check_combo_arg();
                 saveNxspe(this.test_files{i},rd)
             end

--- a/_test/test_data_loaders/test_gen_runfiles.m
+++ b/_test/test_data_loaders/test_gen_runfiles.m
@@ -30,7 +30,7 @@ classdef test_gen_runfiles< TestCase
             end
             this = this@TestCase(name);
             pths = horace_paths;
-            this.test_data_path = paths.test_common;
+            this.test_data_path = pths.test_common;
             this.wk_dir = tmp_dir;
 
             this.par_file = fullfile(this.test_data_path,'demo_par.par');

--- a/_test/test_data_loaders/test_loader_ascii.m
+++ b/_test/test_data_loaders/test_loader_ascii.m
@@ -14,7 +14,7 @@ classdef test_loader_ascii< TestCase
             end
             obj = obj@TestCase(name);
             pths = horace_paths;
-            obj.test_data_path = paths.test_common;
+            obj.test_data_path = pths.test_common;
         end
         function obj=setUp(obj)
             obj.log_level = get(herbert_config,'log_level');

--- a/_test/test_data_loaders/test_loader_ascii.m
+++ b/_test/test_data_loaders/test_loader_ascii.m
@@ -13,8 +13,8 @@ classdef test_loader_ascii< TestCase
                 name = 'test_loader_ascii';
             end
             obj = obj@TestCase(name);
-            [~,tdp] = herbert_root();
-            obj.test_data_path = tdp;
+            pths = horace_paths;
+            obj.test_data_path = paths.test_common;
         end
         function obj=setUp(obj)
             obj.log_level = get(herbert_config,'log_level');
@@ -60,7 +60,7 @@ classdef test_loader_ascii< TestCase
             par_file = fullfile(obj.test_data_path,obj.test_par_file);
             ld = loader_ascii(spe_file,par_file);
             [S,ERR,en,ld] = ld.load_data();
-            [par,ld] = ld.load_par(); 
+            [par,ld] = ld.load_par();
             S(:,1) = 1;
             ERR(:,1) = 1;
             en(10) = 100;
@@ -69,13 +69,13 @@ classdef test_loader_ascii< TestCase
             ld.ERR = ERR;
             ld.en = en;
             ld.det_par = par;
-            
+
             str = ld.to_struct();
             ld_rec = serializable.from_struct(str);
 
             assertEqual(ld,ld_rec);
         end
-        
+
 
         function test_saveload_loader_onfile(obj)
             spe_file = fullfile(obj.test_data_path,'MAP10001.spe');

--- a/_test/test_data_loaders/test_loader_nxspe.m
+++ b/_test/test_data_loaders/test_loader_nxspe.m
@@ -14,8 +14,8 @@ classdef test_loader_nxspe< TestCase
                 name = 'test_loader_nxspe';
             end
             obj = obj@TestCase(name);
-            [~,tdp] = herbert_root();
-            obj.test_data_path = tdp;
+            pths = horace_paths;
+            obj.test_data_path = paths.test_common;
         end
 
         function obj=setUp(obj)
@@ -491,4 +491,3 @@ classdef test_loader_nxspe< TestCase
 
     end
 end
-

--- a/_test/test_data_loaders/test_loader_nxspe.m
+++ b/_test/test_data_loaders/test_loader_nxspe.m
@@ -15,7 +15,7 @@ classdef test_loader_nxspe< TestCase
             end
             obj = obj@TestCase(name);
             pths = horace_paths;
-            obj.test_data_path = paths.test_common;
+            obj.test_data_path = pths.test_common;
         end
 
         function obj=setUp(obj)

--- a/_test/test_data_loaders/test_loader_utilites.m
+++ b/_test/test_data_loaders/test_loader_utilites.m
@@ -1,18 +1,18 @@
 classdef test_loader_utilites< TestCase
-    properties 
-          test_data_path;        
+    properties
+          test_data_path;
           log_level;
     end
-    methods       
-        % 
+    methods
+        %
         function fn=f_name(this,short_filename)
             fn = fullfile(this.test_data_path,short_filename);
         end
-        
+
         function this=test_loader_utilites(name)
             this = this@TestCase(name);
-            [~,tdp] = herbert_root();
-            this.test_data_path = tdp;
+            pths = horace_paths;
+            this.test_data_path = paths.test_common;
         end
         function this=setUp(this)
             this.log_level = get(herbert_config,'log_level');
@@ -21,64 +21,63 @@ classdef test_loader_utilites< TestCase
         function this=tearDown(this)
             set(herbert_config,'log_level',this.log_level,'-buffer');
         end
-        
+
         % tests themself
-        function test_FormatCurrentlyNotSupported(this)               
-            f = @()find_root_nexus_dir(f_name(this,'currently_not_supported_NXSPE.nxspe'),'NXSPE');        
+        function test_FormatCurrentlyNotSupported(this)
+            f = @()find_root_nexus_dir(f_name(this,'currently_not_supported_NXSPE.nxspe'),'NXSPE');
             % more then one nxspe folder is not supported at the moment
             assertExceptionThrown(f,'HERBERT:isis_utilities:invalid_argument');
-        end               
-        function test_CorrectHeader(this)       
+        end
+        function test_CorrectHeader(this)
             [result,version] = find_root_nexus_dir(f_name(this,'MAP11014.nxspe'),'NXSPE'); % file name has loose relation to the result
             assertEqual(result,'/11014.spe');
-            assertEqual(version,'1.1');            
-        end               
- % FIND_DATASET_INFO   
+            assertEqual(version,'1.1');
+        end
+ % FIND_DATASET_INFO
        function test_correct_Folder_found(this)
-            [DS_info,ds_path] = find_dataset_info(f_name(this,'MAP11014.nxspe'),'data',''); 
-            
+            [DS_info,ds_path] = find_dataset_info(f_name(this,'MAP11014.nxspe'),'data','');
+
             assertTrue(all(ismember(fieldnames(DS_info),...
             {'Filename' 'Name' 'Groups' 'Datasets' 'Datatypes' 'Links' 'Attributes'})));
-            assertEqual(ds_path,'/11014.spe/data');                              
+            assertEqual(ds_path,'/11014.spe/data');
        end
        function test_correct_DSinCorrectFolder_found(this)
-            [DS_info,ds_path] = find_dataset_info(f_name(this,'MAP11014.nxspe'),'data','data'); 
-            
+            [DS_info,ds_path] = find_dataset_info(f_name(this,'MAP11014.nxspe'),'data','data');
+
             assertEqual(DS_info.Dataspace.Size,[30,28160]);
-            assertEqual(ds_path,'/11014.spe/data/data');                              
-       end           
+            assertEqual(ds_path,'/11014.spe/data/data');
+       end
        function test_correct_DSinCorrect2Folder_found(this)
-            [DS_info,ds_path] = find_dataset_info(f_name(this,'MAP11014.nxspe'),'data','azimuthal'); 
-            
+            [DS_info,ds_path] = find_dataset_info(f_name(this,'MAP11014.nxspe'),'data','azimuthal');
+
             assertEqual(DS_info.Dataspace.Size,28160);
-            assertEqual(ds_path,'/11014.spe/data/azimuthal');                              
-       end     
+            assertEqual(ds_path,'/11014.spe/data/azimuthal');
+       end
       function test_correct_DS2_found(this)
-            [DS_info,ds_path] = find_dataset_info(f_name(this,'MAP11014.nxspe'),'','azimuthal'); 
-            
+            [DS_info,ds_path] = find_dataset_info(f_name(this,'MAP11014.nxspe'),'','azimuthal');
+
             assertEqual(DS_info.Dataspace.Size,28160);
-            assertEqual(ds_path,'/11014.spe/data/azimuthal');                              
-      end            
+            assertEqual(ds_path,'/11014.spe/data/azimuthal');
+      end
        function test_correct_DS3_found(this)
-            [DS_info,ds_path] = find_dataset_info(f_name(this,'group_search_tester.h5'),'','dsa1cgI4'); 
-            
+            [DS_info,ds_path] = find_dataset_info(f_name(this,'group_search_tester.h5'),'','dsa1cgI4');
+
             assertEqual(DS_info.Dataspace.Size,[2,2]);
-            assertEqual(ds_path,'/a1/cg/dsa1cgI4');                              
-       end           
+            assertEqual(ds_path,'/a1/cg/dsa1cgI4');
+       end
        function test_correct_Folder2_found(this)
-            [DS_info,ds_path] = find_dataset_info(f_name(this,'group_search_tester.h5'),'a3',''); 
-            
+            [DS_info,ds_path] = find_dataset_info(f_name(this,'group_search_tester.h5'),'a3','');
+
             assertTrue(all(ismember(fieldnames(DS_info),...
             {'Filename' 'Name' 'Groups' 'Datasets' 'Datatypes' 'Links' 'Attributes'})));
-            assertEqual(ds_path,'/a3');                              
-       end            
-       function test_correct_FolderInSubstr_found(this)       
+            assertEqual(ds_path,'/a3');
+       end
+       function test_correct_FolderInSubstr_found(this)
             [result,version,data_struct] = find_root_nexus_dir(f_name(this,'MAP11014.nxspe'),'NXSPE'); % file name has loose relation to the result
             assertEqual(result,'/11014.spe');
-            [DS_info,ds_path] = find_dataset_info(data_struct,'data','azimuthal');       
+            [DS_info,ds_path] = find_dataset_info(data_struct,'data','azimuthal');
             assertEqual(DS_info.Dataspace.Size,28160);
-            assertEqual(ds_path,'/11014.spe/data/azimuthal');                              
-       end   
+            assertEqual(ds_path,'/11014.spe/data/azimuthal');
+       end
     end
 end
-

--- a/_test/test_data_loaders/test_loader_utilites.m
+++ b/_test/test_data_loaders/test_loader_utilites.m
@@ -12,7 +12,7 @@ classdef test_loader_utilites< TestCase
         function this=test_loader_utilites(name)
             this = this@TestCase(name);
             pths = horace_paths;
-            this.test_data_path = paths.test_common;
+            this.test_data_path = pths.test_common;
         end
         function this=setUp(this)
             this.log_level = get(herbert_config,'log_level');

--- a/_test/test_data_loaders/test_loaders_factory.m
+++ b/_test/test_data_loaders/test_loaders_factory.m
@@ -6,32 +6,32 @@ classdef test_loaders_factory< TestCase
         %
         function this=test_loaders_factory(name)
             this = this@TestCase(name);
-            [~,tdp] = herbert_root();
-            this.test_data_path = tdp;
+            pths = horace_paths;
+            this.test_data_path = paths.test_common;
         end
-        
+
         function test_select_loader_throws(this)
             not_a_file = 'non_existing_file';
             not_a_data = fullfile(this.test_data_path,'map_4to1_jul09.par');
-            
-            
+
+
             f = @()loaders_factory.instance().get_loader(not_a_file);
             assertExceptionThrown(f,'LOADERS_FACTORY:get_loader');
             f = @()loaders_factory.instance().get_loader(not_a_data);
             assertExceptionThrown(f,'LOADERS_FACTORY:get_loader');
         end
-        
+
         function test_select_loader(this)
             ascii_spe  = fullfile(this.test_data_path,'MAP10001.spe');
             nxspe_f    = fullfile(this.test_data_path,'MAP11014v2.nxspe');
-            
-            
+
+
             asc_loader=loaders_factory.instance().get_loader(ascii_spe);
             nxspe_ld =  loaders_factory.instance().get_loader(nxspe_f);
-            
+
             assertTrue(isa(asc_loader,'loader_ascii'))
             assertTrue(isa(nxspe_ld,'loader_nxspe'))
         end
-        
+
     end
 end

--- a/_test/test_data_loaders/test_loaders_factory.m
+++ b/_test/test_data_loaders/test_loaders_factory.m
@@ -7,7 +7,7 @@ classdef test_loaders_factory< TestCase
         function this=test_loaders_factory(name)
             this = this@TestCase(name);
             pths = horace_paths;
-            this.test_data_path = paths.test_common;
+            this.test_data_path = pths.test_common;
         end
 
         function test_select_loader_throws(this)

--- a/_test/test_data_loaders/test_nxspepar_loader.m
+++ b/_test/test_data_loaders/test_nxspepar_loader.m
@@ -9,8 +9,8 @@ classdef test_nxspepar_loader< TestCase
                 name = 'test_nxspepar_loader';
             end
             this = this@TestCase(name);
-            [~,tdp] = herbert_root();
-            this.test_data_path = tdp;
+            pths = horace_paths;
+            this.test_data_path = paths.test_common;
         end
 
         function test_constr_missing_file_throws(~)
@@ -274,4 +274,3 @@ classdef test_nxspepar_loader< TestCase
         end
     end
 end
-

--- a/_test/test_data_loaders/test_nxspepar_loader.m
+++ b/_test/test_data_loaders/test_nxspepar_loader.m
@@ -10,7 +10,7 @@ classdef test_nxspepar_loader< TestCase
             end
             this = this@TestCase(name);
             pths = horace_paths;
-            this.test_data_path = paths.test_common;
+            this.test_data_path = pths.test_common;
         end
 
         function test_constr_missing_file_throws(~)

--- a/_test/test_data_loaders/test_rundata.m
+++ b/_test/test_data_loaders/test_rundata.m
@@ -19,7 +19,7 @@ classdef test_rundata< TestCase
             end
             obj = obj@TestCase(name);
             pths = horace_paths;
-            obj.test_data_path = paths.test_common;
+            obj.test_data_path = pths.test_common;
         end
         function obj=setUp(obj)
             obj.log_level = get(herbert_config,'log_level');

--- a/_test/test_data_loaders/test_rundata.m
+++ b/_test/test_data_loaders/test_rundata.m
@@ -18,8 +18,8 @@ classdef test_rundata< TestCase
                 name = 'test_rundata';
             end
             obj = obj@TestCase(name);
-            [~,tdp] = herbert_root();
-            obj.test_data_path = tdp;
+            pths = horace_paths;
+            obj.test_data_path = paths.test_common;
         end
         function obj=setUp(obj)
             obj.log_level = get(herbert_config,'log_level');
@@ -58,7 +58,7 @@ classdef test_rundata< TestCase
             assertTrue(rd.isvalid);
             %
             rd = get_rundata (rd,'-this');
-            assertTrue(rd.isvalid);            
+            assertTrue(rd.isvalid);
 
             tf = fullfile(tmp_dir,'test_custom_save_loadobj_all.mat');
             clob = onCleanup(@()delete(tf));

--- a/_test/test_data_loaders/test_rundataOldMatlab.m
+++ b/_test/test_data_loaders/test_rundataOldMatlab.m
@@ -2,24 +2,21 @@ function  test_rundataOldMatlab()
 %The test written in a way, it can run by old matlab and the new one (using
 %xUnittests to verify brifely old matlab consistency.
 %run=rundata();
-[~,path] = herbert_root();
+pths = horace_paths;
 
 
 log_level = get(herbert_config,'log_level');
 set(herbert_config,'log_level',-1,'-buffer');
 cleanupObj = onCleanup(@() set(herbert_config,'log_level',log_level,'-buffer'));
 
-run=rundata(fullfile(path,'MAP10001.spe'),fullfile(path,'demo_par.PAR'));
+run=rundata(fullfile(pths.test_common,'MAP10001.spe'),fullfile(pths.test_common,'demo_par.PAR'));
 run.efix = 200;
 run=get_rundata(run,'-this');
 assertTrue(run.isvalid)
 assertEqual(run.efix,200)
 
-run=rundata(fullfile(path,'MAP11014.nxspe'));
+run=rundata(fullfile(pths.test_common,'MAP11014.nxspe'));
 run.efix = 200;
 run=get_rundata(run,'-this');
 assertFalse(run.isvalid)
 assertEqual(run.efix,200)
-
-
-

--- a/_test/test_data_loaders/test_rundata_get.m
+++ b/_test/test_data_loaders/test_rundata_get.m
@@ -18,7 +18,7 @@ classdef test_rundata_get< TestCase
             this = this@TestCase(name);
             % define default rundata class instance
             pths = horace_paths;
-            this.test_data_path = paths.test_common;
+            this.test_data_path = pths.test_common;
 
             this.the_run = rundata(fullfile(this.test_data_path,'MAP11014.nxspe'));
             % from 01/04/2017 rundata needs minimal non-default oriented lattice to use

--- a/_test/test_data_loaders/test_rundata_get.m
+++ b/_test/test_data_loaders/test_rundata_get.m
@@ -17,8 +17,8 @@ classdef test_rundata_get< TestCase
         function this=test_rundata_get(name)
             this = this@TestCase(name);
             % define default rundata class instance
-            [~,tdp] = herbert_root();
-            this.test_data_path = tdp;
+            pths = horace_paths;
+            this.test_data_path = paths.test_common;
 
             this.the_run = rundata(fullfile(this.test_data_path,'MAP11014.nxspe'));
             % from 01/04/2017 rundata needs minimal non-default oriented lattice to use

--- a/_test/test_dnd/test_dnd_constructors.m
+++ b/_test/test_dnd/test_dnd_constructors.m
@@ -17,7 +17,7 @@ classdef test_dnd_constructors< TestCase
             end
             this=this@TestCase(name);
             pths = horace_paths;
-            this.test_data=fullfile(pths.root,'_test','test_combine');
+            this.test_data=fullfile(pths.test,'test_combine');
             this.common_data = pths.test_common;
         end
 

--- a/_test/test_dnd/test_dnd_constructors.m
+++ b/_test/test_dnd/test_dnd_constructors.m
@@ -1,26 +1,26 @@
 classdef test_dnd_constructors< TestCase
     %
     % Validate fast sqw reader used in combining sqw
-    
-    
+
+
     properties
         test_data
         common_data
     end
-    
+
     methods
-        
+
         %The above can now be read into the test routine directly.
         function this=test_dnd_constructors(name)
             if ~exist('name','var')
                 name = 'test_dnd_constructors';
             end
             this=this@TestCase(name);
-            hor_root = horace_root();
-            this.test_data=fullfile(hor_root,'_test/test_combine');
-            this.common_data = fullfile(hor_root,'_test/common_data');
+            pths = horace_paths;
+            this.test_data=fullfile(pths.root,'_test','test_combine');
+            this.common_data = pths.test_common;
         end
-        
+
         % tests
         function this = test_constructor(this)
             %Create empty object suitable for simulations:
@@ -33,9 +33,9 @@ classdef test_dnd_constructors< TestCase
             %  >> w = d2d (u0,...)         % u0 is offset of origin of dataset,
             %  >> w = d2d (lattice,...)    % Give lattice parameters [a,b,c,alf,bet,gam]
             %  >> w = d2d (lattice,u0,...) % Give u0 and lattice parameters
-            
-            
-            
+
+
+
             t2 = d2d();
             assertTrue(isa(t2,'d2d'))
             t2 = d2d(fullfile(this.test_data,'w2d_qq_d2d.sqw'));
@@ -44,11 +44,11 @@ classdef test_dnd_constructors< TestCase
             t2 = d2d([0,1,1,0],[1,0,0],[-2,0.05,2],[0,1,0],[-2,0.05,2]);
             assertTrue(isa(t2,'d2d'))
             assertEqual(t2.uoffset,[0;1;1;0]);
-            
+
         end
         function test_construct_array_from_multifiles(obj)
             file = fullfile(obj.test_data,'w2d_qq_d2d.sqw');
-            t2 = d2d({file,file});        
+            t2 = d2d({file,file});
             assertTrue(isa(t2,'d2d'))
             assertEqual(size(t2),[1,2]);
         end
@@ -59,7 +59,7 @@ classdef test_dnd_constructors< TestCase
             en = 0:2:20;
             rd = gen_nxspe(S,ERR,en,par_file,'',20,1,2);
             sqw_obj = rd.calc_sqw([]);
-            
+
             dnd_obj = dnd(sqw_obj);
             assertEqual(sqw_obj.data.s,dnd_obj.s);
             assertEqual(sqw_obj.data.e,dnd_obj.e);
@@ -77,7 +77,7 @@ classdef test_dnd_constructors< TestCase
             rd = gen_nxspe(S,ERR,en,par_file,'',20,1,2);
             sqw_obj2 = rd.calc_sqw([]);
             sqw_obj = [sqw_obj1,sqw_obj2];
-            
+
             % check dnd array conversion
             dnd_obj = dnd(sqw_obj);
             assertEqual(size(sqw_obj),size(dnd_obj));
@@ -85,7 +85,7 @@ classdef test_dnd_constructors< TestCase
             assertEqual(sqw_obj(1).data.e,dnd_obj(1).e);
             assertEqual(sqw_obj(2).data.s,dnd_obj(2).s);
             assertEqual(sqw_obj(2).data.e,dnd_obj(2).e);
-            
+
             % check d4d array conversion
             dnd_obj = d4d(sqw_obj);
             assertEqual(size(sqw_obj),size(dnd_obj));
@@ -93,14 +93,12 @@ classdef test_dnd_constructors< TestCase
             assertEqual(sqw_obj(1).data.e,dnd_obj(1).e);
             assertEqual(sqw_obj(2).data.s,dnd_obj(2).s);
             assertEqual(sqw_obj(2).data.e,dnd_obj(2).e);
-            
+
             % check d4d->d2d conversion fails
             f = @()d2d(sqw_obj);
             assertExceptionThrown(f,'HORACE:DnDBase:invalid_argument');
         end
-        
-        
+
+
     end
 end
-
-

--- a/_test/test_gen_sqw_for_powders/test_combine_cyl.m
+++ b/_test/test_gen_sqw_for_powders/test_combine_cyl.m
@@ -6,7 +6,7 @@ classdef test_combine_cyl < TestCaseWithSave
     %                                  % for information about the system specific location returned by tmp_dir)
     %
     % Author: T.G.Perring
-    
+
     properties
         spe_file_1;
         spe_file_2;
@@ -26,10 +26,10 @@ classdef test_combine_cyl < TestCaseWithSave
                 name= mfilename('class');
             end
             obj = obj@TestCaseWithSave(name,fullfile(fileparts(mfilename('fullpath')),'test_combine_cyl_output.mat'));
-            hor_root = horace_root();
-            common_data_dir=fullfile(hor_root,'_test','common_data');
-           
-            
+            pths = horace_paths;
+            common_data_dir = pths.test_common;
+
+
             % =====================================================================================================================
             % Create spe files:
             obj.par_file=fullfile(common_data_dir,'map_4to1_dec09.par');
@@ -37,7 +37,7 @@ classdef test_combine_cyl < TestCaseWithSave
             spe_dir = fileparts(mfilename('fullpath'));
             obj.spe_file_1=fullfile(spe_dir,'test_combine_1.nxspe');
             obj.spe_file_2=fullfile(spe_dir,'test_combine_2.nxspe');
-            
+
             obj.efix=100;
             emode=1;
             obj.alatt=2*pi*[1,1,1];
@@ -45,12 +45,12 @@ classdef test_combine_cyl < TestCaseWithSave
             u=[1,0,0];
             v=[0,1,0];
             omega=0; dpsi=0; gl=0; gs=0;
-            
+
             % Simulate first file, with reproducible random looking noise
             % -----------------------------------------------------------
             en=-5:1:90;
             obj.psi_1=0;
-            
+
             if ~exist(obj.spe_file_1,'file')
                 simulate_spe_testfunc (en, obj.par_file, obj.spe_file_1, @sqw_cylinder, [10,1], 0.3,...
                     obj.efix, emode, obj.alatt, angdeg, u, v, obj.psi_1, omega, dpsi, gl, gs)
@@ -63,28 +63,28 @@ classdef test_combine_cyl < TestCaseWithSave
                 simulate_spe_testfunc (en, obj.par_file, obj.spe_file_2, @sqw_cylinder, [10,1], 0.3,...
                     obj.efix, emode, obj.alatt, angdeg, u, v, obj.psi_2, omega, dpsi, gl, gs)
             end
-            
+
             obj.save();
         end
-        
+
         function this=test_combine_cyl1(this)
             % Create sqw files, combine and check results
             % -------------------------------------------
             sqw_file_1=fullfile(tmp_dir,'test_cyl_1.sqw');
             % clean up
             cleanup_obj=onCleanup(@()this.delete_files(sqw_file_1));
-            
+
             emode = 1;
-            
+
             gen_sqw_cylinder(this.spe_file_1, this.par_file, sqw_file_1, this.efix, emode, this.alatt(3), this.psi_1, 90, 0);
-            
+
             w2_1 = cut_sqw(sqw_file_1,0.1,0.1,[40,50],'-nopix');
             w1_1 = cut_sqw(sqw_file_1,[0,0.1,3],[2.2,2.5],[40,50],'-nopix');
-            
-            
+
+
             this.assertEqualToTolWithSave(w2_1,'ignore_str',true,'tol',3.e-7);
             this.assertEqualToTolWithSave(w1_1,'ignore_str',true,'tol',3.e-7);
-            
+
             %--------------------------------------------------------------------------------------------------
             % Visually inspect
             acolor k
@@ -94,7 +94,7 @@ classdef test_combine_cyl < TestCaseWithSave
             % acolor r
             % pd(w1_tot)  % does not overlay - but that is OK
             %--------------------------------------------------------------------------------------------------
-            
+
         end
         function this=test_combine_cyl2(this)
             % Create sqw files, combine and check results
@@ -102,20 +102,20 @@ classdef test_combine_cyl < TestCaseWithSave
             sqw_file_2=fullfile(tmp_dir,'test_cyl_2.sqw');
             % clean up
             cleanup_obj=onCleanup(@()this.delete_files(sqw_file_2));
-            
+
             emode = 1;
-            
+
             gen_sqw_cylinder(this.spe_file_2, this.par_file, ...
                 sqw_file_2, this.efix, emode, this.alatt(3), this.psi_2, 90, 0);
-            
+
             w2_2=cut_sqw(sqw_file_2,0.1,0.1,[40,50],'-nopix');
-            
+
             w1_2=cut_sqw(sqw_file_2,[0,0.1,3],[2.2,2.5],[40,50],'-nopix');
-            
-            
+
+
             this.assertEqualToTolWithSave(w2_2,'ignore_str',true,'tol',3.e-7);
             this.assertEqualToTolWithSave(w1_2,'ignore_str',true,'tol',3.e-7);
-            
+
             %--------------------------------------------------------------------------------------------------
             % Visually inspect
             acolor k
@@ -132,21 +132,21 @@ classdef test_combine_cyl < TestCaseWithSave
             sqw_file_tot=fullfile(tmp_dir,'test_cyl_tot.sqw');
             % clean up
             cleanup_obj=onCleanup(@()this.delete_files(sqw_file_tot));
-            
+
             emode = 1;
             gen_sqw_cylinder({this.spe_file_1,this.spe_file_2}, ...
                 this.par_file, sqw_file_tot, this.efix, emode, this.alatt(3), [this.psi_1,this.psi_2], 90, 0);
-            
+
             w2_tot=cut_sqw(sqw_file_tot,0.1,0.1,[40,50],'-nopix');
-            
+
             w1_tot=cut_sqw(sqw_file_tot,[0,0.1,3],[2.2,2.5],[40,50],'-nopix');
-            
-            
+
+
             this.assertEqualToTolWithSave(w2_tot,'ignore_str',true, ...
                 'tol',[1.e-7,1.e-7]);
             this.assertEqualToTolWithSave(w1_tot,'ignore_str',true, ...
                 'tol',[1.e-7,1.e-7]);
-            
+
             %--------------------------------------------------------------------------------------------------
             % Visually inspect
             acolor k

--- a/_test/test_gen_sqw_for_powders/test_combine_pow.m
+++ b/_test/test_gen_sqw_for_powders/test_combine_pow.m
@@ -26,8 +26,8 @@ classdef test_combine_pow < TestCaseWithSave
                 name= mfilename('class');
             end
             this = this@TestCaseWithSave(name,fullfile(fileparts(mfilename('fullpath')),'test_combine_pow_output.mat'));
-            hor_root = horace_root();
-            common_data_dir=fullfile(hor_root,'_test','common_data');
+            pths = horace_paths;
+            common_data_dir = pths.test_common;
 
 
             % =====================================================================================================================

--- a/_test/test_gen_sqw_for_powders/test_gen_sqw_cylinder.m
+++ b/_test/test_gen_sqw_for_powders/test_gen_sqw_cylinder.m
@@ -23,8 +23,8 @@ classdef test_gen_sqw_cylinder < TestCaseWithSave
                 name= mfilename('class');
             end
             this = this@TestCaseWithSave(name,fullfile(fileparts(mfilename('fullpath')),'test_gen_sqw_cylinder_output.mat'));
-            hor_root = horace_root();
-            common_data_dir=fullfile(hor_root,'_test','common_data');
+            pths = horace_paths;
+            common_data_dir = pths.test_common;
 
 
             % =====================================================================================================================

--- a/_test/test_gen_sqw_for_powders/test_gen_sqw_powder.m
+++ b/_test/test_gen_sqw_for_powders/test_gen_sqw_powder.m
@@ -31,8 +31,8 @@ classdef test_gen_sqw_powder < TestCaseWithSave
 
             % -----------------------------------------------------------------------------
             % Add common functions folder to path, and get location of common data
-            hor_root = horace_root();
-            common_data_dir = fullfile(hor_root, '_test', 'common_data');
+            pths = horace_paths;
+            common_data_dir = pths.test_common;
             % -----------------------------------------------------------------------------
             hcfg=herbert_config();
             current = hcfg.use_mex;

--- a/_test/test_gen_sqw_workflow/gen_sqw_accumulate_sqw_tests_common.m
+++ b/_test/test_gen_sqw_workflow/gen_sqw_accumulate_sqw_tests_common.m
@@ -69,7 +69,7 @@ classdef gen_sqw_accumulate_sqw_tests_common < TestCaseWithSave
                 [fpath,fn,~] = fileparts(fls);
                 flt = fullfile(fpath,[fn,new_ext]);
                 new_names{i} = flt;
-                if exist(fls,'file')==2
+                if is_file(fls)
                     movefile(fls,flt,'f');
                 end
             end
@@ -101,8 +101,9 @@ classdef gen_sqw_accumulate_sqw_tests_common < TestCaseWithSave
             % do other initialization
             obj.comparison_par={ 'min_denominator', 0.01, 'ignore_str', 1};
             obj.tol = 1.e-5;
-            hor_root= horace_root();
-            obj.test_functions_path=fullfile(hor_root,'_test/common_functions');
+
+            pths = horace_paths;
+            obj.test_functions_path = pths.test_common_func;
 
             addpath(obj.test_functions_path);
 
@@ -112,7 +113,8 @@ classdef gen_sqw_accumulate_sqw_tests_common < TestCaseWithSave
             else
                 obj.working_dir = obj.new_working_folder;
             end
-            if ~(exist(obj.working_dir,'dir') == 7)
+
+            if ~is_folder(obj.working_dir)
                 mkdir(obj.working_dir);
             end
 

--- a/_test/test_instrument_classes/test_oriented_lattice.m
+++ b/_test/test_instrument_classes/test_oriented_lattice.m
@@ -15,7 +15,7 @@ classdef test_oriented_lattice< TestCase
             end
             this = this@TestCase(name);
             pths = horace_paths;
-            this.test_data_path = paths.test_common;
+            this.test_data_path = pths.test_common;
         end
 
         function test_constructor_defaults(~)

--- a/_test/test_instrument_classes/test_oriented_lattice.m
+++ b/_test/test_instrument_classes/test_oriented_lattice.m
@@ -14,8 +14,8 @@ classdef test_oriented_lattice< TestCase
                 name = varargin{1};
             end
             this = this@TestCase(name);
-            [~,tdp] = herbert_root();
-            this.test_data_path = tdp;
+            pths = horace_paths;
+            this.test_data_path = paths.test_common;
         end
 
         function test_constructor_defaults(~)
@@ -40,13 +40,13 @@ classdef test_oriented_lattice< TestCase
             assertEqual(ol.reason_for_invalid,'empty lattice is invalid')
 
             ol.alatt = [1,2,3];
-            assertFalse(ol.isvalid);            
+            assertFalse(ol.isvalid);
             assertTrue(strncmp(ol.reason_for_invalid, ...
-                'The necessary field(s):',23))            
+                'The necessary field(s):',23))
             ol.angdeg = [90,90,90];
             ol.psi = 0;
             assertTrue(ol.isvalid);
-            assertTrue(isempty(ol.reason_for_invalid))            
+            assertTrue(isempty(ol.reason_for_invalid))
 
         end
         %
@@ -212,7 +212,7 @@ classdef test_oriented_lattice< TestCase
             mult = pi/180;
             ol = oriented_lattice('alatt',[2;3;4],'psi',20*mult,...
                 'gl',3*mult,'angdeg',[40,45,50]*mult,'angular_units','rad');
-            
+
             assertTrue(ol.isvalid);
 
             assertTrue(ol.is_defined('psi'));

--- a/_test/test_mex_nomex/test_fake_sqw_bin_pix.m
+++ b/_test/test_mex_nomex/test_fake_sqw_bin_pix.m
@@ -29,8 +29,8 @@ classdef test_fake_sqw_bin_pix < TestCase
                 this.skip_this_test= true;
             end
             this.tmp_data_folder = tmp_dir;
-            root_dir = horace_root();
-            this.sample_dir = fullfile(root_dir,'_test','common_data');
+            pths = horace_paths;
+            this.sample_dir = pths.test_common;
         end
         function test_bin_c(this)
             if this.skip_this_test

--- a/_test/test_mex_nomex/test_main_mex.m
+++ b/_test/test_mex_nomex/test_main_mex.m
@@ -23,11 +23,12 @@ classdef test_main_mex < TestCase
             end
             this = this@TestCase(name);
 
-            root_folder = horace_root();
+            pths = horace_paths;
+
             if ispc
-                this.accum_cut_folder=fullfile(root_folder,'horace_core','\@sqw');
+                this.accum_cut_folder=fullfile(pths.horace,'\@sqw');
             else
-                this.accum_cut_folder=fullfile(root_folder,'horace_core','@sqw');
+                this.accum_cut_folder=fullfile(pths.horace,'@sqw');
             end
             this.this_folder = fileparts(which('test_main_mex.m'));
             this.curr_folder = pwd();

--- a/_test/test_sqw/test_data_sqw_dnd.m
+++ b/_test/test_sqw/test_data_sqw_dnd.m
@@ -20,8 +20,8 @@ classdef test_data_sqw_dnd < TestCaseWithSave
             % to support loading the previous version
             obj = obj@TestCaseWithSave(name,'data_sqw_dnd_V1_ref_data.mat');
 
-            root_dir = horace_root();
-            data_dir = fullfile(root_dir,'_test','common_data');
+            pths = horace_paths;
+            data_dir = pths.test_common;
             obj.par_file =  fullfile(data_dir,obj.par_file);
             ref_sqw = fake_sqw(-80:8:760, obj.par_file, '', 800,...
                 1, [2,2.5,2], [95,110,90],...
@@ -206,9 +206,9 @@ classdef test_data_sqw_dnd < TestCaseWithSave
                 sum(reshape(same_sqw.data.npix,1,cut_size)));
             assertEqual(sum(reshape(obj.ref_sqw.data.s,1,cut_size)),...
                 sum(reshape(same_sqw.data.s,1,cut_size)));
-            % This is the full comparison. The creation date is different 
+            % This is the full comparison. The creation date is different
             % as cut is the same but created at different time
-            same_sqw.main_header.creation_date = obj.ref_sqw.main_header.creation_date;            
+            same_sqw.main_header.creation_date = obj.ref_sqw.main_header.creation_date;
             assertEqualToTol(obj.ref_sqw,same_sqw,'tol',[2.e-15,3.e-16])
 
             same_proj = same_sqw.data.get_projection();

--- a/_test/test_sqw/test_gen_runfiles.m
+++ b/_test/test_sqw/test_gen_runfiles.m
@@ -11,14 +11,14 @@ classdef test_gen_runfiles < TestCase
 
             % -----------------------------------------------------------------------------
             % Add common functions folder to path, and get location of common data
-            hor_root = horace_root();
-            addpath(fullfile(hor_root, '_test', 'common_functions'))
-            obj.common_data_dir = fullfile(hor_root, '_test', 'common_data');
+            pths = horace_paths;
+            addpath(pths.test_common_func);
+            obj.common_data_dir = pths.test_common;
             % -----------------------------------------------------------------------------
         end
 
         function test_gen_sqw_serial(obj)
-            
+
             % This test should always run serially
             % test_gen_sqw_accumulate_sqw_<framework> tests in parallel
             hpc = hpc_config;

--- a/_test/test_sqw/test_rundata_vs_sqw.m
+++ b/_test/test_sqw/test_rundata_vs_sqw.m
@@ -43,8 +43,8 @@ classdef test_rundata_vs_sqw < TestCaseWithSave & common_state_holder
             ref_data = fullfile(fileparts(this_folder),'common_data','rundata_vs_sqw_refdata.mat');
             this = this@TestCaseWithSave(name,ref_data);
             %
-            root_dir = horace_root();
-            data_dir = fullfile(root_dir,'_test','common_data');
+            pths = horace_paths;
+            data_dir = pths.test_common;
             this.sqw_file_single = fullfile(this.out_dir,this.sqw_file_single);
             this.par_file = fullfile(data_dir,this.par_file);
             if this.save_file
@@ -183,8 +183,8 @@ classdef test_rundata_vs_sqw < TestCaseWithSave & common_state_holder
         end
         %
         function test_rundata_sqw(obj)
-            test_file = fullfile(horace_root(),...
-                '_test','common_data','MAP11014.nxspe');
+            pths = horace_paths;
+            test_file = fullfile(pths.test_common,'MAP11014.nxspe');
             ds = struct('alatt',[2.63,2.63,2.63],'angdeg',[90,90,90],...
                 'u',[1,0,0],'v',[0,1,0]);
 

--- a/_test/test_sqw/test_rundata_vs_sqw.m
+++ b/_test/test_sqw/test_rundata_vs_sqw.m
@@ -210,8 +210,8 @@ classdef test_rundata_vs_sqw < TestCaseWithSave & common_state_holder
         end
         %
         function test_rundata_mex_nomex(~)
-            test_file = fullfile(horace_root(),...
-                '_test','common_data','MAP11014.nxspe');
+            pths = horace_paths;
+            test_file = fullfile(pths.test_common,'MAP11014.nxspe');
             ds = struct('alatt',[2.63,2.63,2.63],'angdeg',[97,60,80],...
                 'u',[1,0,0],'v',[0,1,0]);
 

--- a/_test/test_sqw/test_sqw_dnd_eval.m
+++ b/_test/test_sqw/test_sqw_dnd_eval.m
@@ -14,11 +14,13 @@ classdef test_sqw_dnd_eval < TestCase
                 name = 'test_sqw_dnd_eval';
             end
             obj = obj@TestCase(name);
-            obj.data_dir = fullfile(horace_root(),'_test','common_data');
+            pths = horace_paths;
+            obj.data_dir = pths.test_common;
             test_sqw_file = fullfile(obj.data_dir,'sqw_2d_2.sqw');
             obj.sqw_4_test = sqw(test_sqw_file);
             obj.dnd_4_test = read_dnd(test_sqw_file);
         end
+
         function test_tobyfit(obj)
             %
             sample=IX_sample(true,[1,0,0],[0,1,0],'cuboid',[0.04,0.03,0.02]);

--- a/_test/test_sqw_file/test_pix_combine_info.m
+++ b/_test/test_sqw_file/test_pix_combine_info.m
@@ -9,7 +9,7 @@ classdef test_pix_combine_info < TestCase & common_sqw_file_state_holder
         ref_pix_range
         cleanup_ob1
     end
-    
+
     methods
         function obj=test_pix_combine_info(test_class_name)
             %
@@ -18,23 +18,24 @@ classdef test_pix_combine_info < TestCase & common_sqw_file_state_holder
             end
             obj = obj@TestCase(test_class_name);
             data_path= fullfile(fileparts(mfilename('fullpath')),'TestData');
-            
+
             obj.data_path = data_path;
-            source_test_dir = fullfile(horace_root(),'_test','common_data');
+            pths = horace_paths;
+            source_test_dir = pths.test_common;
             source_file = fullfile(source_test_dir,'MAP11014.nxspe');
             target_file = fullfile(tmp_dir,'TPC11014.nxspe');
             copyfile(source_file,target_file,'f');
-            
+
             psi = [0,2,20]; %-- test settings;
             %psi = 0:1:200;  %-- evaluate_performance settings;
             source_test_file  = cell(1,numel(psi));
             for i=1:numel(psi)
                 source_test_file{i}  = target_file;
             end
-            
+
             wk_dir = tmp_dir;
             targ_file =fullfile(wk_dir,'never_created_sqw.sqw');
-            
+
             hc = hor_config;
             hc.saveable = false;
             del_tmp_state = hc.delete_tmp;
@@ -51,8 +52,8 @@ classdef test_pix_combine_info < TestCase & common_sqw_file_state_holder
             hpc.combine_sqw_using  = 'matlab';
             clob2 = onCleanup(@()set(hpc,'build_sqw_in_parallel',comb_state,...
                 'combine_sqw_using',combine_sqw_using));
-            
-            
+
+
             [temp_files,~,obj.ref_pix_range]=gen_sqw(source_test_file,'',targ_file,...
                 787.,1,[2.87,2.87,2.87],[90,90,90],...
                 [1,0,0],[0,1,0],psi,0,0,0,0,'replicate','tmp_only');
@@ -63,15 +64,15 @@ classdef test_pix_combine_info < TestCase & common_sqw_file_state_holder
         %
         function test_pix_range(obj)
             tester = pix_combine_info(obj.test_souce_files);
-            
+
             assertEqual(tester.pix_range,PixelData.EMPTY_RANGE_);
-            
+
             tester = tester.recalc_pix_range();
-            
+
             assertElementsAlmostEqual(tester.pix_range,obj.ref_pix_range,'relative',1.e-6);
         end
         %
-        
+
         %
     end
 end

--- a/_test/test_utilities_herbert/test_nexus_root.m
+++ b/_test/test_utilities_herbert/test_nexus_root.m
@@ -10,31 +10,32 @@ classdef test_nexus_root< TestCase
                 name = varargin{1};
             end
             obj = obj@TestCase(name);
-            obj.common_data_folder = fullfile(herbert_root(),'_test','common_data');
+            pths = horace_paths;
+            obj.common_data_folder = pths.test_common;
         end
         function test_dataset_info_file(obj)
             test_file = fullfile(obj.common_data_folder,'MAP11014.nxspe');
-            
+
             [root_nx_path,data_version,data_struc] = find_root_nexus_dir(test_file);
-            
+
             assertEqual(root_nx_path,'/11014.spe');
             assertEqual(data_version,'1.1');
-            
+
             [dsi_struc,data_path] = find_dataset_info(test_file,'11014.spe');
             assertEqual(data_path,'/11014.spe');
             assertEqual(data_struc.Groups,dsi_struc);
-            
+
         end
-        
-        
+
+
         function test_dataset_info_all(obj)
             test_file = fullfile(obj.common_data_folder,'MAP11014.nxspe');
-            
+
             [root_nx_path,data_version,data_struc] = find_root_nexus_dir(test_file);
-            
+
             assertEqual(root_nx_path,'/11014.spe');
             assertEqual(data_version,'1.1');
-            
+
             [dataset_structure,ds_grouppath] = find_dataset_info(data_struc,'11014.spe');
             assertEqual(ds_grouppath,'/11014.spe');
             assertEqual(numel(dataset_structure.Groups),4)
@@ -44,70 +45,70 @@ classdef test_nexus_root< TestCase
         %
         function test_dataset_info(obj)
             test_file = fullfile(obj.common_data_folder,'MAP11014.nxspe');
-            
+
             [root_nx_path,data_version,data_struc] = find_root_nexus_dir(test_file);
-            
+
             assertEqual(root_nx_path,'/11014.spe');
             assertEqual(data_version,'1.1');
-            
+
             [dataset_structure,ds_grouppath] = find_dataset_info(data_struc,'11014.spe');
             assertEqual(ds_grouppath,'/11014.spe');
             [dataset_info,ds_grouppath] = find_dataset_info(dataset_structure,'data','data');
             assertEqual(ds_grouppath,'/11014.spe/data/data');
             assertEqual(dataset_info.Name,'data');
             assertEqual(dataset_info.Dataspace.Size,[30 28160]);
-            
+
             [dataset_info,ds_grouppath] = find_dataset_info(dataset_structure,'data','polar');
             assertEqual(ds_grouppath,'/11014.spe/data/polar');
             assertEqual(dataset_info.Name,'polar');
             assertEqual(dataset_info.Dataspace.Size,28160);
-            
-            
+
+
             [dataset_info,ds_grouppath] = find_dataset_info(dataset_structure,'fermi','energy');
             assertEqual(ds_grouppath,'/11014.spe/instrument/fermi/energy');
             assertEqual(dataset_info.Name,'energy');
             assertEqual(dataset_info.Dataspace.Size,1);
-            
+
             [dataset_info,ds_grouppath] = find_dataset_info(dataset_structure,'fermi','non_existing');
             assertTrue(isempty(ds_grouppath));
             assertEqual(dataset_info,dataset_structure);
-            
+
             [dataset_info,ds_grouppath] = find_dataset_info(dataset_structure,'non_existing','energy');
             assertTrue(isempty(ds_grouppath));
             assertEqual(dataset_info,dataset_structure);
-            
+
         end
         %
         function test_find_root(obj)
             test_file = fullfile(obj.common_data_folder,'MAP11014.nxspe');
-            
+
             [root_nx_path,data_version] = find_root_nexus_dir(test_file);
-            
+
             assertEqual(root_nx_path,'/11014.spe');
             assertEqual(data_version,'1.1');
         end
         %
         function test_two_groups_fails(obj)
             test_file = fullfile(obj.common_data_folder,'currently_not_supported_NXSPE.nxspe');
-            
+
             f = @()find_root_nexus_dir(test_file);
-            
+
             assertExceptionThrown(f,'HERBERT:isis_utilities:invalid_argument');
         end
         %
         function test_two_groups_tested(obj)
             test_file = fullfile(obj.common_data_folder,'currently_not_supported_NXSPE.nxspe');
-            
+
             [root_nx_path,data_version] =...
                 find_root_nexus_dir(test_file,'NXSPE','test_mode');
             assertEqual(numel(root_nx_path),2);
             assertEqual(numel(data_version),2);
             assertEqual(root_nx_path{1},'/11014.spe');
             assertEqual(data_version{1},'1.1');
-            
+
             assertEqual(root_nx_path{2},'/testNXSPEgroup');
             assertEqual(data_version{2},'1.');
-            
+
         end
         %
         function test_not_nexust_hdf(obj)
@@ -115,8 +116,7 @@ classdef test_nexus_root< TestCase
             f = @()find_root_nexus_dir(test_file);
             assertExceptionThrown(f,'HERBERT:isis_utilities:invalid_argument');
         end
-        
-        
+
+
     end
 end
-

--- a/admin/herbert_mex_mpi.m
+++ b/admin/herbert_mex_mpi.m
@@ -21,7 +21,7 @@ if ispc()
         mpi_lib_folder = fullfile(mpi_folder,'lib');
 
     else
-        % let's use Microsoft MPI, compartible with mpich
+        % use Microsoft MPI, compatible with mpich
         mpi_folder = 'C:\programming\MS_MPI_sdk';
         mpi_lib_folder = fullfile(mpi_folder,'lib','x64');
         mpi_hdrs_folder = fullfile(mpi_folder,'include');
@@ -29,7 +29,7 @@ if ispc()
     mpi_lib_2use ={'msmpi.lib'};
 elseif isunix()
     if use_her_mpich
-        % let's use MPICH
+        % use MPICH
         %mpi_folder = '/usr/local/mpich/';
         mpi_folder = fullfile(pths.low_level,'external','glnxa64','mpich-3.3a2');
         mpi_hdrs_folder = fullfile(mpi_folder,'include');
@@ -44,11 +44,12 @@ elseif isunix()
     %mpi_folder = '/home/isis_direct_soft/mpich/';
 
     mpi_lib_folder = fullfile(mpi_folder,'lib');
-    %
+
 else
     error('HERBERT_MEX_MPI:not_implemented',...
         'Mac build is not implemented. Use cmake');
 end
+
 % Executable part
 ok = true;
 mess = [];

--- a/admin/herbert_mex_mpi.m
+++ b/admin/herbert_mex_mpi.m
@@ -6,11 +6,9 @@ function [ok,mess] = herbert_mex_mpi(varargin)
 % system.
 %
 use_her_mpich = true;
-if nargin > 0
-    verbose = true;
-else
-    verbose = false;
-end
+verbose = nargin > 0;
+pths = horace_paths;
+
 % the files, contributing into the communicator.
 input_files = {'cpp_communicator.cpp', 'input_parser.cpp', 'MPI_wrapper.cpp'};
 % Dependency set-up part
@@ -18,33 +16,33 @@ opt_file = '';
 
 if ispc()
     if use_her_mpich
-        mpi_folder = fullfile(herbert_root(), '_LowLevelCode/external/win64/MSMPI-8.0.12/');
-        mpi_hdrs_folder    = fullfile(mpi_folder,'include');
+        mpi_folder = fullfile(pths.low_level,'external','win64','MSMPI-8.0.12');
+        mpi_hdrs_folder = fullfile(mpi_folder,'include');
         mpi_lib_folder = fullfile(mpi_folder,'lib');
-        
+
     else
-        % let's use Microsof MPI, compartible with mpich
+        % let's use Microsoft MPI, compartible with mpich
         mpi_folder = 'C:\programming\MS_MPI_sdk';
         mpi_lib_folder = fullfile(mpi_folder,'lib','x64');
-        mpi_hdrs_folder    = fullfile(mpi_folder,'include');
+        mpi_hdrs_folder = fullfile(mpi_folder,'include');
     end
     mpi_lib_2use ={'msmpi.lib'};
 elseif isunix()
     if use_her_mpich
         % let's use MPICH
         %mpi_folder = '/usr/local/mpich/';
-        mpi_folder = fullfile(herbert_root(), '_LowLevelCode/external/glnxa64/mpich-3.3a2/');
-        mpi_hdrs_folder    = fullfile(mpi_folder,'include');
+        mpi_folder = fullfile(pths.low_level,'external','glnxa64','mpich-3.3a2');
+        mpi_hdrs_folder = fullfile(mpi_folder,'include');
         % .a also possible
-        mpi_lib_2use ={'libmpi.so','libmpich.so','libmpicxx.so'};
+        mpi_lib_2use = {'libmpi.so','libmpich.so','libmpicxx.so'};
     else
-        %opt_file = fullfile(herbert_root(),'admin/_compiler_settings/Matlab2020a/mex_C++openmpi_glnxa64.xml');
+        %opt_file = fullfile(pths.admin, '_compiler_settings','Matlab2020a','mex_C++openmpi_glnxa64.xml');
         mpi_folder = '/usr/lib64/mpich-3.2/';
-        mpi_hdrs_folder='/usr/include/mpich-3.2-x86_64/';
-        mpi_lib_2use ={'libmpicxx.so','libmpi.so'};
+        mpi_hdrs_folder = '/usr/include/mpich-3.2-x86_64/';
+        mpi_lib_2use = {'libmpicxx.so','libmpi.so'};
     end
     %mpi_folder = '/home/isis_direct_soft/mpich/';
-    
+
     mpi_lib_folder = fullfile(mpi_folder,'lib');
     %
 else
@@ -54,14 +52,11 @@ end
 % Executable part
 ok = true;
 mess = [];
-mpi_lib = cellfun(@(x)fullfile(mpi_lib_folder,x),mpi_lib_2use,...
-    'UniformOutput',false);
-
+mpi_lib = fullfile(mpi_lib_folder,mpi_lib_2use);
 
 % code folder:
-her_folder = herbert_root();
-code_folder = fullfile(her_folder,'_LowLevelCode','cpp','cpp_communicator');
-input_files = cellfun(@(fn)fullfile(code_folder,fn),input_files,'UniformOutput',false);
+code_folder = fullfile(pths.low_level,'cpp','cpp_communicator');
+input_files = fullfile(code_folder,input_files);
 
 % additional include folder, containing mpich
 add_include = ['-I',mpi_hdrs_folder];
@@ -70,9 +65,9 @@ if verbose
 else
     add_include = {add_include};
 end
-outdir = fullfile(her_folder,'herbert_core','DLL',['_',computer],'_R2015a');
+outdir = fullfile(pths.herbert,'DLL',['_',computer],'_R2015a');
 
-build_version_h(her_folder)
+build_version_h(pths.root)
 try
     opt = sprintf('CXXFLAGS=$CFLAGS -fopenmp -std=c++11 -Wl,-rpath=%s,--enable-new-dtags,--no-undefined,-fopenmp',mpi_lib_folder);
     if isempty(opt_file)

--- a/admin/horace_mex.m
+++ b/admin/horace_mex.m
@@ -32,9 +32,9 @@ end
 hdf_version = ma+0.1*me+0.001*mi;
 build_hdf_reader= true;
 if hdf_version == 1.812
-    hdf_root_dir = fullfile(root_dir,'_LowLevelCode','external',['HDF5_1.8.12',hdf_ext]);
+    hdf_root_dir = fullfile(pths.low_level,'external',['HDF5_1.8.12',hdf_ext]);
 elseif hdf_version == 1.806
-    hdf_root_dir = fullfile(root_dir,'_LowLevelCode','external',['HDF5_1.8.6',hdf_ext]);
+    hdf_root_dir = fullfile(pths.low_level,'external',['HDF5_1.8.6',hdf_ext]);
 else
     build_hdf_reader = false;
     warning('HORACE_MEX:not_implemented',...

--- a/admin/horace_mex.m
+++ b/admin/horace_mex.m
@@ -11,7 +11,8 @@ function horace_mex
 
 start_dir=pwd;
 C_compiled=false;
-root_dir = horace_root();
+pths = horace_paths;
+root_dir = pths.root;
 
 % build package version
 build_version_h(root_dir)
@@ -265,4 +266,3 @@ else
     end
 
 end
-

--- a/admin/horace_on.m.template
+++ b/admin/horace_on.m.template
@@ -1,4 +1,4 @@
-function path=horace_on(non_default_path)
+function horace_path=horace_on(non_default_path)
 %  safely switches Horace on
 %  horace_on()                         -- calls Horace with default settings
 %  horace_on(non_default_horace_path)  -- calls Horace with non-default Horace folder;
@@ -51,10 +51,13 @@ if nargin==1
 else
     init_horace(default_horace_path);
 end
-path = fileparts(which('horace_init.m'));
+
+horace_path = fileparts(which('horace_init.m'));
 %
 
 warning('off','MATLAB:subscripting:noSubscriptsSpecified');
+end
+
 
 function init_horace(path)
 if ~(exist(fullfile(path,'horace_init.m'),'file') == 2)
@@ -63,6 +66,8 @@ end
 addpath(path);
 horace_init;
 
+end
+
 function her_path = build_default_her_path(hor_path)
 % build default Herbert path from knowledge that Herbert is located
 % alongside the Horace
@@ -70,9 +75,10 @@ function her_path = build_default_her_path(hor_path)
 if strcmp(hor_folder,'horace_core')
     her_path = fullfile(fp,'herbert_core');
 else
-    her_path = fullfile(hor_path,'herbert_core');    
+    her_path = fullfile(hor_path,'herbert_core');
 end
 
+end
 
 function path =find_default_hor_path(hor_default_path)
 path = which('horace_init.m');
@@ -85,6 +91,7 @@ else
     path=fileparts(path);
 end
 
+end
 
 function init_herbert(path)
 % initialize Herbert directories.
@@ -98,3 +105,5 @@ catch
 end
 addpath(path);
 herbert_init;
+
+end

--- a/admin/horace_on.m.template
+++ b/admin/horace_on.m.template
@@ -30,14 +30,13 @@ if ~isempty(sw_start)
     spinw_on(default_spinw_path);
 end
 
-herbert_initated=~isempty(which('herbert_init.m'));
-% if Herbert is not initiated, try to init it.
-if ~herbert_initated
+% if Herbert is not initialised, try to init it.
+if isempty(which('herbert_init.m'))
     default_herbert_path = build_default_her_path(default_horace_path);
     try
         init_herbert(default_herbert_path);
     catch ME
-        disp('HORACE_ON:wrong_dependencies - cannot initiate Herbert');
+        disp('HORACE:horace_on:bad_dependencies cannot initialise Herbert');
         rethrow(ME);
     end
 else % reinitialize Herbert on where it is now.

--- a/admin/make_horace_distribution_kit.m
+++ b/admin/make_horace_distribution_kit.m
@@ -42,8 +42,8 @@ end% default key values
 %
 common_files_to_distribute = {'LICENSE','README.md','CMakeLists.txt'};
 
-
-hor_root_dir = horace_root(); % MUST have rootpath so that horace_init, horace_off are included
+pths = horace_paths;
+hor_root_dir = pths.root; % MUST have rootpath so that horace_init, horace_off are included
 %
 disp('!===================================================================!')
 disp('!==> Preparing HORACE distribution kit  ============================!')
@@ -148,4 +148,3 @@ disp('!    All done folks ================================================!')
 sound(-1:0.001:1);
 
 disp('!===================================================================!')
-

--- a/admin/validate_herbert.m
+++ b/admin/validate_herbert.m
@@ -86,7 +86,7 @@ pcf.shared_folder_on_local = tmp_dir;
 
 % Generate full test paths to unit tests:
 pths = horace_paths;
-test_path = fullfile(pths.root, '_test'); % path to folder with all unit tests folders:
+test_path = pths.test; % path to folder with all unit tests folders:
 test_folders_full = cellfun(...
     @(x) fullfile(test_path, x), test_folders, 'UniformOutput', false);
 %

--- a/admin/validate_herbert.m
+++ b/admin/validate_herbert.m
@@ -85,7 +85,7 @@ par_config = pcf.get_data_to_store();
 pcf.shared_folder_on_local = tmp_dir;
 
 % Generate full test paths to unit tests:
-pths = paths;
+pths = horace_paths;
 test_path = fullfile(pths.root, '_test'); % path to folder with all unit tests folders:
 test_folders_full = cellfun(...
     @(x) fullfile(test_path, x), test_folders, 'UniformOutput', false);

--- a/admin/validate_herbert.m
+++ b/admin/validate_herbert.m
@@ -85,8 +85,8 @@ par_config = pcf.get_data_to_store();
 pcf.shared_folder_on_local = tmp_dir;
 
 % Generate full test paths to unit tests:
-global root_path
-test_path = fullfile(root_path, '_test'); % path to folder with all unit tests folders:
+pths = paths;
+test_path = fullfile(pths.root, '_test'); % path to folder with all unit tests folders:
 test_folders_full = cellfun(...
     @(x) fullfile(test_path, x), test_folders, 'UniformOutput', false);
 %

--- a/admin/validate_herbert.m
+++ b/admin/validate_herbert.m
@@ -46,7 +46,7 @@ end
 % -----------------------------------------------------------------------------
 if isempty(test_folders) % No tests specified on command line - run them all
     test_folders = { ...
-        'test_admin', ...    
+        'test_admin', ...
         'test_data_loaders', ...
         'test_config', ...
         'test_IX_classes', ...
@@ -85,8 +85,8 @@ par_config = pcf.get_data_to_store();
 pcf.shared_folder_on_local = tmp_dir;
 
 % Generate full test paths to unit tests:
-rootpath = fileparts(fileparts(which('herbert_init')));
-test_path = fullfile(rootpath, '_test'); % path to folder with all unit tests folders:
+global root_path
+test_path = fullfile(root_path, '_test'); % path to folder with all unit tests folders:
 test_folders_full = cellfun(...
     @(x) fullfile(test_path, x), test_folders, 'UniformOutput', false);
 %
@@ -124,7 +124,7 @@ if parallel && license('checkout', 'Distrib_Computing_Toolbox')
         end
         matlabpool(cores);
     end
-    
+
     test_ok = false(1, numel(test_folders_full));
     time = bigtic();
     parfor i = 1:numel(test_folders_full)
@@ -145,7 +145,7 @@ else
     %     end
     %     tests_ok = all(test_ok);
     bigtoc(time, '===COMPLETED UNIT TESTS RUN ');
-    
+
 end
 
 if tests_ok

--- a/admin/validate_horace.m
+++ b/admin/validate_horace.m
@@ -87,10 +87,9 @@ end
 
 % Generate full test paths to unit tests
 % --------------------------------------
-horace_path = horace_root();
-test_path = fullfile(horace_path,  '_test');
-test_folders_full = cellfun(@(x)fullfile(test_path, x), test_folders, ...
-    'UniformOutput', false);
+pths = horace_paths;
+test_path = pths.test;
+test_folders_full = fullfile(test_path, test_folders);
 
 hec = herbert_config();
 hoc = hor_config();

--- a/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
+++ b/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
@@ -174,7 +174,7 @@ classdef ClusterMPI < ClusterWrapper
             end
 
             % Get current horace root dir
-            pths = paths;
+            pths = horace_paths;
             external_dll_dir = fullfile(pths.horace, 'DLL', 'external');
 
             if ispc()

--- a/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
+++ b/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
@@ -173,8 +173,9 @@ classdef ClusterMPI < ClusterWrapper
                 end
             end
 
-            rootpath = fileparts(fileparts(which('herbert_init')));
-            external_dll_dir = fullfile(rootpath, 'horace_core', 'DLL', 'external');
+            % Get current horace root dir
+            global horace_path
+            external_dll_dir = fullfile(horace_path, 'DLL', 'external');
 
             if ispc()
                 mpi_exec = fullfile(external_dll_dir, 'mpiexec.exe');

--- a/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
+++ b/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
@@ -174,8 +174,8 @@ classdef ClusterMPI < ClusterWrapper
             end
 
             % Get current horace root dir
-            global horace_path
-            external_dll_dir = fullfile(horace_path, 'DLL', 'external');
+            pths = paths;
+            external_dll_dir = fullfile(pths.horace, 'DLL', 'external');
 
             if ispc()
                 mpi_exec = fullfile(external_dll_dir, 'mpiexec.exe');

--- a/herbert_core/classes/MPIFramework/@ClusterSlurm/ClusterSlurm.m
+++ b/herbert_core/classes/MPIFramework/@ClusterSlurm/ClusterSlurm.m
@@ -61,10 +61,10 @@ classdef ClusterSlurm < ClusterWrapper
             })
         sjob_reaction_ = containers.Map(ClusterSlurm.sacct_state_abbr_,...
             {'running','paused','paused','paused','finished','failed','failed','failed',...
-            'failed','failed','failed','failed','failed'})        
+            'failed','failed','failed','failed','failed'})
     end
-    
-    
+
+
     methods
         function obj = ClusterSlurm(n_workers,mess_exchange_framework,...
                 log_level)
@@ -94,7 +94,7 @@ classdef ClusterSlurm < ClusterWrapper
                 '**** Slurm MPI job configured,  Starting MPI job  with %d workers ****\n';
             obj.started_info_message_  = ...
                 '**** Slurm MPI job with ID: %10d submitted                 ****\n';
-            
+
             % The default name of the messages framework, used for communications
             % between the nodes of the parallel job
             obj.pool_exchange_frmwk_name_ ='MessagesCppMPI';
@@ -112,8 +112,8 @@ classdef ClusterSlurm < ClusterWrapper
             if ~exist('log_level', 'var')
                 log_level = -1;
             end
-            
-            
+
+
             obj = obj.init(n_workers,mess_exchange_framework,log_level);
         end
         %
@@ -135,8 +135,8 @@ classdef ClusterSlurm < ClusterWrapper
             end
             obj = init@ClusterWrapper(obj,n_workers,mess_exchange_framework,log_level);
             obj.log_level = log_level;
-            
-            
+
+
             slurm_str = {'srun ',['-N',num2str(n_workers)],' --mpi=pmi2 '};
             %
             % May change for compiled Horace
@@ -151,19 +151,20 @@ classdef ClusterSlurm < ClusterWrapper
             % currently used as ISIS implementation does not transfer
             % environmental variables to cluster)
             obj.set_env();
-           
+
             % modify executor script values to export it to remote Slurm
             % session
-            run_source = fullfile(herbert_root,'herbert_core','admin','srun_runner.sh');
+            pths = horace_paths;
+            run_source = fullfile(pths.herbert,'admin','srun_runner.sh');
             [fp,fon] = fileparts(mess_exchange_framework.mess_exchange_folder);
             % the enviromental variables are transferred and stored and set
             % in the shel script
             runner= obj.create_runparam_script(run_source,...
                 fullfile(fp,[fon,'.sh']));
             obj.runner_script_name_  = runner;
-            
+
             queue0_rows = obj.get_queue_info();
-            
+
             run_str = [slurm_str{:},runner,' &'];
             %run_str = [slurm_str{:},runner];
             [failed,mess]=system(run_str);
@@ -175,16 +176,16 @@ classdef ClusterSlurm < ClusterWrapper
             % parse queue and extract new job ID
             obj = extract_job_id(obj,queue0_rows);
             obj.starting_cluster_name_ = sprintf('SlurmJobID%d',obj.slurm_job_id);
-            
+
             % check if job control API reported failure
             pause(obj.time_to_wait_for_job_running_);
             obj.check_failed();
-            
+
         end
         %
         function obj=finalize_all(obj)
             % complete parallel job execution
-            
+
             % close exchange framework and delete exchange folder
             obj = finalize_all@ClusterWrapper(obj);
             if ~isempty(obj.runner_script_name_)
@@ -319,7 +320,7 @@ classdef ClusterSlurm < ClusterWrapper
                 error('HERBERT:ClusterSlurm:invalid_argument',mess);
             end
             queue_rows = get_queue_info_(obj,full_header);
-            
+
         end
         %
         function queue_text = get_queue_text_from_system(obj,full_header)
@@ -336,7 +337,7 @@ classdef ClusterSlurm < ClusterWrapper
         %
         function obj=init_queue_parser(obj)
             % initialize parameters, needed for job queue management
-            
+
             % retrieve user name
             [fail,uname]=system('whoami');
             if fail
@@ -385,5 +386,5 @@ classdef ClusterSlurm < ClusterWrapper
             end
         end
     end
-    
+
 end

--- a/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
+++ b/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
@@ -3,16 +3,8 @@ function  tests_path = process_unit_test_path(init, set_path)
 % depending on init option, adds or removes this path from the Matlab
 % search path
 %
-rootpath = herbert_root();
-if isempty(rootpath)
-    error('HERBERT_CONFIG:runtime_error',...
-        'herbert_init is not on Matlab search path');
-end
-[~,fn] = fileparts(rootpath);
-if ~strcmpi(fn,'Horace')
-    warning('HERBERT_INIT:invalid_setup',...
-    'Herbert is not in default location. Be sure you use correct external Herbert in %s',rootpath);
-end
+pths = paths;
+rootpath = pths.root;
 tests_path = fullfile(rootpath,'_test');
 if ~(is_folder(tests_path))
     if init
@@ -31,13 +23,7 @@ mpi_path = fullfile(tests_path,'test_mpi');
 
 % if the connection is done dynamically, additional folders should be added to Horace too
 % not a real dependency, though not nice Herbert knows about Horace.
-hor_path = fileparts(which('horace_init'));
-if isempty(hor_path)
-    hor_uproot = '';
-else
-    hor_uproot = fileparts(hor_path);
-end
-
+hor_path = pths.horace;
 
 if nargin>1
     common_path= fullfile(tests_path,'common_functions');   % path for unit tests

--- a/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
+++ b/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
@@ -3,7 +3,7 @@ function  tests_path = process_unit_test_path(init, set_path)
 % depending on init option, adds or removes this path from the Matlab
 % search path
 %
-pths = paths;
+pths = horace_paths;
 rootpath = pths.root;
 tests_path = fullfile(rootpath,'_test');
 if ~(is_folder(tests_path))

--- a/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
+++ b/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
@@ -5,8 +5,8 @@ function  tests_path = process_unit_test_path(init, set_path)
 %
 pths = horace_paths;
 rootpath = pths.root;
-tests_path = fullfile(rootpath,'_test');
-if ~(is_folder(tests_path))
+tests_path = pths.test;
+if ~is_folder(tests_path)
     if init
         warning('HERBERT_INIT:invalid_setup',...
             'Can not set-up access to the unit tests as no unit tests at %s are available',...
@@ -15,18 +15,19 @@ if ~(is_folder(tests_path))
     tests_path = '';
     return;
 end
-system_admin = fullfile(rootpath,'admin');
-xunit_path = fullfile(rootpath, '_test', 'shared', 'matlab_xunit', 'xunit');  % path for unit tests harness
-xunit_path_extras = fullfile(rootpath, '_test', 'shared', 'matlab_xunit_ISISextras');  % path for additional functions
+system_admin = pths.admin;
+xunit_path = fullfile(pths.test, 'shared', 'matlab_xunit', 'xunit');  % path for unit tests harness
+xunit_path_extras = fullfile(pths.test, 'shared', 'matlab_xunit_ISISextras');  % path for additional functions
 % add to path the MPI unit tests as these have to be on the  path for all MPI workers
-mpi_path = fullfile(tests_path,'test_mpi');
+mpi_path = fullfile(pths.test,'test_mpi');
 
 % if the connection is done dynamically, additional folders should be added to Horace too
 % not a real dependency, though not nice Herbert knows about Horace.
 hor_path = pths.horace;
+hor_uproot = pths.root;
 
 if nargin>1
-    common_path= fullfile(tests_path,'common_functions');   % path for unit tests
+    common_path = pths.test_common_func;   % path for unit tests
     if init
         addpath(common_path);
         addpath(xunit_path);
@@ -34,8 +35,8 @@ if nargin>1
         addpath(mpi_path);
         addpath(system_admin);
         if ~isempty(hor_uproot)
-            addpath(fullfile(hor_uproot,'admin'));
-            addpath(fullfile(hor_uproot,'_test','common_functions'));
+            addpath(pths.admin);
+            addpath(pths.test_common_func);
         end
     else
         warn_state=warning('off','all');    % turn of warnings (so don't get errors if remove non-existent path)
@@ -45,8 +46,8 @@ if nargin>1
         rmpath(mpi_path);
         rmpath(system_admin);
         if ~isempty(hor_uproot)
-            rmpath(fullfile(hor_uproot,'admin'));
-            rmpath(fullfile(hor_uproot,'_test','common_functions'));
+            rmpath(pths.admin);
+            rmpath(pths.test_common_func);
         end
         warning(warn_state);    % return warnings to initial state
         tests_path  = [];

--- a/herbert_core/herbert_init.m
+++ b/herbert_core/herbert_init.m
@@ -12,7 +12,8 @@ function herbert_init
 
 % Root directory is assumed to be that in which this function resides
 % (keep this path, as may be removed by call to application_off)
-rootpath = fileparts(which('herbert_init'));
+global herbert_path
+herbert_path = fileparts(which('herbert_init'));
 
 % Remove all instances of Herbert
 % -------------------------------
@@ -24,24 +25,24 @@ warning('off','MATLAB:subscripting:noSubscriptsSpecified');
 % end
 % Add paths
 % ---------
-addpath(rootpath);  % MUST have rootpath so that herbert_init, herbert_off included
-addpath(fullfile(rootpath,'admin'));
+addpath(herbert_path);  % MUST have herbert_path so that herbert_init, herbert_off included
+addpath(fullfile(herbert_path,'admin'));
 
 % Configurations
-addgenpath_message (rootpath,'configuration');
+addgenpath_message (herbert_path,'configuration');
 
 % Class definitions, with methods and operator definitions
-addgenpath_message (rootpath,'classes');
+addgenpath_message (herbert_path,'classes');
 
 % Utilities definitions
-addgenpath_message (rootpath,'utilities')
+addgenpath_message (herbert_path,'utilities')
 
 % Graphics
-addgenpath_message (rootpath,'graphics')
+addgenpath_message (herbert_path,'graphics')
 genieplot_init
 
 % Applications definitions
-addgenpath_message (rootpath,'applications')
+addgenpath_message (herbert_path,'applications')
 
 
 % set up multiusers computer specific settings,

--- a/herbert_core/horace_paths.m
+++ b/herbert_core/horace_paths.m
@@ -4,6 +4,8 @@ classdef horace_paths
         herbert
         horace
         root
+        test_common
+        test_common_func
     end
 
     methods
@@ -28,6 +30,14 @@ classdef horace_paths
             if isempty(horace_path)
                 root_path = fileparts(get_folder('horace_init'));
             end
+        end
+
+        function path = get.test_common(obj)
+            path = fullfile(obj.root, '_test', 'common_data')
+        end
+
+        function path = get.test_common_func(obj)
+            path = fullfile(obj.root, '_test', 'common_functions')
         end
     end
 

--- a/herbert_core/horace_paths.m
+++ b/herbert_core/horace_paths.m
@@ -6,38 +6,67 @@ classdef horace_paths
         root
         test_common
         test_common_func
+        admin
+        test
+        low_level
     end
 
     methods
 
-
         function herbert_path = get.herbert(obj)
             global herbert_path
-            if isempty(herbert_path)
+            if ~exist('herbert_path', 'var')
                 herbert_path = get_folder('herbert_init');
             end
         end
 
         function horace_path = get.horace(obj)
             global horace_path
-            if isempty(horace_path)
+            if ~exist('horace_path', 'var')
                 horace_path = get_folder('horace_init');
             end
         end
 
         function root_path = get.root(obj)
             global root_path
-            if isempty(horace_path)
+            if ~exist('root_path', 'var')
                 root_path = fileparts(get_folder('horace_init'));
             end
         end
 
+        function path = get.admin(obj)
+            path = fullfile(obj.root, 'admin')
+            if ~is_folder(tests_path)
+                warning('HORACE:paths:bad_path', 'Cannot find admin path, possibly failed setup')
+            end
+        end
+
+        function path = get.low_level(obj)
+            path = fullfile(obj.root, '_LowLevelCode')
+            if ~is_folder(path)
+                warning('HORACE:paths:bad_path', 'Cannot find low level code path, possibly failed setup')
+            end
+        end
+
+        function path = get.test(obj)
+            path = fullfile(obj.root, '_test')
+            if ~is_folder(path)
+                warning('HORACE:paths:bad_path', 'Cannot find test path, possible failed setup')
+            end
+        end
+
         function path = get.test_common(obj)
-            path = fullfile(obj.root, '_test', 'common_data')
+            path = fullfile(obj.test, 'common_data')
+            if ~is_folder(path)
+                warning('HORACE:paths:bad_path', 'Cannot find test/common_data, possibly failed setup')
+            end
         end
 
         function path = get.test_common_func(obj)
-            path = fullfile(obj.root, '_test', 'common_functions')
+            path = fullfile(obj.test, 'common_functions')
+            if ~is_folder(path)
+                warning('HORACE:paths:bad_path', 'Cannot find test/common_functions, possibly failed setup')
+            end
         end
     end
 

--- a/herbert_core/horace_paths.m
+++ b/herbert_core/horace_paths.m
@@ -1,4 +1,4 @@
-classdef paths
+classdef horace_paths
 
     properties(Dependent)
         herbert

--- a/herbert_core/horace_paths.m
+++ b/herbert_core/horace_paths.m
@@ -36,7 +36,7 @@ classdef horace_paths
 
         function path = get.admin(obj)
             path = fullfile(obj.root, 'admin')
-            if ~is_folder(tests_path)
+            if ~is_folder(path)
                 warning('HORACE:paths:bad_path', 'Cannot find admin path, possibly failed setup')
             end
         end

--- a/herbert_core/paths.m
+++ b/herbert_core/paths.m
@@ -1,0 +1,40 @@
+classdef paths
+
+    properties(Dependent)
+        herbert
+        horace
+        root
+    end
+
+    methods
+
+
+        function herbert_path = get.herbert(obj)
+            global herbert_path
+            if isempty(herbert_path)
+                herbert_path = get_folder('herbert_init');
+            end
+        end
+
+        function horace_path = get.horace(obj)
+            global horace_path
+            if isempty(horace_path)
+                horace_path = get_folder('horace_init');
+            end
+        end
+
+        function root_path = get.root(obj)
+            global root_path
+            if isempty(horace_path)
+                root_path = fileparts(get_folder('horace_init'));
+            end
+        end
+    end
+
+    methods(Static)
+        function folder = get_folder(function_or_class)
+            folder = fileparts(which(function_or_class));
+        end
+    end
+
+end

--- a/herbert_core/paths.m
+++ b/herbert_core/paths.m
@@ -35,6 +35,12 @@ classdef paths
         function folder = get_folder(function_or_class)
             folder = fileparts(which(function_or_class));
         end
+
+        function clear()
+            clear global herbert_path
+            clear global horace_path
+            clear global root_path
+        end
     end
 
 end

--- a/horace_core/horace_init.m
+++ b/horace_core/horace_init.m
@@ -17,38 +17,41 @@ end
 warning('off','MATLAB:subscripting:noSubscriptsSpecified');
 % -----------------------------------------------------------------------------
 % Root directory is assumed to be that in which this function resides
-rootpath = fileparts(which('horace_init'));
-addpath(rootpath)  % MUST have rootpath so that horace_init, horace_off included
+global horace_path
+horace_path = fileparts(which('horace_init'));
+global root_path
+root_path = fileparts(horace_path);
+addpath(horace_path)  % MUST have horace_path so that horace_init, horace_off included
 
 
 % Add admin functions to the path first
-addpath(fullfile(rootpath,'admin'));
+addpath(fullfile(horace_path,'admin'));
 % add sqw immediately after dnd classes
-addpath_message (1,rootpath,'sqw');
-addpath_message (1,rootpath,'algorithms');
+addpath_message (1,horace_path,'sqw');
+addpath_message (1,horace_path,'algorithms');
 
 % Add support package
-addpath_message (1,rootpath,'herbert');
+addpath_message (1,horace_path,'herbert');
 
 % DLL and configuration setup
-addpath_message (2,rootpath,'DLL');
-%addpath_message (1,rootpath,'DLL/bin');
-addpath_message (1,rootpath,'configuration');
+addpath_message (2,horace_path,'DLL');
+%addpath_message (1,horace_path,'DLL/bin');
+addpath_message (1,horace_path,'configuration');
 
 % Other directories
-addpath_message (1,rootpath,'horace_function_utils');
-addpath_message (1,rootpath,'lattice_functions');
-addpath_message (1,rootpath,'utilities');
+addpath_message (1,horace_path,'horace_function_utils');
+addpath_message (1,horace_path,'lattice_functions');
+addpath_message (1,horace_path,'utilities');
 
 % Functions for fitting etc.
-addpath_message (1,rootpath,'functions');
-addpath_message (1,rootpath,'sqw_models');
+addpath_message (1,horace_path,'functions');
+addpath_message (1,horace_path,'sqw_models');
 
 % Add GUI path
-addpath_message(1,rootpath,'GUI');
+addpath_message(1,horace_path,'GUI');
 
 % Add Tobyfit
-addpath_message (1,rootpath,'Tobyfit');
+addpath_message (1,horace_path,'Tobyfit');
 
 
 % Set up graphical defaults for plotting
@@ -61,15 +64,14 @@ horace_plot.name_contour = 'Horace contour plot';
 horace_plot.name_sliceomatic = 'Sliceomatic';
 set_global_var('horace_plot',horace_plot);
 
-%
 hc = hor_config;
 check_mex = false;
 if hc.is_default
     check_mex = true;
 end
-%
+
 hpcc = hpc_config;
-if hc.is_default ||hpcc.is_default
+if hc.is_default || hpcc.is_default
     warning([' Found Horace is not configured. ',...
         ' Setting up the configuration, identified as optimal for this type of the machine.',...
         ' Please, check configurations (typing:',...
@@ -88,17 +90,13 @@ end
 
 if check_mex
     [~, n_mex_errors] = check_horace_mex();
-    if n_mex_errors >= 1
-        hc.use_mex = false;
-    else
-        hc.use_mex = true;
-    end
+    hc.use_mex = n_mex_errors < 1;
 end
 
 hec = herbert_config;
 if hec.init_tests
     % add path to folders, which responsible for administrative operations
-    up_root = fileparts(rootpath);
+    up_root = fileparts(horace_path);
     addpath_message(1,fullfile(up_root,'admin'))
     addpath(fullfile(up_root,'_test','common_functions'));
 end
@@ -148,7 +146,7 @@ lines = {
     '', ...
     'http://dx.doi.org/10.1016/j.nima.2016.07.036',...
     repmat('-', 1, width), ...
-    'If you found a bug or have techical problem with Horace,',...
+    'If you found a bug or have technical problem with Horace,',...
     'please contact our team at HoraceHelp@stfc.ac.uk',...
     'Somebody will be back trying to help you.'...
     };

--- a/horace_core/horace_init.m
+++ b/horace_core/horace_init.m
@@ -96,9 +96,8 @@ end
 hec = herbert_config;
 if hec.init_tests
     % add path to folders, which responsible for administrative operations
-    up_root = fileparts(horace_path);
-    addpath_message(1,fullfile(up_root,'admin'))
-    addpath(fullfile(up_root,'_test','common_functions'));
+    addpath_message(1,fullfile(root_path,'admin'))
+    addpath(fullfile(root_path,'_test','common_functions'));
 end
 % Beta version: Suppress warning occurring when old instrument is stored in
 % an sqw file and is automatically converted into MAPS

--- a/horace_core/horace_off.m
+++ b/horace_core/horace_off.m
@@ -8,7 +8,7 @@ function horace_off
 
 % root directory is assumed to be that in which this function resides
 
-pths = paths;
+pths = horace_paths;
 on_path = pths.get_folder('horace_on');
 
 warn_state=warning('off','all');    % turn of warnings (so don't get errors if remove non-existent paths)

--- a/horace_core/horace_off.m
+++ b/horace_core/horace_off.m
@@ -19,9 +19,14 @@ try
     end
     rmpath(paths);
     warning(warn_state);    % return warnings to initial state
+    clear global horace_path
+    clear global herbert_path
+    clear global root_path
 catch
     warning(warn_state);    % return warnings to initial state if error encountered
     error('Problems removing "%s" and sub-directories from Matlab path',horace_path)
 end
 % Make sure we're not removing any global paths
 addpath(getenv('MATLABPATH'));
+
+end

--- a/horace_core/horace_off.m
+++ b/horace_core/horace_off.m
@@ -7,22 +7,21 @@ function horace_off
 % T.G.Perring
 
 % root directory is assumed to be that in which this function resides
-rootpath = fileparts(fileparts(which('horace_init')));
+global horace_path
 on_path = fileparts(which('horace_on'));
 
 warn_state=warning('off','all');    % turn of warnings (so don't get errors if remove non-existent paths)
 try
-    paths = genpath(rootpath);
+    paths = genpath(horace_path);
     % make sure we are not removing the path to horace_on
     if ~isempty(on_path)
         paths = strrep(paths,[on_path,pathsep],'');
-    end    
+    end
     rmpath(paths);
     warning(warn_state);    % return warnings to initial state
 catch
     warning(warn_state);    % return warnings to initial state if error encountered
-    error('Problems removing "%s" and sub-directories from Matlab path',rootpath)
+    error('Problems removing "%s" and sub-directories from Matlab path',horace_path)
 end
 % Make sure we're not removing any global paths
 addpath(getenv('MATLABPATH'));
-

--- a/horace_core/horace_off.m
+++ b/horace_core/horace_off.m
@@ -7,21 +7,20 @@ function horace_off
 % T.G.Perring
 
 % root directory is assumed to be that in which this function resides
-global horace_path
-on_path = fileparts(which('horace_on'));
+
+pths = paths;
+on_path = pths.get_folder('horace_on');
 
 warn_state=warning('off','all');    % turn of warnings (so don't get errors if remove non-existent paths)
 try
-    paths = genpath(horace_path);
+    old_paths = genpath(pths.horace);
     % make sure we are not removing the path to horace_on
     if ~isempty(on_path)
-        paths = strrep(paths,[on_path,pathsep],'');
+        old_paths = strrep(old_paths,[on_path,pathsep],'');
     end
-    rmpath(paths);
+    rmpath(old_paths);
     warning(warn_state);    % return warnings to initial state
-    clear global horace_path
-    clear global herbert_path
-    clear global root_path
+    pths.clear();
 catch
     warning(warn_state);    % return warnings to initial state if error encountered
     error('Problems removing "%s" and sub-directories from Matlab path',horace_path)


### PR DESCRIPTION
See #821 for detailed info

Adds 3 global variables `herbert_path`, `horace_path` and `root_path` which point to relevant parts of the Horace directory structure for internal reference and consistency. 

These are accessible via the `horace_paths` class (in `herbert_core`) there are also methods to get the folder of a function and clearing `paths` as well as the base paths (admin, tests, lowlevelcode) and two commonly used paths (test/common_data, test/common_functions)

These are set in `herbert_init` and `horace_init` or through the `paths` class and cleared in `horace_off`.

Also fixes typo on startup banner.