### PR TITLE
Make split fb-safe

### DIFF
--- a/horace_core/sqw/@sqw/split.m
+++ b/horace_core/sqw/@sqw/split.m
@@ -29,7 +29,7 @@ npix = w.data.npix;
 pix = w.pix;
 
 % Sort (an index array to) pix into increasing run number, and increasing bin number within each run
-irun = pix.run_idx';
+irun = pix.get_fields('run_idx')';
 ibin = replicate_array (1:numel(npix),npix);
 [runbin,ix] = sortrows([irun,ibin]);  % get index of run
 irun = runbin(:,1);


### PR DESCRIPTION
Use `get_fields` to load all run_idx.

Fixes #1119 