### PR TITLE
Modify runmap_id code to remove slowdown

### DIFF
--- a/horace_core/Tobyfit/tobyfit_DGdisk_resconv_init.m
+++ b/horace_core/Tobyfit/tobyfit_DGdisk_resconv_init.m
@@ -236,8 +236,9 @@ for iw=1:nw
     %  pixels have been shifted, so recalculate)
     [deps,eps_lo,eps_hi,ne]=energy_transfer_info(wtmp.experiment_info);
     irun_max = max(irun);
+    id_max = wtmp.runid_map;
     if irun_max>numel(ne)
-        irun = arrayfun(@(x)wtmp.runid_map(x),irun);
+        irun = arrayfun(@(x)id_max(x),irun);
     end
     if ne>1
         eps=(eps_lo(irun).*(ne(irun)-ien)+eps_hi(irun).*(ien-1))./(ne(irun)-1);


### PR DESCRIPTION
In issue #1135 @abuts  identifies a slowdown due to refetching runmap_id from its parent SQW within an arrayfun. This PR follows his suggestion to factor the fetch outside of the arrayfun.
