### PR TITLE
1066 Add filebacking to section

### DIFF
--- a/_test/test_sqw_class/test_section.m
+++ b/_test/test_sqw_class/test_section.m
@@ -15,6 +15,19 @@ classdef test_section < TestCase
             assertTrue(obj.is_bins_subset_of(test_sec.data.axes.p, w.data.axes.p));
         end
 
+        function obj = test_section_sqw_fb(obj)
+            w = sqw.generate_cube_sqw(10);
+            test_sec_mb = w.section([-3 3], [], [], []);
+
+            clob = set_temporary_config_options(hor_config, 'mem_chunk_size', 500);
+            w.pix = PixelDataFileBacked(w.pix);
+
+            test_sec_fb = w.section([-3 3], [], [], []);
+
+            assertEqualToTol(test_sec_mb, test_sec_fb, 'ignore_str', true);
+
+        end
+
         function obj = test_section_collapse_dim(obj)
             w = sqw.generate_cube_sqw(10);
             test_sec = w.section([-1 0], [], [], []);

--- a/horace_core/sqw/@sqw/section.m
+++ b/horace_core/sqw/@sqw/section.m
@@ -77,6 +77,7 @@ for n = 1:numel(win)
 
             pix_ind = 1;
 
+            new_pix_range = [];
             for iter = 1:num_chunks
                 chunk = block_chunks{iter};
                 pix_start = chunk{1};
@@ -84,12 +85,14 @@ for n = 1:numel(win)
 
                 data = win(n).pix.get_pix_in_ranges(pix_start, block_sizes, false, false);
 
+                new_pix_range = minmax_ranges(new_pix_range, data.pix_range);
+
                 wout(n).pix.format_dump_data(data.data, pix_ind);
 
                 pix_ind = pix_ind + data.num_pixels;
 
             end
-
+            wout(n).pix.pix_range = new_pix_range;
             wout(n).pix = wout(n).pix.finalise(pix_ind-1);
 
         else

--- a/horace_core/sqw/@sqw/section.m
+++ b/horace_core/sqw/@sqw/section.m
@@ -67,7 +67,34 @@ for n = 1:numel(win)
                                         new_axis, ...
                                         win(n).data.proj);
 
-        wout(n).pix = win(n).pix.get_pix_in_ranges(bl_start,bl_size);
+        if win(n).pix.is_filebacked
+            chunk_size = get(hor_config, 'mem_chunk_size');
+
+            block_chunks = split_data_blocks(bl_start, bl_size, chunk_size);
+            num_chunks = numel(block_chunks);
+
+            wout(n) = wout(n).get_new_handle();
+
+            pix_ind = 1;
+
+            for iter = 1:num_chunks
+                chunk = block_chunks{iter};
+                pix_start = chunk{1};
+                block_sizes = chunk{2};
+
+                data = win(n).pix.get_pix_in_ranges(pix_start, block_sizes, false, false);
+
+                wout(n).pix.format_dump_data(data.data, pix_ind);
+
+                pix_ind = pix_ind + data.num_pixels;
+
+            end
+
+            wout(n).pix = wout(n).pix.finalise(pix_ind-1);
+
+        else
+            wout(n).pix = win(n).pix.get_pix_in_ranges(bl_start,bl_size);
+        end
     end
 end
 


### PR DESCRIPTION
Add filebacked calculation capabilities to `sqw.section` to filter pixels, along with corresponding unit test.

Fixes #1066