### PR TITLE
Update test_smooth so only issue 628 problems remain

### DIFF
--- a/_test/test_dnd_class/test_smooth.m
+++ b/_test/test_dnd_class/test_smooth.m
@@ -84,8 +84,8 @@ classdef test_smooth < TestCaseWithSave
         end
 
         function test_smooth_resolution_shape_arg(obj)
-            skipTest('No valid agruments allowed for ''resolution'' shape call bug #628');
-            d2d_obj = d2d(obj.test_sqw_2d_fullpath);
+            %skipTest('No valid agruments allowed for ''resolution'' shape call bug #628');
+            d2d_obj = read_dnd(obj.test_sqw_2d_fullpath);
 
             d = d2d_obj.smooth([100, 201, 301], 'resolution');
 


### PR DESCRIPTION
Issue #628 is tested by test_dnd_class/test_smooth::test_smooth_resolution_shape_arg.

It is currently skipped because of that issue. If the skip is removed then there is an earlier failure because dnd construction with a d2d constructor no longer works. It has to be replaced with read_dnd.

This PR replaces the d2d call with a read_dnd call so that the test is ready to be redeployed when 628 is fixed. The skip has been restored meanwhile. With this fix, the expected failure from 628 occurs.