### PR TITLE
Remove recalc range from finalise

### DIFF
--- a/horace_core/sqw/PixelData/@PixelDataFileBacked/PixelDataFileBacked.m
+++ b/horace_core/sqw/PixelData/@PixelDataFileBacked/PixelDataFileBacked.m
@@ -426,7 +426,6 @@ classdef PixelDataFileBacked < PixelDataBase
                                              'Repeat', 1, ...
                                              'Writable', true, ...
                                              'offset', obj.offset_);
-                obj = obj.recalc_data_range('all');
             end
         end
 


### PR DESCRIPTION
Remove the forced recalculation of ranges on tmp-pix (not tmp sqw) backed objects