### PR TITLE
Fix issues with parallel multifit

### DIFF
--- a/herbert_core/applications/multifit/@mfclass/private/multifit_lsqr_par.m
+++ b/herbert_core/applications/multifit/@mfclass/private/multifit_lsqr_par.m
@@ -350,6 +350,7 @@ for i=1:nWorkers
     data(i).y = w.y(points(i)+1:points(i+1));
     data(i).e = w.e(points(i)+1:points(i+1));
     merge_data(i).range = [points(i)+1,points(i+1)];
+    merge_data(i).pix_range = merge_data(i).range;
 end
 
 end
@@ -370,6 +371,7 @@ for i = 1:nWorkers
     data(i).signal = w.signal(points(i)+1:points(i+1));
     data(i).error = w.error(points(i)+1:points(i+1));
     merge_data(i).range = [points(i)+1,points(i+1)];
+    merge_data(i).pix_range = merge_data(i).range;
 end
 
 if dims > 1

--- a/herbert_core/applications/multifit/MFParallel_Job.m
+++ b/herbert_core/applications/multifit/MFParallel_Job.m
@@ -286,7 +286,7 @@ classdef MFParallel_Job < JobExecutor
             [obj.converged, obj.finished] = obj.bcast(1, obj.converged, obj.finished);
 
             tend = toc(timer);
-            obj.log_progress(obj.iter, obj.niter, tend)
+            obj.log_progress(obj.iter, obj.niter, tend, '')
 
         end
 


### PR DESCRIPTION
Change in `split_sqw` not mirrored in other splittings leading to crash