### PR TITLE
Fix C++ on GCC13

### DIFF
--- a/_LowLevelCode/cpp/CommonCode.h
+++ b/_LowLevelCode/cpp/CommonCode.h
@@ -23,7 +23,7 @@ inline void omp_set_num_threads(int nThreads) {};
 #endif
 
 
-#ifdef __cplusplus 
+#ifdef __cplusplus
 extern "C" bool utIsInterruptPending();
 extern "C" bool ioFlush(void);
 #else
@@ -85,7 +85,7 @@ T getMatlabScalar(const mxArray* pPar, const char* const fieldName) {
     if (mxGetM(pPar) != 1 || mxGetN(pPar) != 1) {
         std::stringstream buf;
         buf << " The input variable: " << *fieldName << " has to be a scalar\n";
-        mexErrMsgIdAndTxt("HORACE:getMatlabScalar_mex:invalid_argument", 
+        mexErrMsgIdAndTxt("HORACE:getMatlabScalar_mex:invalid_argument",
             buf.str().c_str());
     }
     return static_cast<T>(*mxGetPr(pPar));
@@ -146,7 +146,7 @@ public:
                     se_vec_stor.assign(new_data_size, 0.);
                     largeMemory = &se_vec_stor[0];
                 }
-                catch (...) // no space on stack try heap, 
+                catch (...) // no space on stack try heap,
                 {
                     largeMemory = (double*)mxCalloc(new_data_size, sizeof(double));
                     if (!largeMemory)throw("Can not allocate memory for processing data on threads. Decrease number of threads");
@@ -214,4 +214,3 @@ private:
     double* largeMemory;
 
 };
-

--- a/_LowLevelCode/cpp/combine_sqw/fileParameters.h
+++ b/_LowLevelCode/cpp/combine_sqw/fileParameters.h
@@ -1,6 +1,7 @@
 #ifndef H_FILE_PARAMETERS
 #define H_FILE_PARAMETERS
 
+#include <cstdint>
 #include <string>
 #include <map>
 #include <stdio.h>
@@ -26,7 +27,5 @@ public:
 private:
     static const std::map<std::string, int> fileParamNames;
 };
-
-
 
 #endif

--- a/_LowLevelCode/cpp/cpp_communicator/input_parser.h
+++ b/_LowLevelCode/cpp/cpp_communicator/input_parser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mex.h>
+#include <cstdint>
 #include <cstring>
 #include <sstream>
 #include <typeinfo>
@@ -98,7 +99,7 @@ struct InitParamHolder {
     int async_queue_length; // how many asynchronous messages could be placed into asynchronous queue
     int data_message_tag;    // the tag of a data message, to process synchronously.
     int interrupt_tag;    // the tag of an interrupt message, to process intermittently with any other type of messages.
-    int32_t debug_frmwk_param[2] = { 0,1 }; // in debug mode, this array contains fake labIndex and numLabs, 
+    int32_t debug_frmwk_param[2] = { 0,1 }; // in debug mode, this array contains fake labIndex and numLabs,
                               // used for testing framework in serial mode.
     InitParamHolder() :
         is_tested(false), async_queue_length(10), data_message_tag(8), interrupt_tag(100)

--- a/_LowLevelCode/cpp/serialiser/cpp_serialise.hpp
+++ b/_LowLevelCode/cpp/serialiser/cpp_serialise.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mex.h>
+#include <cstdint>
 #include <matrix.h>
 #include <limits>
 


### PR DESCRIPTION
GCC 13 doesn't seem to automatically include `cstdint` causing compilation errors