### PR TITLE
1003 symop symmetrise

### DIFF
--- a/_test/test_sym_op/test_symop.m
+++ b/_test/test_sym_op/test_symop.m
@@ -129,18 +129,20 @@ classdef test_symop < TestCase
                                  -1  0  0
                                  0  1  0]);
             assertTrue(isa(out, 'Symop'))
-            assertEqual(out.R,  [0  0 -1
+            assertEqual(out.W,  [0  0 -1
                                  -1 0  0
                                  0  1  0])
             assertEqual(out.offset, [0; 0; 0])
         end
 
         function test_matrix_constructor(obj)
-            out = SymopGeneral([-1  0 0
-                                0  -1 0
-                                0   0 1], [3  3  3]);
+            out = Symop.create([ 0  0 -1
+                                 -1  0  0
+                                 0  1  0], [3; 3; 3]);
             assertTrue(isa(out, 'Symop'))
-            assertEqual(out.W, op.W)
+            assertEqual(out.W,  [0  0 -1
+                                 -1 0  0
+                                 0  1  0])
             assertEqual(out.offset, [3; 3; 3])
         end
 

--- a/_test/test_sym_op/test_symop.m
+++ b/_test/test_sym_op/test_symop.m
@@ -140,9 +140,7 @@ classdef test_symop < TestCase
                                 0  -1 0
                                 0   0 1], [3  3  3]);
             assertTrue(isa(out, 'Symop'))
-            assertEqual(out.W,  [-1  0  0
-                                 0  -1  0
-                                 0   0  1])
+            assertEqual(out.W, op.W)
             assertEqual(out.offset, [3; 3; 3])
         end
 
@@ -237,7 +235,7 @@ classdef test_symop < TestCase
 
             assertEqualToTol(out_proj.u, [1, 0, 0], 'abstol', 1e-10)
             assertEqualToTol(out_proj.v, [0, -1, 0], 'abstol', 1e-10)
-            assertEqualToTol(out_bin, {[0 0.1 1], [0 0.1 1], [-1 -0.1 0]})
+            assertEqualToTol(out_bin, {[0 0.1 1], [0 0.1 1], [0 0.1 1]})
 
             [out_proj_mat, out_bin_mat] = obj.ref_op_mat.transform_proj(obj.proj, obj.binning);
             assertEqualToTol(out_proj.u, out_proj_mat.u, 'abstol', 1e-10)

--- a/_test/test_symmetrisation/test_symm.m
+++ b/_test/test_symmetrisation/test_symm.m
@@ -85,7 +85,7 @@ classdef test_symm < TestCase
         % ------------------------------------------------------------------------------------------------
         function this = test_sym_sqw(this)
             % sqw symmetrisation:
-            w3d_sqw=read_sqw(fullfile(this.testdir,'w3d_sqw.sqw'));
+            w3d_sqw = read_sqw(fullfile(this.testdir,'w3d_sqw.sqw'), 'filbacked', false);
 
             w3d_sqw_sym=symmetrise_sqw(w3d_sqw,[0,0,1],[-1,1,0],[0,0,0]);
             % one pixel lost, pity, but bearable.

--- a/_test/test_symmetrisation/test_symm.m
+++ b/_test/test_symmetrisation/test_symm.m
@@ -86,7 +86,7 @@ classdef test_symm < TestCase
         function this = test_sym_sqw(this)
             % sqw symmetrisation:
             w3d_sqw = read_sqw(fullfile(this.testdir,'w3d_sqw.sqw'), 'filbacked', false);
-
+            w3d_sqw.pix = PixelDataMemory(w3d_sqw.pix);
             w3d_sqw_sym=symmetrise_sqw(w3d_sqw,[0,0,1],[-1,1,0],[0,0,0]);
             % one pixel lost, pity, but bearable.
             assertEqual(w3d_sqw.pix.num_pixels-1,w3d_sqw_sym.pix.num_pixels);

--- a/_test/test_symmetrisation/test_symm.m
+++ b/_test/test_symmetrisation/test_symm.m
@@ -85,8 +85,8 @@ classdef test_symm < TestCase
         % ------------------------------------------------------------------------------------------------
         function this = test_sym_sqw(this)
             % sqw symmetrisation:
-            w3d_sqw = read_sqw(fullfile(this.testdir,'w3d_sqw.sqw'), 'filbacked', false);
-            w3d_sqw.pix = PixelDataMemory(w3d_sqw.pix);
+            w3d_sqw=read_sqw(fullfile(this.testdir,'w3d_sqw.sqw'));
+
             w3d_sqw_sym=symmetrise_sqw(w3d_sqw,[0,0,1],[-1,1,0],[0,0,0]);
             % one pixel lost, pity, but bearable.
             assertEqual(w3d_sqw.pix.num_pixels-1,w3d_sqw_sym.pix.num_pixels);

