### PR TITLE
1047 fix var names

### DIFF
--- a/_test/test_mpi_wrappers/test_parallel_config_and_clusters_factory.m
+++ b/_test/test_mpi_wrappers/test_parallel_config_and_clusters_factory.m
@@ -182,7 +182,7 @@ classdef test_parallel_config_and_clusters_factory < TestCase
 
             pc.parallel_cluster='her';
             assertEqual(pc.parallel_cluster,'herbert');
-            all_clcfg = pc.known_clust_configs;
+            all_clcfg = pc.known_cluster_configs;
             clust = pc.cluster_config;
             assertEqual(numel(all_clcfg),1);
             assertEqual(all_clcfg{1},clust);
@@ -218,7 +218,7 @@ classdef test_parallel_config_and_clusters_factory < TestCase
             end
             assertEqual(pc.parallel_cluster,'parpool');
 
-            all_clcfg = pc.known_clust_configs;
+            all_clcfg = pc.known_cluster_configs;
             cl_config = pc.cluster_config;
             assertEqual(numel(all_clcfg),1);
             assertEqual(all_clcfg{1},cl_config);
@@ -254,7 +254,7 @@ classdef test_parallel_config_and_clusters_factory < TestCase
             end
             assertEqual(pc.parallel_cluster,'mpiexec_mpi');
 
-            all_clcfg = pc.known_clust_configs;
+            all_clcfg = pc.known_cluster_configs;
             cl_config = pc.cluster_config;
             assertTrue(numel(all_clcfg)>1);
 
@@ -303,7 +303,7 @@ classdef test_parallel_config_and_clusters_factory < TestCase
             end
             assertEqual(pc.parallel_cluster,'slurm_mpi');
 
-            all_clcfg = pc.known_clust_configs;
+            all_clcfg = pc.known_cluster_configs;
             assertEqual(numel(all_clcfg),2);
 
             cl_config = pc.cluster_config;

--- a/herbert_core/classes/MPIFramework/@ClusterSlurm/ClusterSlurm.m
+++ b/herbert_core/classes/MPIFramework/@ClusterSlurm/ClusterSlurm.m
@@ -145,14 +145,14 @@ classdef ClusterSlurm < ClusterWrapper
 
             par = parallel_config();
             comm = par.slurm_commands;
-            
+
             [n_nodes, cores_per_node] = obj.get_remote_info(comm);
 
-            if par.is_auto_par_threads
+            if par.is_auto_parallel_threads
                 % If user not specified threads to use assume MPI applications are not wanting to be threaded
                 target_threads = 1;
             else
-                target_threads = par.par_threads;
+                target_threads = par.parallel_threads;
             end
 
             req_nodes = ceil(n_workers / cores_per_node);

--- a/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
+++ b/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
@@ -318,7 +318,7 @@ classdef ClusterWrapper
             addOptional(p, 'postfix_command', {}, @iscellstr);
             addOptional(p, 'matlab_extra'   , '', @isstring);
             addOptional(p, 'debug', par.debug, @islognumscalar);
-            addOptional(p, 'target_threads', par.par_threads, @isnumeric);
+            addOptional(p, 'target_threads', par.parallel_threads, @isnumeric);
             parse(p, varargin{:});
 
             prefix_command = p.Results.prefix_command;

--- a/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
+++ b/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
@@ -122,7 +122,6 @@ classdef parallel_config<config_base
         cluster_config;
 
         % number of workers to deploy in parallel jobs
-        accumulating_process_num;
         parallel_workers_number;
 
         % Threading using auto-calculated threads used in Slurm because
@@ -468,10 +467,6 @@ classdef parallel_config<config_base
             end
 
             config_store.instance().store_config(obj,'cluster_config',the_config);
-        end
-
-        function obj = set.accumulating_process_num(obj,val)
-            obj.parallel_workers_number = val;
         end
 
         function obj = set.parallel_workers_number(obj,val)

--- a/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
+++ b/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
@@ -188,10 +188,6 @@ classdef parallel_config<config_base
         % evaluated on a remote worker equal to shared_folder_on_remote value
         working_directory;
 
-        % Information field:
-        % true, if working directory have not ever been set
-        wkdir_is_default;
-
         % if set up, specifies the mpiexc program with full path to it,
         % used to launch parallel jobs instead of internal mpiexec
         % program, provided with Horace. Must be used when you compiled
