### PR TITLE
Make symmetrise operate in projection basis

### DIFF
--- a/horace_core/sqw/@sqw/symmetrise_sqw.m
+++ b/horace_core/sqw/@sqw/symmetrise_sqw.m
@@ -98,9 +98,10 @@ if isa(sym, 'SymopReflection')
 
     for i = 1:fold
         % transform existing range into transformed range
-        idx = ~sym(i).in_irreducible(cc_exist_range);
+        idx = ~sym(i).in_irreducible(cc_exist_range, win.data.proj);
         cc_exist_range(:,idx) = sym(i).transform_vec(cc_exist_range(:,idx));
     end
+
 elseif isa(sym, 'SymopRotation')
     cc_exist_range = [cc_ranges]; % Keep old range
 end

--- a/horace_core/sqw/@sqw/symmetrise_sqw.m
+++ b/horace_core/sqw/@sqw/symmetrise_sqw.m
@@ -58,14 +58,16 @@ end
 if isa(varargin{end}, 'aProjection')
     proj = varargin(end);
     varargin = varargin(1:end-1);
+
+    if ~proj{1}.nonorthogonal
+        error('HORACE:symmetrise_sqw:invalid_argument', ...
+              'Cannot symmetrise to non-orthogonal projection');
+    end
+
 else
     proj = {};
 end
 
-if ~proj.nonorthogonal
-    error('HORACE:symmetrise_sqw:invalid_argument', ...
-          'Cannot symmetrise to non-orthogonal projection');
-end
 
 
 
@@ -87,9 +89,7 @@ wout = copy(win);
 
 [sym, fold] = validate_sym(sym);
 transforms = arrayfun(@(x) @x.transform_pix, sym, 'UniformOutput', false);
-wout = wout.apply(transforms, {win.data.proj}, false);
-
-wout.pix = sym.transform_pix(wout.pix, proj{:});
+wout = wout.apply(transforms, {proj{:}}, false);
 
 %=========================================================================
 % Transform Ranges:

--- a/horace_core/sqw/@sqw/symmetrise_sqw.m
+++ b/horace_core/sqw/@sqw/symmetrise_sqw.m
@@ -62,7 +62,7 @@ else
     proj = {};
 end
 
-if ~proj.isorthogonal
+if ~proj.nonorthogonal
     error('HORACE:symmetrise_sqw:invalid_argument', ...
           'Cannot symmetrise to non-orthogonal projection');
 end

--- a/horace_core/sqw/@sqw/symmetrise_sqw.m
+++ b/horace_core/sqw/@sqw/symmetrise_sqw.m
@@ -104,7 +104,7 @@ exp_range = expand_box(existing_range(1,1:3), existing_range(2,1:3));
 cc_ranges = proj.transform_img_to_pix(exp_range);
 
 % identify intersection points between the image range and the symmetry plane
-if isa(sym, 'SymopReflection') && isempty(proj)
+if isa(sym, 'SymopReflection')
 
     cc_exist_range = [cc_ranges];
     for i = 1:fold

--- a/horace_core/sqw/@sqw/symmetrise_sqw.m
+++ b/horace_core/sqw/@sqw/symmetrise_sqw.m
@@ -70,7 +70,7 @@ wout = copy(win);
 
 [sym, fold] = validate_sym(sym);
 transforms = arrayfun(@(x) @x.transform_pix, sym, 'UniformOutput', false);
-wout = wout.apply(transforms, {}, false);
+wout = wout.apply(transforms, {win.data.proj}, false);
 
 %=========================================================================
 % Transform Ranges:

--- a/horace_core/symop/@SymopReflection/SymopReflection.m
+++ b/horace_core/symop/@SymopReflection/SymopReflection.m
@@ -67,10 +67,16 @@ classdef SymopReflection < Symop
             normvec = normvec / norm(normvec);
         end
 
-        function selected = in_irreducible(obj, coords)
+        function selected = in_irreducible(obj, coords, proj)
         % Compute whether the coordinates in `coords` are in the irreducible
         % set following the operation
-            selected = coords'*obj.normvec > 0;
+
+            if exist('proj', 'var')
+                selected = coords'*proj.transform_img_to_pix(obj.normvec) > 0;
+            else
+                selected = coords'*obj.normvec > 0;
+            end
+
         end
 
         function R = calculate_transform(obj, Minv)

--- a/horace_core/symop/@SymopReflection/SymopReflection.m
+++ b/horace_core/symop/@SymopReflection/SymopReflection.m
@@ -99,7 +99,7 @@ classdef SymopReflection < Symop
         % ------
         %   obj     Symmetry operator object (scalar)
         %   Minv    Matrix to convert components of a vector given in rlu to those
-        %          in an orthonormal frame
+        %             in an orthonormal frame
         %
         % Output:
         % -------

--- a/horace_core/symop/@SymopRotation/SymopRotation.m
+++ b/horace_core/symop/@SymopRotation/SymopRotation.m
@@ -57,7 +57,7 @@ classdef SymopRotation < Symop
             theta_deg = obj.theta_deg_;
         end
 
-        function selected = in_irreducible(obj, coords)
+        function selected = in_irreducible(obj, coords, proj)
         % Compute whether the coordinates in `coords` (Q) are in the irreducible
         % set following the symmetry reduction under this operator
         %
@@ -68,6 +68,11 @@ classdef SymopRotation < Symop
         % And thus any coordinate `q` from `Q` where
         % q*(n x u) > 0 && q*(v x n) > 0
         % belong to the irreducible set in the upper right quadrant
+
+            if ~exist('proj', 'var')
+                proj = ortho_proj();
+            end
+
             n = obj.n / norm(obj.n);
             if sum(abs(n - [1; 0; 0])) > 1e-1
                 u = [1; 0; 0];
@@ -76,6 +81,10 @@ classdef SymopRotation < Symop
             end
 
             v = obj.transform_vec(u);
+
+            u = proj.transform_img_to_pix(u);
+            v = proj.transform_img_to_pix(v);
+
             normvec_u = cross(n, u);
             normvec_v = cross(v, n);
 


### PR DESCRIPTION
Transform symmetry irreducible region according to current projection to symmetrise in the basis of the current projection rather than the cartesian lattice basis. 

Only currently considering lattice-based projections (`ortho_proj`) may have trouble with others. Will consult and add warning as necessary.

Needs unit tests to prove

Fixes #1039