### PR TITLE
simple fix

### DIFF
--- a/_test/test_serializers/test_serializable_class_2.m
+++ b/_test/test_serializers/test_serializable_class_2.m
@@ -7,12 +7,12 @@ classdef test_serializable_class_2 < TestCaseWithSave
         atms
         path
     end
-    
+
     methods
         %--------------------------------------------------------------------------
         function obj = test_serializable_class_2 (name)
             obj@TestCaseWithSave(name);
-            
+
             % Arrays for construction of detectors
             % Note: have varying paths w.r.t. detector coordinate frame
             dia(1) = 0.0254;  height(1) = 0.015; wall(1) = 6.35e-4; atms(1) = 10; th(1) = pi/2;
@@ -20,13 +20,13 @@ classdef test_serializable_class_2 < TestCaseWithSave
             dia(3) = 0.0400;  height(3) = 0.035; wall(3) = 15.0e-4; atms(3) = 4;  th(3) = 0.775;
             dia(4) = 0.0400;  height(4) = 0.035; wall(4) = 15.0e-4; atms(4) = 7;  th(4) = 0.775;
             dia(5) = 0.0400;  height(5) = 0.035; wall(5) = 15.0e-4; atms(5) = 9;  th(5) = 0.775;
-            
+
             obj.dia = dia;
             obj.height = height;
             obj.wall = wall;
             obj.atms = atms;
             obj.path = [sin(th); zeros(size(th)); cos(th)];
-            
+
             obj.save()
         end
 
@@ -40,32 +40,32 @@ classdef test_serializable_class_2 < TestCaseWithSave
             % Test alternastive ways of calling from_bare_struct
             % for a single detector
             dets_ref = construct_detectors (obj);
-            
+
             % Structures from single detector
             S = to_struct (dets_ref(1));
             Sbare = to_bare_struct (dets_ref(1));
-            
+
             % Recover detector
             det_1 = serializable.from_struct (S);
             det_1_bare = from_bare_struct (serializableTester3, Sbare);
             myobj = serializableTester3();
             det_1_bare_alternate = myobj.from_bare_struct (Sbare);
-            
+
             assertEqual (dets_ref(1), det_1)
             assertEqual (dets_ref(1), det_1_bare)
             assertEqual (dets_ref(1), det_1_bare_alternate)
-        end       
+        end
 
         %--------------------------------------------------------------------------
         function test_to_bare_struct_2 (obj)
             % Test alternastive ways of calling from_bare_struct
             % for a multiple detectors
             dets_ref = construct_detectors (obj);
-            
+
             % Structures from array of detectors
             S = to_struct (dets_ref);
             Sbare = to_bare_struct (dets_ref);
-            
+
             % Recover array of detectors
             dets = serializable.from_struct (S);
             dets_bare = from_bare_struct (serializableTester3, Sbare);
@@ -76,41 +76,41 @@ classdef test_serializable_class_2 < TestCaseWithSave
             assertEqual (dets_ref, dets_bare)
             assertEqual (dets_ref, dets_bare_alternate)
         end
-                
+
         %--------------------------------------------------------------------------
         function test_saveobj_1 (obj)
             % Test save and load for a single detector
             dets_ref = construct_detectors (obj);
-            
+
             % Save single detector
             det_1_ref = dets_ref(1);
 
             test_file = fullfile (tmp_dir(), 'test_serializable_saveobj_1.mat');
             cleanup = onCleanup(@()delete(test_file));
             save (test_file, 'det_1_ref');
-            
+
             % Recover detector
             tmp = load (test_file);
-            
+
             assertEqual (det_1_ref, tmp.det_1_ref)
         end
-                
+
         %--------------------------------------------------------------------------
         function test_saveobj_2 (obj)
             % Test save and load for multiple detectors
             dets_ref = construct_detectors (obj);
-            
+
             % Save detector array
             test_file = fullfile (tmp_dir(), 'test_serializable_saveobj_2.mat');
             cleanup = onCleanup(@()delete(test_file));
             save (test_file, 'dets_ref');