--- a/herbert_core/utilities/geometry/box_intersect.m
+++ b/herbert_core/utilities/geometry/box_intersect.m
@@ -1,37 +1,37 @@
-function inter_points = box_intersect(box_minmax,cross_plain)
+function inter_points = box_intersect(box_minmax,cross_plane)
 % Calculate intersection points between the box in ND (N=2,3,4)
-% and line/plain/hyperplane of dimensions (N-1)D
+% and line/plane/hyperplane of dimensions (N-1)D
 %
 % Inputs:
 % box_minmax
 %      either -- NDx2 array of min and max points of the box, to intersect with.
-%         or  -- NDx2^ND array of all nodes, defining the box, arranged in the order, 
+%         or  -- NDx2^ND array of all nodes, defining the box, arranged in the order,
 %                produced by expand_box routine
 %
-% cross_plain -- NDxND array of points defining plain in the appropriate
+% cross_plane -- NDxND array of points defining plane in the appropriate
 %                dimensions. The coordinates defined along the first
 %                dimension and the second dimention correspont to number of
-%                points, the plain is passing through (has to be ND). If
+%                points, the plane is passing through (has to be ND). If
 %                there are ND-1 points, the missing point assumed to be
 %                equal to 0.
 % Outputs:
 % inter_points - NDxNp array of points, defining intersection between the
-%                edges of the box and the line/plain/hyperplain defined as
+%                edges of the box and the line/plane/hyperplane defined as
 %                the second argument. NP is the number of intesection
 %                points.
-%                If no intersections between box and plain occur, 
+%                If no intersections between box and plane occur,
 %                the inter_points array is empty.
 % Examples:
-% 
+%
 % Calculate intersection points between line passing trhough points 0.5,0.5
 % and 0.5,1 and the box [0,0;1,1]':
 %>>cp = box_intersect([0,0;1,1]',[0.5,0.5;0.5,1]');
 %>>disp(cp)
-%>>cp = 
+%>>cp =
 %>>   0.5000    0.5000
 %>>        0    1.0000
 %
-% Calculate intersection points between plain passing through the points 
+% Calculate intersection points between plane passing through the points
 % (1/2,0,0), (1/2,0,1) and (1,1/2,0) and unit 3D box in the centre of
 % coordinages:
 %
@@ -42,33 +42,33 @@ function inter_points = box_intersect(box_minmax,cross_plain)
 %         0         0    1.0000    1.0000
 %
 % NOTE:
-% Can be generalized to N-Dimensions and simplified, if the generic 
-% normal in N-D isvdefined and expressed through N-dimensional Levi-Civita 
+% Can be generalized to N-Dimensions and simplified, if the generic
+% normal in N-D isvdefined and expressed through N-dimensional Levi-Civita
 % symbol.
 
-ndim = size(cross_plain,1);
+ndim = size(cross_plane,1);
 switch(ndim)
     case(2)
-        inter_points = intersect2D(box_minmax,cross_plain);
+        inter_points = intersect2D(box_minmax,cross_plane);
     case(3)
-        inter_points = intersect3D(box_minmax,cross_plain);
+        inter_points = intersect3D(box_minmax,cross_plane);
     case(4)
-        inter_points = intersect4D(box_minmax,cross_plain);
+        inter_points = intersect4D(box_minmax,cross_plane);
     otherwise
         error('BOX_INTERSECT:invalid_argument',...
             'Routine accepts the data from 2 to 4 dimensions. Got %d',...
             ndim);
 end
 %
-function inter_points = intersect4D(box_minmax,cross_plain)
-npoints = size(cross_plain,2);
+function inter_points = intersect4D(box_minmax,cross_plane)
+npoints = size(cross_plane,2);
 if npoints == 3 %
-    cross_plain = [cross_plain,[0;0;0;0]];
+    cross_plane = [cross_plane,[0;0;0;0]];
 end
-plain_norm = normal4D(cross_plain);
-if plain_norm'*plain_norm < 1.e-12
+plane_norm = normal4D(cross_plane);
+if plane_norm'*plane_norm < 1.e-12
     error('BOX_INTERSECT:invalid_argument',...
-        'vectors, defining the intersection plain are parallel')
+        'vectors, defining the intersection plane are parallel')
 end
 %
 [~,edges_ind] = get_geometry(4);
@@ -77,7 +77,7 @@ nint = 0;
 for i=1:size(edges_ind,2)
     edge_ind = edges_ind(:,i);
     edge =edge4D(box_minmax,edge_ind);
-    int_point = intersection(edge,plain_norm,cross_plain(:,4));
+    int_point = intersection(edge,plane_norm,cross_plane(:,4));
     if ~isempty(int_point)
         nint = nint+1;
         buf{nint} = int_point;
