### PR TITLE
Fix CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,12 @@ if(POLICY CMP0074)
     # Ignore warnings when setting <MODULE>_ROOT variables
     cmake_policy(SET CMP0074 NEW)
 endif()
-cmake_policy(SET CMP0115 NEW)
-cmake_policy(SET CMP0109 OLD)
+if(POLICY CMP0115)
+  cmake_policy(SET CMP0115 NEW)
+endif()
+if(POLICY CMP0109)
+  cmake_policy(SET CMP0109 OLD)
+endif()
 
 # Add cmake directory to CMake's path
 list(APPEND CMAKE_MODULE_PATH "${Horace_ROOT}/cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ if(POLICY CMP0074)
     # Ignore warnings when setting <MODULE>_ROOT variables
     cmake_policy(SET CMP0074 NEW)
 endif()
+cmake_policy(SET CMP0115 NEW)
+cmake_policy(SET CMP0109 OLD)
 
 # Add cmake directory to CMake's path
 list(APPEND CMAKE_MODULE_PATH "${Horace_ROOT}/cmake"

--- a/_LowLevelCode/cpp/test/get_ascii_file.tests/CMakeLists.txt
+++ b/_LowLevelCode/cpp/test/get_ascii_file.tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(TEST_SRC_FILES
-    "IIget_ascii_file.test"
+    "IIget_ascii_file.test.cpp"
 )
 
 set(SRC_FILES

--- a/cmake/shared/PACE_FindGTest.cmake
+++ b/cmake/shared/PACE_FindGTest.cmake
@@ -38,7 +38,7 @@ This script is based on the script given in the CMake guide on GoogleTest's
 GitHub https://github.com/google/googletest/blob/master/googletest/README.md.
 
 #]=======================================================================]
-set(GTEST_VERSION "1.10.0")
+set(GTEST_VERSION "1.12.1")
 
 set(GTEST_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/googletest-download")
 # Copy the CMakeLists file that imports the external project


### PR DESCRIPTION
Fix CMake policies and update `googletest` to avoid CMake generated warnings.

Fixes #568 