### PR TITLE
Fix horace_install with herbert_off gone

### DIFF
--- a/admin/horace_install.m
+++ b/admin/horace_install.m
@@ -71,22 +71,18 @@ init_folder= opt.init_folder;
 
 
 if ~opt.test_mode
-    try % remove from search path any possible previous version of Horace/Herbert
-        herbert_off();
-    catch % ignore errors if the code has not been installed before and script
-    end   % has not been found
     try
         horace_off();
     catch  % ignore errors if the code has not been installed before and script
     end    % has not been found
     %
-    
+
     % remove herbert_on which may be left from previous installations
     old_herbert_on = which('herbert_on');
     if ~isempty(old_herbert_on)
         delete(old_herbert_on);
     end
-    
+
     if ~exist(init_folder,'dir')
         mkdir(init_folder);
     end
@@ -180,68 +176,66 @@ function opts = parse_args(code_root,init_folder_default,...
 % Parse install script options and identify default package
 % location(s)
 %
-if ismember('-test_mode',varargin)
-    tm = ismember(varargin,'-test_mode');
-    argi = varargin(~tm);
-    test_mode = true;
-else
-    argi = varargin;
-    test_mode = false;
-end
-
+    test_mode = ismember('-test_mode',varargin);
+    if test_mode
+        tm = ismember(varargin,'-test_mode');
+        argi = varargin(~tm);
+    else
+        argi = varargin;
+    end
 
     function validate_path(x, arg_name)
+
         validateattributes( ...
             x, {'string', 'char'}, {'scalartext'},...
             'horace_install', arg_name );
+
     end
 
-% Default horace_root is "<check_up_folder_name>/Horace", but Jenkins
-% checks it up directly into check_up_folder_name.
-hor_root_default = fullfile(code_root, hor_checkup_folder);
-% Default init folder location is either init folder where previous Horace
-% init files are located or, if clean installation, "<horace_root>/../ISIS"
-if isempty(init_folder_default)
-    use_old_init_path   = false;
-    init_folder_default = fullfile(code_root,'ISIS');
-else
-    use_old_init_path   = true;
-end
+    % Default horace_root is "<check_up_folder_name>/Horace", but Jenkins
+    % checks it up directly into check_up_folder_name.
+    hor_root_default = fullfile(code_root, hor_checkup_folder);
+    % Default init folder location is either init folder where previous Horace
+    % init files are located or, if clean installation, "<horace_root>/../ISIS"
 
-parser = inputParser();
-% Default horace_root is one directory above this script
-parser.addParameter( ...
-    'horace_root', ...
-    hor_root_default, ...
-    @(x) validate_path(x, 'horace_root') ...
-    );
-parser.addParameter( ...
-    'init_folder', ...
-    init_folder_default, ...
-    @(x) validate_path(x, 'init_folder') ...
-    );
-
-parser.parse(argi{:});
-%
-opts = parser.Results;
-
-opts.test_mode = test_mode;
-% check if user provided some specific location for init folder, different
-% from the previous default location
-if ~strcmp(opts.init_folder,init_folder_default)
-    use_old_init_path = false;
-    % if user provided init folder without ISIS extension, add ISIS
-    % extension to the folder name
-    [~,folder_name] = fileparts(opts.init_folder);
-    if ~strcmp(folder_name,'ISIS')
-        opts.init_folder = fullfile(opts.init_folder,'ISIS');
+    use_old_init_path = ~isempty(init_folder_default);
+    if ~use_old_init_path
+        init_folder_default = fullfile(code_root,'ISIS');
     end
-end
-opts.use_old_init_path = use_old_init_path;
-opts.herbert_root = opts.horace_root;
+
+    parser = inputParser();
+    % Default horace_root is one directory above this script
+    parser.addParameter( ...
+        'horace_root', ...
+        hor_root_default, ...
+        @(x) validate_path(x, 'horace_root') ...
+                       );
+    parser.addParameter( ...
+        'init_folder', ...
+        init_folder_default, ...
+        @(x) validate_path(x, 'init_folder') ...
+                       );
+
+    parser.parse(argi{:});
+
+    opts = parser.Results;
+
+    opts.test_mode = test_mode;
+    % check if user provided some specific location for init folder, different
+    % from the previous default location
+    if ~strcmp(opts.init_folder, init_folder_default)
+        use_old_init_path = false;
+        % if user provided init folder without ISIS extension, add ISIS
+        % extension to the folder name
+        [~,folder_name] = fileparts(opts.init_folder);
+        if ~strcmp(folder_name,'ISIS')
+            opts.init_folder = fullfile(opts.init_folder,'ISIS');
+        end
+    end
+    opts.use_old_init_path = use_old_init_path;
+    opts.herbert_root = opts.horace_root;
 
 end
-
 
 function install_file(source, dest, placeholders, replace_strs)
 % copy the given file to the given destination

--- a/herbert_core/herbert_init.m
+++ b/herbert_core/herbert_init.m
@@ -1,9 +1,8 @@
 function herbert_init
 % Adds the paths needed by Herbert.
 %
-% In your startup.m, add the Herbert root path and call herbert_init, e.g.
-%       addpath('c:\mprogs\herbert')
-%       herbert_init
+% In your startup.m, add the Horace root path and call horace_on, do not
+% call this directly
 %
 % Is PC and Unix compatible.
 
@@ -15,14 +14,8 @@ function herbert_init
 global herbert_path
 herbert_path = fileparts(which('herbert_init'));
 
-% Remove all instances of Herbert
-% -------------------------------
-% (This might include this version of Herbert)
-application_off('herbert');
 warning('off','MATLAB:subscripting:noSubscriptsSpecified');
-% if ~verLessThan('matlab','9.1')
-%     warning('off','MATLAB:subscripting:noSubscriptsSpecified');
-% end
+
 % Add paths
 % ---------
 addpath(herbert_path);  % MUST have herbert_path so that herbert_init, included
@@ -59,10 +52,10 @@ if parc.is_default
     ocp.load_configuration('-set_config','-change_only_default','-force_save');
 end
 
-
 print_banner();
 
-%=========================================================================================================
+end
+
 function addgenpath_message (varargin)
 % Add a recursive toolbox path from the component directory names, printing
 % a message if the directory does not exist.
@@ -72,51 +65,13 @@ function addgenpath_message (varargin)
 % T.G.Perring
 
 string=fullfile(varargin{:},'');    % '' needed to circumvent bug in fullfile if only one argument, Matlab 2008b (& maybe earlier)
-if exist(string,'dir')==7 % is_dir has not been loaded yet
-    try
-        addpath (genpath_special(string),'-frozen');
-    catch ME
-        rethrow(ME);
-    end
-else
-    error([string, ' is not a directory - not added to path']);
+
+if ~exist(string,'dir') == 7 % is_dir has not been loaded yet
+    error('HERBERT:herbert_init:invalid_argument', '%s is not a directory - not added to path', string);
 end
 
-function application_off(app_name)
-% Remove paths to all instances of the application.
+addpath (genpath_special(string),'-frozen');
 
-start_dir=pwd;
-
-% Determine the rootpaths of any instances of the application by looking for app_name on the matlab path
-application_init_old = which([app_name,'_init'],'-all');
-
-for i=1:numel(application_init_old)
-    try
-        rootpath=fileparts(application_init_old{i});
-        cd(rootpath)
-        if exist(fullfile(pwd,[app_name,'_off.m']),'file') % check that 'off' routine exists in the particular rootpath
-            try
-                feval([app_name,'_off'])    % call the 'off' routine
-            catch ME
-                message=ME.message;
-                disp(['Unable to run function ',fullfile(pwd,[app_name,'_off.m']),'. Reason: ',message]);
-            end
-        else
-            disp(['Function ',app_name,'_off.m not found in ',rootpath])
-            disp('Clearing rootpath and subdirectories from Matlab path in any case')
-            paths = genpath(rootpath);
-            warn_state=warning('off','all');    % turn of warnings (so don't get errors if remove non-existent paths)
-            rmpath(paths);
-            warning(warn_state);    % return warnings to initial state
-        end
-        cd(start_dir)           % return to starting directory
-    catch ME
-        cd(start_dir)           % return to starting directory
-        message=ME.message;
-        disp(['Problems removing ',rootpath,' and any sub-directories from matlab path. Reason: ',message]);
-    end
-    % Make sure we're not removing any global paths
-    addpath(getenv('MATLABPATH'));
 end
 
 function print_banner()
@@ -130,3 +85,5 @@ function print_banner()
         fprintf('!%s!\n', center_and_pad_string(lines{i}, ' ', width));
     end
     fprintf('!%s!\n', repmat('-', 1, width));
+
+end

--- a/herbert_core/herbert_init.m
+++ b/herbert_core/herbert_init.m
@@ -25,7 +25,7 @@ warning('off','MATLAB:subscripting:noSubscriptsSpecified');
 % end
 % Add paths
 % ---------
-addpath(herbert_path);  % MUST have herbert_path so that herbert_init, herbert_off included
+addpath(herbert_path);  % MUST have herbert_path so that herbert_init, included
 addpath(fullfile(herbert_path,'admin'));
 
 % Configurations
@@ -76,11 +76,9 @@ if exist(string,'dir')==7 % is_dir has not been loaded yet
     try
         addpath (genpath_special(string),'-frozen');
     catch ME
-        herbert_off
         rethrow(ME);
     end
 else
-    herbert_off
     error([string, ' is not a directory - not added to path']);
 end
 

--- a/horace_core/horace_off.m
+++ b/horace_core/horace_off.m
@@ -11,24 +11,32 @@ function horace_off
 pths = horace_paths;
 horace_on_path = pths.get_folder('horace_on');
 herbert_on_path = pths.get_folder('herbert_on');
+pths.clear();
 
 warn_state=warning('off','all');    % turn of warnings (so don't get errors if remove non-existent paths)
 try
-    old_paths = [genpath(pths.horace), genpath(pths.herbert)];
+    old_paths = genpath(pths.horace);
     % make sure we are not removing the path to horace_on
     if ~isempty(horace_on_path)
         old_paths = strrep(old_paths,[horace_on_path,pathsep],'');
     end
+    rmpath(old_paths);
+catch
+    error('Problems removing "%s" and sub-directories from Matlab path',horace_on_path)
+end
+
+try
+    old_paths = genpath(pths.herbert);
     if ~isempty(herbert_on_path)
         old_paths = strrep(old_paths,[herbert_on_path,pathsep],'');
     end
     rmpath(old_paths);
-    warning(warn_state);    % return warnings to initial state
-    pths.clear();
 catch
-    warning(warn_state);    % return warnings to initial state if error encountered
-    error('Problems removing "%s" and sub-directories from Matlab path',horace_path)
+    error('Problems removing "%s" and sub-directories from Matlab path',herbert_on_path)
 end
+
+warning(warn_state);    % return warnings to initial state if error encountered
+
 % Make sure we're not removing any global paths
 addpath(getenv('MATLABPATH'));
 


### PR DESCRIPTION
Fix to removing herbert_off for horace_install and other misc. Should be hotfix.

Still not sure where 
> Function herbert_off.m not found in /home/jacob/PACE/HorBack/herbert_core
> Clearing rootpath and subdirectories from Matlab path in any case

Is coming from, but should be simple fix