@@ -87,7 +87,7 @@ if nint>0
     inter_points = [buf{:}];
     max1 = max(inter_points(1,:))+1;
     max2 = max(inter_points(2,:))+1;
-    max3 = max(inter_points(3,:))+1;    
+    max3 = max(inter_points(3,:))+1;
     p_id = inter_points(1,:)+max1*(inter_points(2,:)+...
         max2*(inter_points(3,:)+max3*inter_points(4,:)));
     [~,uid] = unique(p_id);
@@ -96,17 +96,17 @@ else
     inter_points = [];
 end
 
-function inter_points = intersect3D(box_minmax,cross_plain)
-npoints = size(cross_plain,2);
+function inter_points = intersect3D(box_minmax,cross_plane)
+npoints = size(cross_plane,2);
 if npoints == 2 %
-    cross_plain = [cross_plain,[0;0;0]];
+    cross_plane = [cross_plane,[0;0;0]];
 end
-plain_norm = cross(cross_plain(:,1)-cross_plain(:,3),cross_plain(:,2)-cross_plain(:,3));
-if plain_norm'*plain_norm < 1.e-12
+plane_norm = cross(cross_plane(:,1)-cross_plane(:,3),cross_plane(:,2)-cross_plane(:,3));
+if plane_norm'*plane_norm < 1.e-12
     error('BOX_INTERSECT:invalid_argument',...
-        'vectors, defining the intersection plain are parallel')
+        'vectors, defining the intersection plane are parallel')
 end
-plain_norm = plain_norm/norm(plain_norm);
+plane_norm = plane_norm/norm(plane_norm);
 %
 [~,edges_ind] = get_geometry(3);
 buf = cell(12,1);
@@ -114,7 +114,7 @@ nint = 0;
 for i=1:size(edges_ind,2)
     edge_ind = edges_ind(:,i);
     edge =edge3D(box_minmax,edge_ind);
-    int_point = intersection(edge,plain_norm,cross_plain(:,3));
+    int_point = intersection(edge,plane_norm,cross_plane(:,3));
     if ~isempty(int_point)
         nint = nint+1;
         buf{nint} = int_point;
@@ -131,16 +131,16 @@ else
     inter_points = [];
 end
 
-function inter_points = intersect2D(box_minmax,cross_plain)
-npoints = size(cross_plain,2);
+function inter_points = intersect2D(box_minmax,cross_plane)
+npoints = size(cross_plane,2);
 if npoints == 1 %
-    cross_plain = [cross_plain,[0;0]];
+    cross_plane = [cross_plane,[0;0]];
 end
 [~,edges_ind] = get_geometry(2);
 buf = cell(4,1);
 nint = 0;
-p0 = cross_plain(:,2);
-dr = cross_plain(:,1)-p0;
+p0 = cross_plane(:,2);
+dr = cross_plane(:,1)-p0;
 normal = [dr(2);-dr(1)];
 normal = normal/norm(normal);
 for i=1:size(edges_ind,2)
@@ -168,8 +168,8 @@ r0 = edg(:,1);
 dr = edg(:,2) - r0;
 edge_length = norm(dr);
 slope = normal'*dr;
-if abs(slope)  <1.e-12  % parallel or in plain
-    % even if the edge lies in the plain,
+if abs(slope)  <1.e-12  % parallel or in plane
+    % even if the edge lies in the plane,
     % we can reject this intersection, as other edges will provide
     % appropriate intersections with nodes
     int_point = [];
@@ -182,7 +182,7 @@ rr = dr*t;
 e_edge = dr/sqrt(dr'*dr); % unit vector along edge
 proj_edge = rr'*e_edge;   % projection of interpolation point to edge
 
-if proj_edge<0 || proj_edge>edge_length %on plain but outside of the edge
+if proj_edge<0 || proj_edge>edge_length %on plane but outside of the edge
     int_point  = [];
     return
 end

--- a/horace_core/sqw/@sqw/symmetrise_sqw.m
+++ b/horace_core/sqw/@sqw/symmetrise_sqw.m
@@ -1,16 +1,24 @@
-function wout=symmetrise_sqw(win,v1,v2,v3)
-% Symmetrise sqw dataset in the plane specified by the vectors v1, v2, and
-% v3.
-% wout=symmetrise_sqw(win,v1,v2,v3)
+function wout=symmetrise_sqw(win,varargin)
+% Symmetrise sqw dataset according to symop.
+%
+% v1,v2,v3 interface is deprecated and provided for backwards compatibility only
+%
+% wout = symmetrise_sqw(win, sym)
+% DEPRECATED wout = symmetrise_sqw(win,v1,v2,v3)
 %
 % WORKS ONLY FOR DATA OBJECTS OF SQW-TYPE (I.E. WITH PIXEL INFO RETAINED).
 %
+% sym
+%     Symmetry operation over which to reduce data
+%       If rotation will map to positive quadrant as much as possible
+%       rotation about theta will reduce all
 %
 % v1 and v2 are two vectors which lie in the plane of the reflection plane.
 % v3 is a vector connecting the plane to the origin (i.e. specifies an
 % offset).
 %
-% e.g. wout=symmetrise_sqw(win,[0,1,0],[0,0,1],[1,0,0])
+% sym = SymopReflection([0,1,0],[0,0,1],[1,0,0]);
+% e.g. wout=symmetrise_sqw(win, sym)
 % The object win is symmetrised in the plane specified by [0,1,0] and
 % [0,1,0] (i.e a mirror plane which reflects [-1,0,0] on to [1,0,0]). v3
 % is [1,0,0], so the plane is offset from the origin. This means that
@@ -38,129 +46,29 @@ if ~has_pixels(win)
           'input object must be sqw type with detector pixel information');
 end
 