@@ -215,6 +211,15 @@ classdef parallel_config<config_base
 
         % Redirect IO to host and other debug features
         debug;
+
+        % Threading using auto-calculated threads used in Slurm because
+        % remote machine probably doesn't have same number of cores as
+        % local machine
+        is_auto_parallel_threads;
+
+        % Information field:
+        % true, if working directory has not ever been set
+        wkdir_is_default;
     end
 
     properties(Constant,Access=private)

--- a/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
+++ b/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
@@ -35,6 +35,8 @@ classdef parallel_config<config_base
     %                      cluster, running selected cluster.
     % threads            - How many computational threads to use in parallel
     %                      and in MEX
+    % parallel_threads   - Number of computational threads to use on remote
+    %                      workers
     % ---------------------------------------------------------------------
     % shared_folder_on_local - The folder on your working machine containing
     %                          the job input and output data.
@@ -55,7 +57,7 @@ classdef parallel_config<config_base
     % =====================================================================
     % known_clusters       - Information method returning the list of
     %                        the parallel clusters, known to Herbert.
-    % known_clust_configs  - Information method returning the list of
+    % known_cluster_configs- Information method returning the list of
     %                        the configurations, available for the selected
     %                        cluster.
     % ---------------------------------------------------------------------
@@ -150,7 +152,7 @@ classdef parallel_config<config_base
         % The cluster used by parpool and slurm clusters are using the default
         % configurations selected in parallel computing toolbox GUI for
         % parpool and slurm database configuration for slurm.
-        known_clust_configs;
+        known_cluster_configs;
 
         % The folder on your working machine containing the job input and
         % output data mounted on local machine and available from the remote
@@ -413,7 +415,7 @@ classdef parallel_config<config_base
             end
         end
 
-        function clust_configs = get.known_clust_configs(obj)
+        function clust_configs = get.known_cluster_configs(obj)
             % information about clusters (cluster configurations),
             % available for the selected cluster
             fram = obj.parallel_cluster;
@@ -458,7 +460,7 @@ classdef parallel_config<config_base
             % Throws HERBERT:parallel_config:invalid_argument if the cluster
             % configuration is invalid or not available on the current system.
 
-            opt = obj.known_clust_configs;
+            opt = obj.known_cluster_configs;
             if strcmpi(opt{1},'none')
                 the_config = 'none';
             else

--- a/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
+++ b/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
@@ -124,16 +124,11 @@ classdef parallel_config<config_base
         % number of workers to deploy in parallel jobs
         parallel_workers_number;
 
-        % Threading using auto-calculated threads used in Slurm because
-        % remote machine probably doesn't have same number of cores as
-        % local machine
-        is_auto_par_threads;
-
         % Number of threads to use.
         threads;
 
         % Number of threads to use in MPIFramework.
-        par_threads;
+        parallel_threads;
 
         % Information method returning the list of the parallel clusters,
         % known to Herbert. You can not add or change a cluster
@@ -212,7 +207,7 @@ classdef parallel_config<config_base
         % Redirect IO to host and other debug features
         debug;
 
-        % Threading using auto-calculated threads used in Slurm because
+        % Threading using auto-calculated threads; used in Slurm because
         % remote machine probably doesn't have same number of cores as
         % local machine
         is_auto_parallel_threads;
@@ -233,7 +228,7 @@ classdef parallel_config<config_base
             'cluster_config', ...
             'parallel_workers_number',...
             'threads', ...
-            'par_threads', ...
+            'parallel_threads', ...
             'shared_folder_on_local', ...
             'shared_folder_on_remote', ...
             'working_directory', ...
@@ -260,7 +255,7 @@ classdef parallel_config<config_base
         % default auto threads
         threads_ = 0;
         % default auto threads
-        par_threads_ = 0;
+        parallel_threads_ = 0;
 
         % default remote folder is unset
         shared_folder_on_local_ ='';
@@ -325,8 +320,8 @@ classdef parallel_config<config_base
             conf = obj.get_or_restore_field('cluster_config');
         end
 
-        function tf = get.is_auto_par_threads(obj)
-            n_threads = get_or_restore_field(obj,'par_threads');
+        function tf = get.is_auto_parallel_threads(obj)
+            n_threads = get_or_restore_field(obj,'parallel_threads');
             tf = n_threads < 1;
         end
 
@@ -341,8 +336,8 @@ classdef parallel_config<config_base
             end
         end
 
