### PR TITLE
Add test comparing mem & fb diff paged; fix reporting of column name

### DIFF
--- a/_test/test_sqw_class/test_equal_to_tol.m
+++ b/_test/test_sqw_class/test_equal_to_tol.m
@@ -79,6 +79,7 @@ classdef test_equal_to_tol < TestCase & common_sqw_class_state_holder
             assertTrue(isa(new_sqw_paged.pix, 'PixelDataFileBacked'));
 
             assertFalse(equal_to_tol(new_sqw, new_sqw_paged));
+            assertFalse(equal_to_tol(new_sqw_paged, new_sqw));
         end
 
         function test_paged_sqw_objects_equal_if_pix_within_each_bin_shuffled(obj)

--- a/_test/test_sqw_class/test_equal_to_tol.m
+++ b/_test/test_sqw_class/test_equal_to_tol.m
@@ -1,8 +1,7 @@
 classdef test_equal_to_tol < TestCase & common_sqw_class_state_holder
 
     properties
-        horace_config;
-        log_level 
+        clOb;
 
         ALL_IN_MEM_PG_SIZE = 1e12;
 
@@ -19,12 +18,7 @@ classdef test_equal_to_tol < TestCase & common_sqw_class_state_holder
         function obj = test_equal_to_tol(~)
             obj = obj@TestCase('test_equal_to_tol');
 
-            hc = hor_config();
-
-            if hc.saveable
-                obj.horace_config  = hc.get_data_to_store();
-                hc.saveable = false;
-            end
+            obj.clOb = set_temporary_config_options(hor_config, 'log_level', -1);
 
             pths = horace_paths;
             obj.test_sqw_file_path = fullfile(pths.test_common, 'sqw_2d_1.sqw');
@@ -39,26 +33,6 @@ classdef test_equal_to_tol < TestCase & common_sqw_class_state_holder
             assertTrue(pix.is_filebacked);
 
             obj.sqw_2d = sqw(obj.test_sqw_file_path);
-        end
-
-        function delete(obj)
-            hc = hor_config;            
-            if ~isempty(obj.horace_config)
-                set(hor_config, obj.horace_config);
-            end
-            hc.saveable = true;            
-        end
-
-        function setUp(obj)
-            hc = hor_config();
-            hc.saveable = false;
-            obj.log_level= hc.log_level;
-            hc.log_level = 0;  % hide the (quite verbose) equal_to_tol output
-        end
-
-        function tearDown(obj)
-            hc = hor_config();            
-            hc.log_level = obj.log_level;
         end
 
         function test_the_same_sqw_objects_are_equal(obj)
@@ -92,6 +66,19 @@ classdef test_equal_to_tol < TestCase & common_sqw_class_state_holder
             shuffled_sqw.pix = obj.shuffle_pixel_bin_rows(pix, npix);
 
             assertEqualToTol(shuffled_sqw, original_sqw);
+        end
+
+        function test_paged_mem_sqw_ne_change_2nd_page(obj)
+            new_sqw = sqw.generate_cube_sqw(10);
+            clob = set_temporary_config_options(hor_config, 'mem_chunk_size', 50);
+            new_sqw_paged = new_sqw.copy();
+            new_sqw_paged.pix.data(4, 180) = -1;
+            new_sqw_paged.pix = PixelDataFileBacked(new_sqw_paged.pix);
+
+            assertTrue(isa(new_sqw.pix, 'PixelDataMemory'));
+            assertTrue(isa(new_sqw_paged.pix, 'PixelDataFileBacked'));
+
+            assertFalse(equal_to_tol(new_sqw, new_sqw_paged));
         end
 
         function test_paged_sqw_objects_equal_if_pix_within_each_bin_shuffled(obj)

--- a/horace_core/sqw/PixelData/@PixelDataBase/equal_to_tol.m
+++ b/horace_core/sqw/PixelData/@PixelDataBase/equal_to_tol.m
@@ -257,7 +257,7 @@ function mess = process_message(mess, offset, spacing, ix1, ix2)
     ind = str2num(match{1}{1});
 
     pix = floor(ind / 9);
-    col = PixelDataBase.COLS{mod(ind, 9)};
+    col = PixelDataBase.COLS{mod(ind-1, 9)+1};
 
     if ~exist('ix1', 'var')
         mess = sprintf([str{1} 'pixel %d (col=%s)'], offset + spacing*pix, col);

--- a/horace_core/sqw/PixelData/@PixelDataBase/equal_to_tol.m
+++ b/horace_core/sqw/PixelData/@PixelDataBase/equal_to_tol.m
@@ -257,7 +257,7 @@ function mess = process_message(mess, offset, spacing, ix1, ix2)
     ind = str2num(match{1}{1});
 
     pix = floor(ind / 9);
-    col = PixelDataBase.COLS{mod(ind, 9)+1};
+    col = PixelDataBase.COLS{mod(ind, 9)};
 
     if ~exist('ix1', 'var')
         mess = sprintf([str{1} 'pixel %d (col=%s)'], offset + spacing*pix, col);

--- a/horace_core/sqw/PixelData/@PixelDataBase/equal_to_tol.m
+++ b/horace_core/sqw/PixelData/@PixelDataBase/equal_to_tol.m
@@ -256,7 +256,7 @@ function mess = process_message(mess, offset, spacing, ix1, ix2)
 
     ind = str2num(match{1}{1});
 
-    pix = floor(ind / 9);
+    pix = floor(ind / 9)+1;
     col = PixelDataBase.COLS{mod(ind-1, 9)+1};
 
     if ~exist('ix1', 'var')


### PR DESCRIPTION
- Add test comparing mem & fb are different if nth page is modified.
- Fix reporting of column name

Related to issue raised by @abuts about comparisons between mem & filebacked pix not checking all pages.