-if numel(v1)~=3 || numel(v2)~=3 || numel(v3)~=3
-    error('HORACE:symmetrise_sqw:invalid_argument', ...
-          'the vectors v1, v2 and v3 must all have 3 elements');
-end
+if numel(varargin) == 1 && isa(varargin{1}, 'Symop')
 
+    sym = varargin{1}
+elseif numel(varargin) == 3
+
+    sym = SymopReflection(v1, v2, v3);
+
+else
+    error('HORACE:symmetrise_sqw:invalid_argument', ...
+          ['Call as:\n', ...
+          'wout = symmetrise_sqw(win, sym)\n', ...
+          'DEPRECATED wout = symmetrise_sqw(win,v1,v2,v3)']);
+end
 
 win = sqw(win);
 wout = copy(win);
 
-%New code (problem spotted by Matt Mena for case when using a single
-%contributing spe file):
-header = win.experiment_info;
-
-
-if isequal(size(v1), [3,1])
-    v1=v1';
+if isa(sym, 'SymopReflection')
+    wout.pix = sym.transform_pix(win.pix);
+else
+    error('HORACE:symmetrise_sqw:not_implemented', ...
+          'Symmetrise does not currently support %s', class(sym))
 end
-if isequal(size(v2), [3,1])
-    v2=v2';
-end
-if isequal(size(v3), [3,1])
-    v3=v3';
-end
-
-%Get B-matrix and reciprocal lattice vectors and angles
-s1 = header.samples{1};
-alatt=s1.alatt;
-angdeg=s1.angdeg;
-
-[b, arlu, angrlu] = bmatrix(alatt, angdeg);
-
-
-% The first 3 rows of the pix array specify the co-ordinates in Q of each
-% contributing detector pixel. The reference frame for the pix array is
-% given by an orthonormal set of vectors found as the columns of
-% the win.header.u_to_rlu. The x/y/z components of the vectors u are defined
-% as follows:
-% x is parallel to a*
-% y is in the plane of a* and b* (perpendicular to x), with positive
-% component along b*
-% z is the cross-product of x and y.
-%
-% The vector win.header.uoffset is specified in terms of h,k,l (i.e. its
-% components are along a*, along b* and along c*, so it is NOT specified in
-% an orthonormal frame).
-
-% First step, therefore, is to work out what is the reflection matrix in
-% the orthonormal frame specified by u_to_rlu.
-
-uconv=header.expdata(1).u_to_rlu(1:3,1:3);
-
-%
-%convert the vectors specifying the reflection plane from rlu to the
-%orthonormal frame of the pix array:
-% do not rely on the shift of the image to define symmetry plane.
-%
-% There are currently no situation when header would have offset.
-% if it does have it, it should be utilized here.
-%vec1=uconv\(v1'-header.uoffset(1:3));
-%vec2=uconv\(v2'-header.uoffset(1:3));
-% the symmetry plane should be defined in real hkl, not shifted hkl the
-% image may be expressed in.
-vec1=uconv\(v1');
-vec2=uconv\(v2');
-
-%Normal to the plane, in the frame of pix array (crystal Cartesian):
-normvec=cross(vec1,vec2);
-
-%Construct the reflection matrix in frame of pix array:
-Reflec=zeros(3,3);%initialise reflection matrix
-for i=1:3
-    for j=1:3
-        if i==j
-            delt=1;
-        else
-            delt=0;
-        end
-        Reflec(i,j)=delt - (2 * normvec(i) .* normvec(j))./(sum(normvec.^2));
-    end
-end
-
-%Coordinates of detector pixels, in the frame discussed above
-coords=@() win.pix.q_coordinates; % MP: emulate a pointer / lazy data copy
-
-
-%Note that we allow the inclusion of an offset from the origin of the
-%reflection plane. This is specified in rlu.
-%vec3=uconv\(v3'-header.uoffset(1:3));
-vec3=uconv\(v3');
-%Ensure v3 is a column vector:
-if all(size(vec3)==[1,3])
-    vec3=vec3';
-end
-
-%Translate the pixel co-ords by v3:
-coords_new=bsxfun(@minus, coords(), vec3); % MP: favor bsxfun(@minus, A, B) over A-repmat(B)
-
-%What we want to do now is to replace elements of the pix array whose
-%coordinates are on one side of the plane with coords_refl, but not replace the elements on
-%the other side of the reflection plane.
-
-%Can determine which side of the plane a given point is on by taking the
-%dot product of the normal and the coordinate of the point relative to some
-%position in the plane.
-
-side_dot=coords_new'*normvec; % MP: vector of scalar products, w/o repmat/bsxfun
-
-% MP: (TODO) mem usage of the following could be reduced further by making it work
-% in-place (the Reflec*... part created a temporary)
-idx = find(side_dot > 0);
-coords_new(:, idx) = Reflec*coords_new(:, idx); % MP: (TODO) could potentially be optimized further
-clear 'side_dot'; % MP: not needed any more
-
-coords_new=bsxfun(@plus, coords_new, vec3); % MP
-%
-% Clear existing pages range not to extend new range with existing.
-% Take care if this method is extended to file-based data -- needs careful
-% thinking
-
-wout.pix.q_coordinates=coords_new;
-% real pix range, calculated at the assignment of new coordinates to the
-% pixels coordinates
-clear 'coords_new';
 
 %=========================================================================
 % Transform Ranges:
@@ -171,29 +79,32 @@ existing_range = wout.data.img_range;
 proj = win.data.proj;
 
 % expand img_box into whole box and transform image range into pix range
-exp_range= expand_box(existing_range(1,1:3),existing_range(2,1:3));
+exp_range = expand_box(existing_range(1,1:3), existing_range(2,1:3));
 cc_ranges = proj.transform_img_to_pix(exp_range);
-%
-%
-% identify intersection points between the image range and the symmetry plain
-cross_points = box_intersect(cc_ranges ,[vec1+vec3,vec2+vec3,vec3]);
+
+% identify intersection points between the image range and the symmetry plane
+cross_points = box_intersect(cc_ranges, ...
+                             [sym.u+sym.offset,sym.v+sym.offset,sym.offset]);
+
 % and combine all them together
 cc_exist_range = [cc_ranges,cross_points];
 
 % transform existing range into transformed range
-side_dot=cc_exist_range'*normvec;
-idx = find(side_dot > 0);
-cc_exist_range(:,idx) = Reflec*cc_exist_range(:,idx);
+idx = sym.is_irreducible(cc_exist_range)
+
+cc_exist_range(:,idx) = obj.transform_vec(cc_exist_range(:,idx));
+
 img_box_points = proj.transform_pix_to_img(cc_exist_range);
 img_db_range_minmax = [min(img_box_points,[],2),max(img_box_points,[],2)]';
+
 % add forth dimension to the range
 all_sym_range = [img_db_range_minmax,existing_range(:,4)];
-%
+
 % Extract existing binning: TODO: refactor using future ortho_axes, extract
 % common code with combine_sqw
-%
+
 new_range_arg = cell(1,4);
-paxis  = false(4,1);
+paxis = false(4,1);
 paxis(wout.data.pax) = true;
 npax = 0;
 for i=1:4
@@ -221,14 +132,15 @@ set(hor_config,'log_level',-1);
 % all pixels contribute into single large bin
 ax = wout.data.axes;
 proj = wout.data.proj;
-%
-ax.do_check_combo_arg  = false;
+
+ax.do_check_combo_arg = false;
 ax.img_range = all_sym_range;
 ax.nbins_all_dims = ones(1,4);
 ax.do_check_combo_arg = true;
 ax = ax.check_combo_arg();
 dat = DnDBase.dnd(ax,proj,0,0,sum(wout.data.npix(:)));
-wout.data = dat ;
+wout.data = dat;
 
-%
 wout=cut(wout,proj,new_range_arg{:});
+
+end

--- a/horace_core/sqw/@sqw/symmetrise_sqw.m
+++ b/horace_core/sqw/@sqw/symmetrise_sqw.m
@@ -10,8 +10,14 @@ function wout=symmetrise_sqw(win,varargin)
 %
 % sym
 %     Symmetry operation over which to reduce data
-%       If rotation will map to positive quadrant as much as possible
-%       rotation about theta will reduce all
+%       For reflections this is an array of SymopReflections
+%          which are applied in sequence taking the values
+%          for which coords'*cross(u, v) > 0
+%          reducing the data onto the minimal set
+%       For rotations this is a single SymopRotation
+%          which will apply 360/theta_deg rotations
+%          to reduce data into the positive quadrant
+%          ** N.B. ** 360/theta_deg MUST be integral
 %
 % v1 and v2 are two vectors which lie in the plane of the reflection plane.
 % v3 is a vector connecting the plane to the origin (i.e. specifies an

--- a/horace_core/symop/@Symop/Symop.m
+++ b/horace_core/symop/@Symop/Symop.m
@@ -226,55 +226,10 @@ classdef(Abstract) Symop < matlab.mixin.Heterogeneous
             % Transform proj
             b = bmatrix(proj.alatt, proj.angdeg);
 
-            % Get bounding box of pbin
-%             bb = [pbin{1}(1) pbin{1}(end)
-%                   pbin{2}(1) bind{2}(end)
-%                   pbin{3}(1) pbin(3}(end)];
-
             for i=numel(obj):-1:1
                 [proj, sgn(i)] = obj(i).transform_proj_single(b, proj);
-%                 bb = obj(i).transform_vec(bb);
             end
 
-
-%
-%
-%
-%             sgntot = prod(sgn);     % +1 or -1 depending on even or odd number of reflections
-%
-%             if sgntot == -1
-%                 % odd number of reflections
-%                 % Does not work for non-orthogonal axes. The problem is that reflections
-%                 % do not have a simple relationship
-%                 % Find an axis to invert. Invert an integration axis (then there are no
-%                 % problems with order of bins in the sqw object); if none, then invert axis 3
-%                 invert = cellfun(@numel, pbin) == 2;
-%
-%                 if invert(3)
-%                     pbin{3} = -flip(pbin{3});
-%                     proj.w = -proj.w;
-%
-%                 elseif invert(2)
-%                     pbin{2} = -flip(pbin{2});
-%                     proj.v = -proj.v;
-%
-%                 elseif invert(1)
-%                     pbin{1} = -flip(pbin{1});
-%                     proj.u = -proj.u;
-%
-%                 else
-%                     % The following is correct if the true bin descriptor is given
-%                     % i.e. the interval is an integer multiple of the step size
-%                     nbin = (pbin{3}(3) - pbin{3}(1)) / pbin{3}(2);
-%                     if floor(nbin) ~= nbin
-%                         error('HORACE:symop:invalid_argument', ...
-%                               'Range along third projection axis is not an integer multiple of bin size');
-%                     end
-%                     pbin{3} = -flip(pbin{3});
-%                     proj.w = -proj.w;
-%
-%                 end
-%             end
         end
     end
 

--- a/horace_core/symop/@Symop/Symop.m
+++ b/horace_core/symop/@Symop/Symop.m
@@ -171,25 +171,12 @@ classdef(Abstract) Symop < matlab.mixin.Heterogeneous
 
             % Get transformation
             if isa(pix, 'PixelDataMemory')
-                sel = obj.in_irreducible(new_coords)
+                sel = obj.in_irreducible(new_coords);
                 pix.q_coordinates(:, ~sel) = obj.transform_vec(new_coords(:, ~sel));
             else
                 error('HORACE:symop:not_implemented', ...
-                      'Pix backed reduction not possible')
+                      'filebacked pix reduction not possible')
             end
-
-%             Rtot = obj(end).W;
-%             Om = obj(end).compute_offset(Rtot, Minv, upix_offset(1:3));
-%
-%             for i=n-1:-1:1
-%                 R = obj(i).calculate_transform(Minv);
-%                 O = obj(i).compute_offset(R, Minv, upix_offset(1:3));
-%                 Rtot = Rtot * R;
-%                 Om = R \ Om + O;
-%             end
-%
-%             % Transform pixels
-%             pix = Rtot \ pix_in + Om;
 
         end
 
@@ -239,46 +226,55 @@ classdef(Abstract) Symop < matlab.mixin.Heterogeneous
             % Transform proj
             b = bmatrix(proj.alatt, proj.angdeg);
 
-            sgn = ones(1,numel(obj));
+            % Get bounding box of pbin
+%             bb = [pbin{1}(1) pbin{1}(end)
+%                   pbin{2}(1) bind{2}(end)
+%                   pbin{3}(1) pbin(3}(end)];
+
             for i=numel(obj):-1:1
-                [proj, sgn(i)] = transform_proj_single(obj(i), b, proj);
+                [proj, sgn(i)] = obj(i).transform_proj_single(b, proj);
+%                 bb = obj(i).transform_vec(bb);
             end
 
-            sgntot = prod(sgn);     % +1 or -1 depending on even or odd number of reflections
 
-            if sgntot == -1
-                % odd number of reflections
-                % Does not work for non-orthogonal axes. The problem is that reflections
-                % do not have a simple relationship
-                % Find an axis to invert. Invert an integration axis (then there are no
-                % problems with order of bins in the sqw object); if none, then invert axis 3
-                invert = cellfun(@numel, pbin) == 2;
-
-                if invert(3)
-                    pbin{3} = -flip(pbin{3});
-                    proj.w = -proj.w;
-
-                elseif invert(2)
-                    pbin{2} = -flip(pbin{2});
-                    proj.v = -proj.v;
-
-                elseif invert(1)
-                    pbin{1} = -flip(pbin{1});
-                    proj.u = -proj.u;
-
-                else
-                    % The following is correct if the true bin descriptor is given
-                    % i.e. the interval is an integer multiple of the step size
-                    nbin = (pbin{3}(3) - pbin{3}(1)) / pbin{3}(2);
-                    if floor(nbin) ~= nbin
-                        error('HORACE:symop:invalid_argument', ...
-                              'Range along third projection axis is not an integer multiple of bin size');
-                    end
-                    pbin{3} = -flip(pbin{3});
-                    proj.w = -proj.w;
-
-                end
-            end
+%
+%
+%
+%             sgntot = prod(sgn);     % +1 or -1 depending on even or odd number of reflections
+%
+%             if sgntot == -1
+%                 % odd number of reflections
+%                 % Does not work for non-orthogonal axes. The problem is that reflections
+%                 % do not have a simple relationship
+%                 % Find an axis to invert. Invert an integration axis (then there are no
+%                 % problems with order of bins in the sqw object); if none, then invert axis 3
+%                 invert = cellfun(@numel, pbin) == 2;
+%
+%                 if invert(3)
+%                     pbin{3} = -flip(pbin{3});
+%                     proj.w = -proj.w;
+%
+%                 elseif invert(2)
+%                     pbin{2} = -flip(pbin{2});
+%                     proj.v = -proj.v;
+%
+%                 elseif invert(1)
+%                     pbin{1} = -flip(pbin{1});
+%                     proj.u = -proj.u;
+%
+%                 else
+%                     % The following is correct if the true bin descriptor is given
+%                     % i.e. the interval is an integer multiple of the step size
+%                     nbin = (pbin{3}(3) - pbin{3}(1)) / pbin{3}(2);
+%                     if floor(nbin) ~= nbin
+%                         error('HORACE:symop:invalid_argument', ...
+%                               'Range along third projection axis is not an integer multiple of bin size');
+%                     end
+%                     pbin{3} = -flip(pbin{3});
+%                     proj.w = -proj.w;
+%
+%                 end
+%             end
         end
     end
 

--- a/horace_core/symop/@Symop/Symop.m
+++ b/horace_core/symop/@Symop/Symop.m
@@ -95,6 +95,7 @@ classdef(Abstract) Symop < matlab.mixin.Heterogeneous
     methods(Abstract)
         R = calculate_transform(obj, Minv)
         local_disp(obj)
+        selected = in_irreducible(obj, coords)
     end
 
     methods(Sealed)
@@ -163,15 +164,32 @@ classdef(Abstract) Symop < matlab.mixin.Heterogeneous
         %   pix_out     Transformed pixel array (3 x n array).
 
             % Check input
-            if isempty(obj)
+            if ~isa(pix, 'PixelDataBase')
                 error('HORACE:symop:invalid_argument', ...
-                      'Empty symmetry operation object array')
+                      'Transform pix requires pixels');
             end
 
             % Get transformation
-            for i = numel(obj):-1:1
-                pix.coordinates = obj(i).transform_vec(pix.coordinates)
+            if isa(pix, 'PixelDataMemory')
+                sel = obj.in_irreducible(new_coords)
+                pix.q_coordinates(:, ~sel) = obj.transform_vec(new_coords(:, ~sel));
+            else
+                error('HORACE:symop:not_implemented', ...
+                      'Pix backed reduction not possible')
             end
+
+%             Rtot = obj(end).W;
+%             Om = obj(end).compute_offset(Rtot, Minv, upix_offset(1:3));
+%
+%             for i=n-1:-1:1
+%                 R = obj(i).calculate_transform(Minv);
+%                 O = obj(i).compute_offset(R, Minv, upix_offset(1:3));
+%                 Rtot = Rtot * R;
+%                 Om = R \ Om + O;
+%             end
+%
+%             % Transform pixels
+%             pix = Rtot \ pix_in + Om;
 
         end
 

--- a/horace_core/symop/@SymopGeneral/SymopGeneral.m
+++ b/horace_core/symop/@SymopGeneral/SymopGeneral.m
@@ -22,6 +22,13 @@ classdef SymopGeneral < Symop
             W = obj.W_;
         end
 
+        function selected = in_irreducible(obj, coords)
+        % Compute whether the coordinates in `coords` are in the irreducible
+        % set following the operation
+            error('HORACE:symop:not_implemented', ...
+                  'Cannot compute the irreducible set from general 3x3 transform');
+        end
+
         function R = calculate_transform(obj, Minv)
         % Get transformation matrix for the symmetry operator in an orthonormal frame
         %

--- a/horace_core/symop/@SymopIdentity/SymopIdentity.m
+++ b/horace_core/symop/@SymopIdentity/SymopIdentity.m
@@ -19,6 +19,12 @@ classdef SymopIdentity < Symop
             end
         end
 
+        function selected = in_irreducible(obj, coords)
+        % Compute whether the coordinates in `coords` are in the irreducible
+        % set following the operation
+            selected = true(size(coords));
+        end
+
         function R = calculate_transform(obj, Minv)
         % Get transformation matrix for the symmetry operator in an orthonormal frame
         %

--- a/horace_core/symop/@SymopReflection/SymopReflection.m
+++ b/horace_core/symop/@SymopReflection/SymopReflection.m
@@ -3,6 +3,7 @@ classdef SymopReflection < Symop
     properties(Dependent)
         u;
         v;
+        normvec;
     end
 
     properties(Access=private)
@@ -59,6 +60,17 @@ classdef SymopReflection < Symop
 
         function v = get.v(obj)
             v = obj.v_;
+        end
+
+        function normvec = get.normvec(obj)
+            normvec = cross(obj.u, obj.v);
+            normvec = normvec / norm(normvec);
+        end
+
+        function selected = in_irreducible(obj, coords)
+        % Compute whether the coordinates in `coords` are in the irreducible
+        % set following the operation
+            selected = coords'*obj.normvec > 0;
         end
 
         function R = calculate_transform(obj, Minv)

--- a/horace_core/symop/@SymopRotation/SymopRotation.m
+++ b/horace_core/symop/@SymopRotation/SymopRotation.m
@@ -57,6 +57,32 @@ classdef SymopRotation < Symop
             theta_deg = obj.theta_deg_;
         end
 
+        function selected = in_irreducible(obj, coords)
+        % Compute whether the coordinates in `coords` (Q) are in the irreducible
+        % set following the symmetry reduction under this operator
+        %
+        % For a rotation `R` about axis `n` of angle `theta`:
+        %
+        % For any `u` not parallel to `n` and v = R*u;
+        % The planes defined by UN, VN encapsulate the reduced region
+        % And thus any coordinate `q` from `Q` where
+        % q*(u x n) > 0 && q*(n x v) > 0
+        % belong to the irreducible set
+            n = obj.n / norm(obj.n);
+            if sum(abs(n - [1; 0; 0])) > 1e-1
+                u = [1; 0; 0];
+            else
+                u = [0; 1; 0];
+            end
+
+            v = obj.transform_vec(u);
+            normvec_u = cross(u, n);
+            normvec_v = cross(n, v);
+
+            selected = (coords'*normvec_u > 0 & ...
+                        coords'*normvec_v > 0);
+        end
+
         function R = calculate_transform(obj, Minv)
         % Get transformation matrix for the symmetry operator in an orthonormal frame
         %

--- a/horace_core/symop/@SymopRotation/SymopRotation.m
+++ b/horace_core/symop/@SymopRotation/SymopRotation.m
@@ -66,8 +66,8 @@ classdef SymopRotation < Symop
         % For any `u` not parallel to `n` and v = R*u;
         % The planes defined by UN, VN encapsulate the reduced region
         % And thus any coordinate `q` from `Q` where
-        % q*(u x n) > 0 && q*(n x v) > 0
-        % belong to the irreducible set
+        % q*(n x u) > 0 && q*(v x n) > 0
+        % belong to the irreducible set in the upper right quadrant
             n = obj.n / norm(obj.n);
             if sum(abs(n - [1; 0; 0])) > 1e-1
                 u = [1; 0; 0];
@@ -76,8 +76,8 @@ classdef SymopRotation < Symop
             end
 
             v = obj.transform_vec(u);
-            normvec_u = cross(u, n);
-            normvec_v = cross(n, v);
+            normvec_u = cross(n, u);
+            normvec_v = cross(v, n);
 
             selected = (coords'*normvec_u > 0 & ...
                         coords'*normvec_v > 0);


### PR DESCRIPTION
- Converts `symmtrise_sqw` to use `Symop`s rather than reflection plane vectors. (Legacy supported)
- Adds experimental rotational symmetry reduction (though untested as yet)
- Corrects spelling of `plain` to `plane` in `box_intersect`