-        function n_threads=get.par_threads(obj)
-            n_threads = get_or_restore_field(obj, 'par_threads');
+        function n_threads=get.parallel_threads(obj)
+            n_threads = get_or_restore_field(obj, 'parallel_threads');
             n_workers = get_or_restore_field(obj, 'parallel_workers_number');
             n_poss_threads = floor(obj.n_cores/n_workers);
 
@@ -493,17 +488,17 @@ classdef parallel_config<config_base
             config_store.instance().store_config(obj,'threads',n_threads);
         end
 
-        function obj = set.par_threads(obj,n_threads)
+        function obj = set.parallel_threads(obj,n_threads)
             n_threads = floor(n_threads);
             n_workers = get_or_restore_field(obj, 'parallel_workers_number');
             n_poss_threads = floor(obj.n_cores/n_workers);
 
             if n_threads < 0
-                error('HERBERT:parallel_config:invalid_argument', 'par_threads must be positive or 0 (automatic)')
+                error('HERBERT:parallel_config:invalid_argument', 'parallel_threads must be positive or 0 (automatic)')
             elseif n_threads > n_poss_threads
-                warning('HERBERT:parallel_config:par_threads', 'Number of par threads (%d) might exceed computer capacity (%d)', n_threads, n_poss_threads)
+                warning('HERBERT:parallel_config:parallel_threads', 'Number of par threads (%d) might exceed computer capacity (%d)', n_threads, n_poss_threads)
             end
-            config_store.instance().store_config(obj,'par_threads',n_threads);
+            config_store.instance().store_config(obj,'parallel_threads',n_threads);
         end
 
         function obj = set.slurm_commands(obj,val)

--- a/horace_core/configuration/@hor_config/hor_config.m
+++ b/horace_core/configuration/@hor_config/hor_config.m
@@ -34,10 +34,10 @@ classdef hor_config < config_base
     %
     %   force_mex_if_use_mex - Fail if mex can not be used. Used in mex files debugging
     %--
-    %   high_perf_config_info  - an interface, displaying high performance computing settings.
+    %   hpc_config       - an interface, displaying high performance computing settings.
     %                       Use hpc_config class directly to modify these
     %                       settings.
-    %   init_tests          Enable the unit test functions
+    %   init_tests       -  Enable the unit test functions
     %
     %
     properties(Dependent)
@@ -45,13 +45,13 @@ classdef hor_config < config_base
         % on usual machine with 16Gb of RAM it is 10^7  (higher value does
         % not provide obvious performance benefits) but on older machines
         % with ~4Gb it has to be reduced to 10^6
-        mem_chunk_size
+        mem_chunk_size;
 
         % ignore NaN values if pixels have them.  %  (default --true)
-        ignore_nan
+        ignore_nan;
 
         % ignore inf values if pixels have them. %  (default --false)
-        ignore_inf
+        ignore_inf;
 
         % The verbosity of the log messages
         %      The larger the value, the more information is printed, e.g.:
@@ -59,16 +59,16 @@ classdef hor_config < config_base
         %   0  Major information messages printed
         %   1  Minor information messages printed in addition
         %   2  Time of the run measured and printed as well.
-        log_level
+        log_level;
 
         % use mex-code for time-consuming operations
         % default -- true if mex files are compiled
-        use_mex
+        use_mex;
 
         % automatically delete temporary files after generating sqw files
         % by default its true, but you may set it to false to keep files
         % for later operations.
-        delete_tmp
+        delete_tmp;
 
         % the folder where tmp files should be stored.
         % by default gen_sqw sets this value to place where spe files are
@@ -78,17 +78,17 @@ classdef hor_config < config_base
         % parallel file system.
         % Assign empty value to restore it to default (system tmp
         % directory)
-        working_directory
+        working_directory;
 
         % testing and debugging option -- fail if mex can not be used
         % By default if mex file fails, program tries to use Matlab, but
         % if this option is set to true, the whole operation may fail.
-        force_mex_if_use_mex
+        force_mex_if_use_mex;
 
         % the property, related to high performance computing settings.
         % Here it provided for information only while changes to this
         % property should be made through hpc_config class setters directly.
-        high_perf_config_info
+        hpc_config;
 
         % add unit test folders to search path (option for testing)
         init_tests;
