### PR TITLE
Stop `herbert_init` trying to load `hor_config`

### DIFF
--- a/herbert_core/herbert_init.m
+++ b/herbert_core/herbert_init.m
@@ -37,21 +37,6 @@ genieplot_init
 % Applications definitions
 addgenpath_message (herbert_path,'applications')
 
-
-% set up multi-users computer specific settings,
-% namely settings which are common for all new users of the specific computer
-% e.g.:
-parc = parallel_config();
-if parc.is_default
-    warning(['Found Herbert is not configured. ',...
-        ' Setting up the configuration, identified as optimal for this type of the machine.',...
-        ' Please, check configurations (typing:',...
-        ' >>parallel_config)',...
-        ' to ensure this configuration is correct.'])
-    ocp = opt_config_manager();
-    ocp.load_configuration('-set_config','-change_only_default','-force_save');
-end
-
 print_banner();
 
 end

--- a/horace_core/horace_init.m
+++ b/horace_core/horace_init.m
@@ -82,8 +82,12 @@ if hc.init_tests % this is developer version
     addpath(fullfile(root_path,'_test','common_functions'));
 end
 
-hpcc = hpc_config;
-if hc.is_default || hpcc.is_default
+% set up multi-users computer specific settings,
+% namely settings which are common for all new users of the specific computer
+% e.g.:
+hpcc = hpc_config();
+parc = parallel_config();
+if hc.is_default || hpcc.is_default || parc.is_default
     warning([' Found Horace is not configured. ',...
         ' Setting up the configuration, identified as optimal for this type of the machine.',...
         ' Please, check configurations (typing:',...
@@ -93,11 +97,8 @@ if hc.is_default || hpcc.is_default
     conf_c = opt_config_manager();
     conf_c.load_configuration('-set_config','-change_only_default','-force_save');
 end
-check_mex = false;
+
 if hc.is_default
-    check_mex = true;
-end
-if check_mex
     [~, n_mex_errors] = check_horace_mex();
     hc.use_mex = n_mex_errors < 1;
 end


### PR DESCRIPTION
`herbert_init` tries to load `hor_config` as part of the `optimal_config` loader. This causes a crash as `hor_config` has not been included in the search path yet. This is called as part of `horace_init` anyway.

Fixes #1204 