### PR TITLE
Replace get with object name directly (Horace GUI Fixes)

### DIFF
--- a/horace_core/GUI/horace.m
+++ b/horace_core/GUI/horace.m
@@ -290,10 +290,10 @@ ds = sqw(w_in);
 
 %Get the info about the object:
 if has_pixels(w_in)
-    getit=get(w_in);
-    gg=getit.data;
+    getit = w_in;
+    gg = w_in.data;
 else
-    gg=get(w_in);
+    gg = w_in;
 end
 
 


### PR DESCRIPTION
Object is in local workspace and `get` causes issues. 