-            
+
             % Recover detector array
             tmp = load (test_file);
-            
+
             assertEqual (dets_ref, tmp.dets_ref)
         end
-                
+
         %--------------------------------------------------------------------------
         % Test reading old class versions
         %--------------------------------------------------------------------------
@@ -149,7 +149,7 @@ classdef test_serializable_class_2 < TestCaseWithSave
             end
             assertEqual (dets_ref, tmp.dets_ver1)
         end
-                
+
         function test_ver1_reserialize (obj)
             % Test save and load for multiple detectors
             % save/load will treat each detector in the array individually i.e
@@ -157,7 +157,7 @@ classdef test_serializable_class_2 < TestCaseWithSave
             % object functionality
             % serialize/deserialize treats the array as a whole, so exercises
             % the .array_dat field in to_struct/from_struct
-            serializableTester3.version_holder(2);            
+            serializableTester3.version_holder(2);
             dets_ref = construct_detectors (obj);
 
             % Serialize detector array - ver1
@@ -172,20 +172,20 @@ classdef test_serializable_class_2 < TestCaseWithSave
             dets_ver1_reserialized = serializableTester3.deserialize (byte_array);
 
             % Confirm that reserialisation of ver1 detectors results in version 2
-            % classes, with value for property 'wall' from convert_old_struct            
+            % classes, with value for property 'wall' from convert_old_struct
             for i=1:numel(dets_ver1)
-                dets_ref(i).wall = 1e-7;
-                dets_ref(i).atms = 27;
+                dets_ref(i).wall = 1e-6;
+                assertEqual (dets_ref(i), dets_ver1_reserialized(i))
             end
-            assertEqual (dets_ref, dets_ver1_reserialized)
+
         end
-                
+
         function test_verNaN_from_struct (obj)
             % Cannot test save and load for multiple detectors directly as
             % serializable does not have a mechanism to save pre-serializable
             % class versions.
-            % The nearest we can do is create a bare structure with the verNaN 
-            % form (which mimics te structure of our notional pre-serializable 
+            % The nearest we can do is create a bare structure with the verNaN
+            % form (which mimics te structure of our notional pre-serializable
             % bare structure) and use from_struct to generate the latest version
             dets_ref = construct_detectors (obj);
 
@@ -207,12 +207,12 @@ classdef test_serializable_class_2 < TestCaseWithSave
             end
             assertEqual (dets_ref, tmp)
         end
-                
+
         %--------------------------------------------------------------------------
         % Utility methods
         %--------------------------------------------------------------------------
         function dets = construct_detectors (obj)
-            % Create array of single IX_det_He3tube objects, and the 
+            % Create array of single IX_det_He3tube objects, and the
             % equivalent IX_det_He3tube object containing an array of
             % detectors.
             dets = repmat(serializableTester3, [1,5]);
@@ -220,9 +220,9 @@ classdef test_serializable_class_2 < TestCaseWithSave
                 dets(i) = serializableTester3 (obj.dia(i), obj.height(i), obj.wall(i), obj.atms(i));
             end
         end
-        
+
         %--------------------------------------------------------------------------
     end
-    
-    
+
+
 end

--- a/herbert_core/utilities/classes/@serializable/private/from_struct_.m
+++ b/herbert_core/utilities/classes/@serializable/private/from_struct_.m
@@ -71,17 +71,6 @@ else
     % Structure was created from an earlier version of a serializable object, or
     % has a different provenance e.g. came from an older format that predates
     % the use of serializable
-    if isfield(S,'array_dat')
-        S = S.array_dat;
-    end
-    if numel(S)>1
-        obj = repmat(obj,size(S));
-    end
-    for i=1:numel(S)
-        obj(i).do_check_combo_arg = false;
-        obj(i) = obj(i).from_old_struct (S(i));
-        obj(i).do_check_combo_arg = true;
-        obj(i) = obj(i).check_combo_arg();
-    end
+    obj = obj.from_old_struct (S);
 
 end


### PR DESCRIPTION
which just removes all unnecessary checks. The `test_IX_experiment` which was erroneously faling before is working fine