### PR TITLE
Fix date time comparison once and for all

### DIFF
--- a/_test/test_sqw_class/test_equal_to_tol.m
+++ b/_test/test_sqw_class/test_equal_to_tol.m
@@ -37,7 +37,7 @@ classdef test_equal_to_tol < TestCase & common_sqw_class_state_holder
 
         function test_datetime_equal_to_tol(obj)
             % Times within a minute of each other are equal
-            assertEqualToTol('2023-07-18T18:47:41', '2023-07-18T18:47:44');
+            assertEqualToTol('2023-07-18T18:47:01', '2023-07-18T18:47:59');
             [ok, mess] = equal_to_tol('2023-07-18T18:47:41', '2023-07-18T18:49:41');
             assertFalse(ok);
             assertEqual(mess, 'lhs_obj and rhs_obj: Character arrays being compared are not equal');

--- a/_test/test_sqw_class/test_equal_to_tol.m
+++ b/_test/test_sqw_class/test_equal_to_tol.m
@@ -35,6 +35,14 @@ classdef test_equal_to_tol < TestCase & common_sqw_class_state_holder
             obj.sqw_2d = sqw(obj.test_sqw_file_path);
         end
 
+        function test_datetime_equal_to_tol(obj)
+            % Times within a minute of each other are equal
+            assertEqualToTol('2023-07-18T18:47:41', '2023-07-18T18:47:44');
+            [ok, mess] = equal_to_tol('2023-07-18T18:47:41', '2023-07-18T18:49:41');
+            assertFalse(ok);
+            assertEqual(mess, 'lhs_obj and rhs_obj: Character arrays being compared are not equal');
+        end
+
         function test_the_same_sqw_objects_are_equal(obj)
             sqw_copy = obj.sqw_2d;
             assertEqualToTol(obj.sqw_2d, sqw_copy);

--- a/herbert_core/utilities/maths/equal_to_tol.m
+++ b/herbert_core/utilities/maths/equal_to_tol.m
@@ -552,6 +552,19 @@ elseif ischar(a) && ischar(b)
             name_a,name_b);
     end
 
+    if ~isempty(regexp(a, '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'))
+        % Probably Dealing with datetime string
+        try
+            a = main_header_cl.convert_datetime_from_str(a);
+            b = main_header_cl.convert_datetime_from_str(b);
+            % Allow separation of up to 1 minute to be same
+            if abs(posixtime(a) - posixtime(b)) < 60
+                return
+            end
+        catch
+        end
+    end
+
     if ~strcmp(a,b)
         error('HERBERT:equal_to_tol:inputs_mismatch',...
             '%s and %s: Character arrays being compared are not equal',...
@@ -655,7 +668,7 @@ abs_tol = tol(1);
 rel_tol = tol(2);
 if ~isa(a,class(b))
     a = double(a);
-    b = double(b);    
+    b = double(b);
 end
 if abs_tol==0 && rel_tol==0
 

--- a/herbert_core/utilities/maths/equal_to_tol.m
+++ b/herbert_core/utilities/maths/equal_to_tol.m
@@ -552,7 +552,7 @@ elseif ischar(a) && ischar(b)
             name_a,name_b);
     end
 
-    if ~isempty(regexp(a, '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'))
+    if isrow(a) && ~isempty(regexp(a, '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'))
         % Probably Dealing with datetime string
         try
             a = main_header_cl.convert_datetime_from_str(a);

--- a/herbert_core/utilities/maths/equal_to_tol.m
+++ b/herbert_core/utilities/maths/equal_to_tol.m
@@ -553,7 +553,7 @@ elseif ischar(a) && ischar(b)
     end
 
     if isrow(a) && ~isempty(regexp(a, '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'))
-        % Probably Dealing with datetime string
+        % Probably dealing with datetime string
         try
             a = main_header_cl.convert_datetime_from_str(a);
             b = main_header_cl.convert_datetime_from_str(b);


### PR DESCRIPTION
Get rid of intermediate failures with `datetime` mismatches by comparing actual times. If within one minute of each other, considered equal.