@@ -105,14 +105,14 @@ classdef hor_config < config_base
         % set horace_info_level method indicating how verbose Horace would be.
         %      The larger the value, the more information is printed.
         % See log_level for more details.
-        horace_info_level
+        horace_info_level;
 
         %   pixel_page_size   - Maximum memory size of pixel data array in
         %                       file-backed algorithms (units of bytes).
         % PixelData page size in bytes. Overrides mem_chunk_size for
         % filebased PixelData if pixel_page_size is smaller then
         % appropriate mem_chunk_size expressed in bytes.
-        pixel_page_size
+        pixel_page_size;
 
         % Information field:
         % true, if working directory has not ever been set
@@ -121,7 +121,7 @@ classdef hor_config < config_base
 
     properties(Access=protected, Hidden=true)
         % private properties behind public interface
-        mem_chunk_size_ = 10000000;
+        mem_chunk_size_ = 1e7;
 
         ignore_nan_ = true;
         ignore_inf_ = false;
@@ -215,7 +215,7 @@ classdef hor_config < config_base
             is = isempty(work_dir);
         end
 
-        function hpcc = get.high_perf_config_info(~)
+        function hpcc = get.hpc_config(~)
             hpcc = hpc_config;
         end
 

--- a/horace_core/configuration/@hor_config/hor_config.m
+++ b/horace_core/configuration/@hor_config/hor_config.m
@@ -113,6 +113,10 @@ classdef hor_config < config_base
         % filebased PixelData if pixel_page_size is smaller then
         % appropriate mem_chunk_size expressed in bytes.
         pixel_page_size
+
+        % Information field:
+        % true, if working directory has not ever been set
+        wkdir_is_default;
     end
 
     properties(Access=protected, Hidden=true)
@@ -201,7 +205,7 @@ classdef hor_config < config_base
             doinit = get_or_restore_field(this,'init_tests');
         end
 
-        function is = wkdir_is_default(~)
+        function is = get.wkdir_is_default(~)
             % return true if working directory has not been set and refers
             % to default (system tmp) directory
             % Usage

--- a/horace_core/configuration/@hpc_config/hpc_config.m
+++ b/horace_core/configuration/@hpc_config/hpc_config.m
@@ -132,8 +132,6 @@ classdef hpc_config < config_base
         use_mex_for_combine
         % if true, launch separate Matlab session(s) to generate tmp files
         accum_in_separate_process
-        % number of sessions to launch to calculate additional files
-        accumulating_process_num
     end
 
     properties(Access=protected,Hidden = true)
@@ -194,10 +192,6 @@ classdef hpc_config < config_base
 
         function accum = get.accum_in_separate_process(obj)
             accum = get_or_restore_field(obj,'build_sqw_in_parallel');
-        end
-
-        function accum = get.accumulating_process_num(obj)
-            accum = get_or_restore_field(obj,'parallel_workers_number');
         end
 
         function accum = get.build_sqw_in_parallel(obj)

--- a/horace_core/configuration/@hpc_config/hpc_config.m
+++ b/horace_core/configuration/@hpc_config/hpc_config.m
@@ -74,8 +74,8 @@ classdef hpc_config < config_base
         %            of MPI workers and the speed of parallel file system.
         % To select one of the options above, one can provide only first
         % distinctive input for any option. (e.g. ma, me or mp)
-
         combine_sqw_options;
+
         % If mex code is used for combining tmp files various thread
         % modes can be deployed for this operation:
         % namely:
@@ -116,7 +116,7 @@ classdef hpc_config < config_base
         % immutable reference to the class, which describes the parallel
         % configuration. To change the parallel configuration, work with
         % the configuration class itself;
-        parallel_configuration;
+        parallel_config;
 
         % helper read-only property, returning list of options, which
         % define hpc configuration. Set by saved_properties_list_
@@ -214,7 +214,7 @@ classdef hpc_config < config_base
             rem_f = config_store.instance.get_value('parallel_config','remote_folder');
         end
 
-        function config = get.parallel_configuration(~)
+        function config = get.parallel_config(~)
             config = parallel_config();
         end
 


### PR DESCRIPTION
Standardise names between different configurations:
- `par_threads` -> `parallel_threads`
- `known_clust_configs` -> `known_cluster_configs`
- Removed `accumulating_process_num`
- Moved `wkdir_is_default` and `is_auto_parallel_threads` to hidden blocks
- Made internal references to other configs be the actual name of the config.

Fixes #1047 