### PR TITLE
Test herbert and horace versions of replicate_array

### DIFF
--- a/_test/test_algorithms/test_replicate.m
+++ b/_test/test_algorithms/test_replicate.m
@@ -1,0 +1,53 @@
+classdef test_replicate < TestCase
+    
+    properties
+    end
+    
+    methods
+        
+        function obj = test_replicate(varargin)
+            if nargin > 0
+                name = varargin{1};
+            else
+                name= mfilename('class');
+            end
+            obj = obj@TestCase(name);
+        end
+        
+        function test_replicate_herbert(~)
+            % test the herbert replicate_array
+            
+            % array of numbers of replicates to be added
+            np = [1 2 3 4 5 6 7 8 9 10];
+            % array of things to be replicated
+            vv = [111 222 333 444 555 666 777 888 999 1000];
+            % replication of vv by np using the herbert/utilities/maths
+            % version of replicate array
+            ww = replicate_array(vv,np);
+
+            % check size of replicated array
+            assertEqual( numel(ww), 55);
+            % check last members of replications are correct
+            assertEqual([ww(1),ww(3),ww(6),ww(10),ww(15), ...
+                         ww(21),ww(28),ww(36),ww(45),ww(55)], ...
+                         [111 222 333 444 555 666 777 888 999 1000]);
+            % check first members of replications are correct
+            assertEqual([ww(1),ww(2),ww(4),ww(7),ww(11), ...
+                         ww(16),ww(22),ww(29),ww(37),ww(46)], ...
+                         [111 222 333 444 555 666 777 888 999 1000]);
+        end
+        
+        
+        function test_replicate_horace(~)
+            % test the horace replicate_array in @sqw
+            % this was going to be a clone of the herbert version above.
+            % however the horace version is a static method in a private
+            % folder of the class and according to the matlab help should
+            % therefore not exist. Accordingly this test is skipped but
+            % retained here to point out the problem which may be fixed
+            % some day.
+            skipTest(' ');
+        end
+ 
+    end
+end

--- a/_test/test_algorithms/test_replicate.m
+++ b/_test/test_algorithms/test_replicate.m
@@ -24,7 +24,9 @@ classdef test_replicate < TestCase
             % replication of vv by np using the herbert/utilities/maths
             % version of replicate array
             ww = replicate_array(vv,np);
-
+            ww = replicate_array(vv,np); %replicate_array(vv,np);
+            
+            
             % check size of replicated array
             assertEqual( numel(ww), 55);
             % check last members of replications are correct
@@ -36,18 +38,30 @@ classdef test_replicate < TestCase
                          ww(16),ww(22),ww(29),ww(37),ww(46)], ...
                          [111 222 333 444 555 666 777 888 999 1000]);
         end
-        
-        
+
         function test_replicate_horace(~)
-            % test the horace replicate_array in @sqw
-            % this was going to be a clone of the herbert version above.
-            % however the horace version is a static method in a private
-            % folder of the class and according to the matlab help should
-            % therefore not exist. Accordingly this test is skipped but
-            % retained here to point out the problem which may be fixed
-            % some day.
-            skipTest(' ');
+            % test the herbert replicate_array
+            
+            % array of numbers of replicates to be added
+            np = [1 2 3 4 5 6 7 8 9 10];
+            % array of things to be replicated
+            vv = [111 222 333 444 555 666 777 888 999 1000];
+            % replication of vv by np using the herbert/utilities/maths
+            % version of replicate array
+            ww = sqw.TESTONLY_replicatearray(vv,np);
+            
+            
+            % check size of replicated array
+            assertEqual( numel(ww), 55);
+            % check last members of replications are correct
+            assertEqual([ww(1),ww(3),ww(6),ww(10),ww(15), ...
+                         ww(21),ww(28),ww(36),ww(45),ww(55)], ...
+                         [111 222 333 444 555 666 777 888 999 1000]);
+            % check first members of replications are correct
+            assertEqual([ww(1),ww(2),ww(4),ww(7),ww(11), ...
+                         ww(16),ww(22),ww(29),ww(37),ww(46)], ...
+                         [111 222 333 444 555 666 777 888 999 1000]);
         end
- 
+
     end
 end

--- a/herbert_core/utilities/maths/replicate_array.m
+++ b/herbert_core/utilities/maths/replicate_array.m
@@ -36,4 +36,3 @@ else
         ['The number of elements in input array ''v'' (%d) is different from \n', ...
         'the number of elements in input array ''n'' (%d)'], numel(v),numel(n));
 end
-

--- a/herbert_core/utilities/maths/replicate_array.m
+++ b/herbert_core/utilities/maths/replicate_array.m
@@ -36,3 +36,4 @@ else
         ['The number of elements in input array ''v'' (%d) is different from \n', ...
         'the number of elements in input array ''n'' (%d)'], numel(v),numel(n));
 end
+

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -155,7 +155,17 @@ classdef (InferiorClasses = {?d0d, ?d1d, ?d2d, ?d3d, ?d4d}) sqw < SQWDnDBase & s
     %======================================================================
     % METHODS, Available on SQW but redirecting actions to DnD and requesting
     % only DND object for implementation.
+    methods(Static)
+        
+        function ww=TESTONLY_replicatearray(vv,np)
+            % exposes replicate_array for testing purposes only
+            ww = replicate_array(vv,np);
+        end
+        
+    end
+    
     methods
+        
         function [nd,sz] = dimensions(win)
             % Return size and shape of the image
             % arrays in sqw or dnd object


### PR DESCRIPTION
Visual inspection of the 2 replicate_array methods in horace and herbert indiciate that they have identical functionality although they are differently implemented; one uses an array_func to make individual replicas which are concatenated, while the other makes a large array, works out the replica positions and fills them.

This PR provides a test for the herbert version. The horace version is tested similarly by providing a public static interface function in the sqw.m file itself. It may be that this needs to be retired after this testing to preserve the integrity of the sqw class.

Alex claims that the horace version is twice as fast. Additional timings for this test suggest that for this size test the timing can vary either way so that issue is not dealt with here.

Related: #848 