### PR TITLE
Make C and MATLAB serialisers return corresponding errors

### DIFF
--- a/_LowLevelCode/cpp/serialiser/c_deserialize.cpp
+++ b/_LowLevelCode/cpp/serialiser/c_deserialize.cpp
@@ -371,6 +371,10 @@ mxArray* deserialize(uint8_t* data, size_t& memPtr, size_t size, bool recursed) 
 
     }
     break;
+    default:
+      mexErrMsgIdAndTxt("MATLAB:deserialize:invalid_argument",
+                        "Cannot deserialize tag with ID: %d.",
+                        tag.type);
     }
 
     /* Avoid making plhs persistent,
@@ -395,7 +399,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
 #ifdef MX_COMPAT_32
     for (i = 0; i < nrhs; i++) {
         if (mxIsSparse(prhs[i])) {
-            mexErrMsgIdAndTxt("MATLAB:c_deserialize:NoSparseCompat",
+            mexErrMsgIdAndTxt("MATLAB:deserialize:NoSparseCompat",
                 "MEX-files compiled on a 64-bit platform that use sparse array functions "
                 "need to be compiled using -largeArrayDims.");
         }
@@ -404,10 +408,10 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
 #endif
 
     if (nlhs > 2) {
-        mexErrMsgIdAndTxt("MATLAB:c_deserialize:badLHS", "Bad number of LHS arguments in c_deserialize");
+        mexErrMsgIdAndTxt("MATLAB:deserialize:badLHS", "Bad number of LHS arguments in c_deserialize");
     }
     if (nrhs < 1 || nrhs > 2) {
-        mexErrMsgIdAndTxt("MATLAB:c_deserialize:badRHS", "Bad number of RHS arguments in c_deserialize");
+        mexErrMsgIdAndTxt("MATLAB:deserialize:badRHS", "Bad number of RHS arguments in c_deserialize");
     }
 
     // the position of the data in the input bytes array. By default, it's 0

--- a/_LowLevelCode/cpp/serialiser/c_serialize.cpp
+++ b/_LowLevelCode/cpp/serialiser/c_serialize.cpp
@@ -310,7 +310,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[] ) {
 #ifdef MX_COMPAT_32
   for (i=0; i<nrhs; i++)  {
     if (mxIsSparse(prhs[i])) {
-      mexErrMsgIdAndTxt("MATLAB:c_serialize:NoSparseCompat",
+      mexErrMsgIdAndTxt("MATLAB:serialize:NoSparseCompat",
                         "MEX-files compiled on a 64-bit platform that use sparse array functions "
                         "need to be compiled using -largeArrayDims.");
     }
@@ -319,10 +319,10 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[] ) {
 #endif
 
   if (nlhs > 1) {
-    mexErrMsgIdAndTxt("MATLAB:c_serialize:badLHS", "Bad number of LHS arguments in c_serialize");
+    mexErrMsgIdAndTxt("MATLAB:serialize:badLHS", "Bad number of LHS arguments in c_serialize");
   }
   if (nrhs != 1) {
-    mexErrMsgIdAndTxt("MATLAB:c_serialize:badRHS", "Bad number of RHS arguments in c_serialize");
+    mexErrMsgIdAndTxt("MATLAB:serialize:badRHS", "Bad number of RHS arguments in c_serialize");
   }
 
   mxArray* size_arr;

--- a/_test/test_serializers/test_cpp_deserialize.m
+++ b/_test/test_serializers/test_cpp_deserialize.m
@@ -1,6 +1,5 @@
 classdef test_cpp_deserialize < TestCase
     properties
-        warned
         use_mex
         old_mex
     end
@@ -13,7 +12,6 @@ classdef test_cpp_deserialize < TestCase
                 name  = 'test_cpp_deserialize';
             end
             this = this@TestCase(name);
-            this.warned = get(hor_config, 'log_level') > 0;
             this.old_mex = get(hor_config, 'use_mex');
             [~,nerr] = check_herbert_mex();
             this.use_mex = nerr == 0;
@@ -568,14 +566,13 @@ classdef test_cpp_deserialize < TestCase
             test_cell_rec{7} = func2str(test_cell_rec{7});
             assertEqual(test_cell, test_cell_rec)
         end
+
         function test_deserialize_invalid(obj)
-            skipTest('invalid arguments test disabled #817')
             if ~obj.use_mex
                 skipTest('MEX not enabled');
             end
             input = 'wrong input';
-            [a,n]=hlp_deserialize(input);
-            assertExcetionThrown(@()c_deserialize(input),'');
+            assertExceptionThrown(@()c_deserialize(input),'MATLAB:deserialize:invalid_argument');
 
         end
 

--- a/herbert_core/utilities/misc/hlp_deserialize.m
+++ b/herbert_core/utilities/misc/hlp_deserialize.m
@@ -57,8 +57,8 @@ switch typeID
     case 32
         [v,pos] = obj_deserialize_itself(m,pos);
     otherwise
-        error('HORACE:hlp_deserialize:invalid_argument', ...
-            'Cannot deserialize tag with ID: %d at position %d.',typeID,pos);
+        error('HORACE:deserialize:invalid_argument', ...
+              'Cannot deserialize tag with ID: %d at position %d.',typeID,pos);
 end
 end
 
@@ -246,7 +246,7 @@ switch fTag
             try
                 v = arg_report('handle',v,parentage{k});
             catch
-                error('MATLAB:deserialize_function_handle:hlp_deserialize',...
+                error('MATLAB:deserialize:invalid_argument',...
                     'Cannot deserialize a function handle to a nested function.')
             end
         end

--- a/herbert_core/utilities/misc/hlp_serialize.m
+++ b/herbert_core/utilities/misc/hlp_serialize.m
@@ -72,7 +72,7 @@ switch type.name
     case {'serializable'}
         m = serialize_themselves(v,type);
     otherwise
-        error('MATLAB:hlp_serialize:invalid_argument', 'Cannot serialize type %s.', type.name);
+        error('MATLAB:serialize:invalid_argument', 'Cannot serialize type %s.', type.name);
 end
 end
 
@@ -253,7 +253,7 @@ switch rep.type
         m = [comb_tag; ... Tag
             serialize_cell(rep.parentage, hlp_serial_types.get_details('cell'))]; % Parentage
     otherwise
-        warn_once('hlp_serialize:unknown_handle_type','A function handle with unsupported type "%s" was encountered; using a placeholder instead.',rep.type);
+        warn_once('serialize:unknown_handle_type','A function handle with unsupported type "%s" was encountered; using a placeholder instead.',rep.type);
         m = serialize_string(['<<hlp_serialize: function handle of type ' rep.type ' unsupported>>']);
 end
 end


### PR DESCRIPTION
Just renames error IDs, other changes and renames covered in #1064 

Fixes #817 