### PR TITLE
Restore bin masking on pix `equal_to_tol`

### DIFF
--- a/_test/test_sqw_class/test_equal_to_tol.m
+++ b/_test/test_sqw_class/test_equal_to_tol.m
@@ -174,8 +174,8 @@ classdef test_equal_to_tol < TestCase & common_sqw_class_state_holder
 
             fraction = 0.5;
             % get the bins to zero out
-            bins_to_edit = round(2:2:30);
-            edited_data(:, bins_to_edit) = 0;
+            edited_data(:, 11:15) = 0;
+            edited_data(:, 22:24) = 0;
 
             pix = obj.get_pix_with_fake_faccess(data);
             edited_pix = obj.get_pix_with_fake_faccess(edited_data);
@@ -190,7 +190,7 @@ classdef test_equal_to_tol < TestCase & common_sqw_class_state_holder
             % check equal_to_tol false when comparing all bins
             assertFalse(equal_to_tol(edited_sqw, original_sqw, 'fraction', 1));
             % check equal_to_tol true when comparing a fraction of the bins
-            assertEqualToTol(edited_sqw, original_sqw, 'fraction', fraction, 'reorder', false);
+            assertEqualToTol(edited_sqw, original_sqw, 'fraction', fraction, 'reorder', true);
         end
 
         function test_using_fraction_argument_is_faster_than_comparing_all_pix(obj)

--- a/horace_core/sqw/@sqw/private/equal_to_tol_internal_.m
+++ b/horace_core/sqw/@sqw/private/equal_to_tol_internal_.m
@@ -68,5 +68,5 @@ end
 % Compare pix
 [ok, mess] = equal_to_tol(w1.pix, w2.pix, args{:}, ...
                           'reorder', opt.reorder, 'npix', w1.data.npix(:), 'fraction', opt.fraction, ...
-                          'name_a', [name_a, '.pix'], 'name_a', [name_b, '.pix']);
+                          'name_a', [name_a, '.pix'], 'name_b', [name_b, '.pix']);
 end

--- a/horace_core/sqw/PixelData/@PixelDataBase/equal_to_tol.m
+++ b/horace_core/sqw/PixelData/@PixelDataBase/equal_to_tol.m
@@ -62,6 +62,13 @@ function [ok, mess] = equal_to_tol(pix, other_pix, varargin)
         return
     end
 
+    % Empty pix equal, validate proves both empty
+    if pix.num_pixels == 0
+        ok = true;
+        mess = [];
+        return;
+    end
+
     if opt.reorder
         [ok, mess] = compare_reorder(pix, other_pix, opt, argi);
     elseif opt.fraction ~= 1


### PR DESCRIPTION
Restore masking bins on `fraction`al `equal_to_tol` between `PixelData` objects

Fixes #1033 