### PR TITLE
Remove Advanced multifit from main docs

### DIFF
--- a/documentation/user_docs/docs/Horace_manual.rst
+++ b/documentation/user_docs/docs/Horace_manual.rst
@@ -18,7 +18,6 @@ Horace Manual
    manual/Plotting
    manual/Simulation
    manual/Multifit
-   manual/Advanced_Multifit
    manual/Tobyfit
    manual/Parallel
 

--- a/documentation/user_docs/docs/Unsorted.rst
+++ b/documentation/user_docs/docs/Unsorted.rst
@@ -6,6 +6,7 @@ and may not be needed in the new documentation.
 
 .. toctree::
 
+   manual/Advanced_Multifit
    manual/Changing_object_type
    manual/Developer_information
    manual/Horace_command_line
@@ -20,5 +21,4 @@ and may not be needed in the new documentation.
    manual/Script_for_making_publication_quality_figures
    manual/Script_for_making_simulations
    manual/Script_for_planning_an_experiment
-   manual/s_new
    new_page

--- a/documentation/user_docs/docs/manual/Advanced_Multifit.rst
+++ b/documentation/user_docs/docs/manual/Advanced_Multifit.rst
@@ -2,133 +2,204 @@
 Advanced Multifit
 #################
 
-Parallel fitting
-================
+At some point in the future it may be possible that someone wishes to extend the
+usage of ``multifit`` as a generic fitting engine to fit multivariate problems
+with multiple correlated datasets contained in a data-containing class. To
+support this no-doubt noble goal, this section describes how to define a
+dataclass which is compatible with ``multifit`` specifications.
 
-It is possible to use ``multifit`` and its derivatives (``tobyfit``, ``multifit_sqw``, ``multifit_sqw_sqw``) in parallel
-(see :ref:`manual/Parallel:Running Horace in Parallel` for more info) by either enabling HPC options through
-
-::
-
-   >> hpc('on');
-
-or by setting ``parallel_multifit`` directly in the ``hpc_config`` (see :ref:`Changing Horace settings
-<manual/Changing_Horace_settings:HPC Config>`)
-
-::
-
-   >> hc = hpc_config;
-   >> hc.parallel_multifit = true;
-
-Parallel multifit decomposes the objects passed in into slices which are distributed between the processors. E.g. if we
-are fitting three ``IX_dataset`` objects with 100 points between two processors, each processor will receive 50
-points from each ``IX_dataset``.
-
-This decomposition is performed differently for each of the three classes of fittable objects for each they are divided
-into ``N_items/N_procs``:
-
-- For sqw objects, the items are pixels
-- For dnd objects, the items are whole bins.
-- For IX_dataset objects, the items are points.
-
-If the fitting is run with the ``-ave`` option, then the decomposition will not split bins, but will distribute whole
-bins only.
 
 Multifit methods requirements
 =============================
-This section describes how to set up an object to work with Multifit specifications
 
-In many cases, the most convenient thing to do is extract the x,y,e arrays from an object and pass those to
-multifit. This can be done by using a method defined on the object to extract an x,y,e triple:
 
-::
+In many cases, the most convenient thing to do is extract the x, y, and error
+arrays from an object and pass those to ``multifit``. This can be done by
+defining an ``xye`` method on the class which returns an x, y, e triple:
 
-   >> [wout, fitdata] = multifit (xye(w), func, pin,...)
+.. code-block:: matlab
 
-where the method xye must return a structure of the form required by multifit, namely a structure with fields ``x``,
-``y`` and ``e`` ,where ``x`` is a cell array ``{x1,x2,...}`` containing vectors of coordinates of the points along the
-first, second, ...  axes, and ``y`` and ``e`` are vectors of the signal standard deviations repeactively. A convenient
-way to do this is to use the methods sigvar_get and sigvar_getx if they have been written to allow the object itself to
-be passed to multifit (see below).
+   >> kk = multifit(xye(w));
 
-If multifit is being used to fit functions to objects rather than x-y-e triples, then there are some methods that need
-to be defined. You might want to fit the objects if their internal structure is more complex, for example if the fitting
-function depends on fields other than just the x values and parameters being passed to the fit function. Another case is
-when the masking of points from fitting requires manipulation of fields other than simply removing x-y-e values. [An
-example is the case of the sqw objects used in Horace. Here the calculation of the intensity at a data point depends on
-the information of the individual pixels that contribute to that data point. Masking requires that the pixel information
-of masked bins is removed from the sqw object.]
+where the method ``xye`` must return a structure of the form required by
+``multifit``, i.e. a structure with fields ``x``, ``y`` and ``e``, where ``x``
+is a cell array ``{x1, x2, ...}`` containing vectors of coordinates along each
+axis, and ``y`` and ``e`` are vectors of the signal's magnitude and standard
+deviation respectively.
 
-The methods required for fitting objects with multifit are as follows:
+A convenient way to do this is to use the methods `sigvar_get`_ and
+`sigvar_getx`_ if they have been written to allow the object itself to be passed
+to ``multifit``.
+
+If ``multifit`` is being used to fit functions to instances of the class itself
+rather than bare x-y-e triples, then there are some methods that need to be
+defined on the class. You might want to fit the objects if their internal
+structure is more complex, for example if the fitting function depends on fields
+other than just the x values and parameters being passed to the fit function.
+
+Another case is when the masking of points from fitting requires manipulation of
+fields other than simply removing x-y-e values.
+
+.. note::
+
+   One example is the ``sqw`` objects used in Horace. Here, the calculation of
+   the intensity at a data point depends on the individual pixels that
+   contribute to that data point. Masking requires that the pixel information of
+   masked bins is removed from the ``sqw`` object.
+
+The methods required for fitting objects with ``multifit`` are as follows:
 
 Fit functions
 *************
 
-The global function, and background function(s) if given, can be methods of the class or simply functions, with input
-argument form as described in detail in multifit help. The general format is:
+The general format for a valid fitting function is:
 
-::
+.. code-block:: matlab
 
-        >> wcalc = my_function (w,p,c1,c2,...)
+   >> wcalc = my_function (w, c1, c2, c3, ...)
 
-If multifit is defined as a method of the class, then one can use the capability of nesting functions within the method
-to accept different fit function syntax. This is done, for example, for sqw objects when the fit functions to multifit,
-and equivalently multifit_func, are just a 1D/2D...4D Gaussian (according to the dimensionality of the sqw object).
+where ``w`` is the object to be fitted and ``c1``, ``c2``, ``c3``, ... are the fit
+parameters.
 
+.. note::
+
+   The global and background function(s) if given, can be methods of the
+   class or simply functions, with input argument form as described in detail by
+   ``help('multifit')``.
+
+Defining members of the ``multifit`` family of functions as methods of your
+class allows you to use that method to process arguments as needed before
+passing them through to the underlying ``mfclass`` object (which defines the
+fitting operation itself). This is done when fitting a Guassian to an ``sqw``,
+for example, where the ``sqw`` determines the correct dimensionality of Gaussian
+to match that of the object.
 
 Utility methods
 ---------------
 
-These are required to enable multifit to work with objects
+This section contains a list of methods which ``multifit`` understands and are
+used to fit user-defined classes.
 
-wout = mask(win, msk)
+.. note::
+
+   Those defined as "[Optional]" are not necessary for an class to be fit, but
+   can be helpful in optimisation. They will be used if available, but
+   ``multifit`` will fall back to mandatory methods automatically if not
+   provided.
+
+mask
+~~~~
+
+.. code-block:: matlab
+
+   wout = mask(win, msk)
+
+
+A method that removes data points from further calculation. The output object must
+be a valid instance of the class in which the masked values have been removed in
+whatever sense the class and fitting requires.
+
+.. _mask_points:
+
+mask_points [optional]
 ~~~~~~~~~~~~~~~~~~~~~~
 
-A method that masks data points from further calculation. The output object must be a valid instance of the class in
-which the masked values have been removed in whatever sense the class requires.
+.. code-block:: matlab
+
+   [msk, ok, mess] = mask_points(win, 'keep', xkeep, 'remove', xremove, 'mask', msk_in)
+
+Create a mask array given ranges of x-coordinates to keep, remove or mask from
+the array. The elements of a mask array are ``true`` for those data points which
+are to be retained, i.e. NOT omitted.
+
+.. note::
+
+   It is not necessary to provide a ``mask_points`` method if a `sigvar_getx`_
+   method is defined, however, ``mask_points`` will take priority over
+   ``sigvar_getx``
+
+.. warning::
+
+   ``mask_points`` should return a logical flag ``ok``, with message string in
+   ``mess`` if not ``ok`` rather than terminate.
+
+   If the function is only ever to be used without demanding the ``ok`` /
+   ``mess`` return values from ``multifit`` it is possible to avoid this
+   requirement.
+
+   However, if it is expected that other people will attempt to fit your custom
+   class, this requirement should be respected or very obviously documented as
+   not complying.
+
+sigvar_get
+~~~~~~~~~~
+
+.. code-block:: matlab
+
+   [y, var, msk] = sigvar_get(win)
+
+A method that returns the intensity and variance arrays from an object, along
+with a mask array that indicates which elements are to be retained.
+
+.. note::
+
+   elements of ``y`` and ``var`` which correspond to ``true`` elements of
+   ``msk`` are retained.
+
+   An example of where ``msk`` might be useful is points where ``y``
+   or ``var`` are undefined due to normalisation (dividing by zero) as part of
+   calculating ``sigvar``.
+
+.. warning::
+
+   The output arrays ``y`` and ``var`` must have the same size and shape.
+
+   ``msk`` must have the same number of elements as ``y`` and ``var``, but can
+   be a different shape.
+
+.. warning::
+
+   The returned ``msk`` must be compatibible with the `mask`_ method.
+
+.. _sigvar_getx:
+
+sigvar_getx [optional]
+~~~~~~~~~~~~~~~~~~~~~~
 
 
-[y,var,msk] = sigvar_get(win)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. code-block:: matlab
 
-A method that returns the intensity and variance arrays from the objects, along with a mask array that indicates which
-elements are to be retained (where elements of msk are true, the corresponding elements of y and var are retained). The
-output arrays y and var must have the same size and shape; msk must have the same number of elements (but can be a
-different shape). The array msk must be understood by the method 'mask' defined below.
+   x = sigvar_getx(win)
 
+Get the corresponding ``x`` values to the ``y``, ``var``, ``msk`` arrays that
+are returned by ``sigvar_get``.
 
-wsum = w1 + w2
-~~~~~~~~~~~~~~
+- If one dimensional, i.e. single x coordinate per point:
 
-If a background function is provided, addition of objects must be defined (requires overloading of the addition
-operator with a method named plus.m).
+  ``x`` will be a single array, the same size as ``y`` and ``var``
 
+- If n-dimensional, i.e. n x-values per point:
 
+  ``x`` will be a cell array of arrays, one per x dimension, each the same size
+  as ``y`` and ``var`` as returned by ``sigvar_get``.
 
-x = sigvar_getx(win) [optional]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. note::
 
-Get the corresponding x values to the y, var, msk arrays that are returned by sigvar_get.
+   This method replaces the need to have the `mask_points`_ method, as
+   ``sigvar_getx`` will enable ``multifit`` to use its own masking
+   function. However, if ``mask_points`` exists, then it will have priority over
+   ``sigvar_getx``.
 
-- If one dimensional i.e. single x coordinate per point:
+plus [optional]
+~~~~~~~~~~~~~~~
 
-    x must be a single array, the same size as y and var
-- If n-dimensional i.e. n x-values per point:
+.. code-block:: matlab
 
-    x must be a cell array of arrays, one per x dimension, each the same size as y and var as returned by sigvar_get.
+   wsum = plus(w1, w2)
 
-This method replaces the need to have the method 'mask_points' described below, as 'sigvar_getx' will enable the masking
-function built in to multifit to be used. However, if mask_points exists, then it will have priority over the use of
-sigvar_getx.
+Basic addition of two objects of the custom class.
 
+.. warning::
 
-[msk, ok, mess] = mask_points(win, 'keep', xkeep, 'remove', xremove, 'mask', msk_in) [optional]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Create a mask array given ranges of x-coordinates to keep, remove or mask from the array. The elements of a mask array are
-``true`` for those data points which are to be retained.
-
-Function must output a logical flag ``ok``, with message string if ``ok==false`` rather than terminate.
-
-(It is possible to have the function terminate if ``ok`` and ``mess`` are not given as return arguments; it is the
-advanced syntax that is required within multifit).
+   In order to use a background function with ``multifit``, the addition of
+   objects must be defined.

--- a/documentation/user_docs/docs/manual/Multifit.rst
+++ b/documentation/user_docs/docs/manual/Multifit.rst
@@ -464,3 +464,43 @@ where
 - ``p`` Vector of parameters needed by the model e.g. [A, js, gam] as intensity, exchange, lifetime
 - ``c1``, ``c2``, ..., ``cn`` Other constant parameters e.g. file name for look-up table weight Array containing calculated spectral weight
 - ``weight`` Array containing calculated spectral weight
+
+
+Parallel fitting
+================
+
+It is possible to use ``multifit`` and its derivatives (``tobyfit``,
+``multifit_sqw``, ``multifit_sqw_sqw``) in parallel (see
+:ref:`manual/Parallel:Running Horace in Parallel` for more info) by either
+enabling HPC options through
+
+.. code-block:: matlab
+
+   >> hpc('on');
+
+or by setting ``parallel_multifit`` directly in the ``hpc_config`` (see
+:ref:`Changing Horace settings <manual/Changing_Horace_settings:HPC Config>`)
+
+.. code-block:: matlab
+
+   >> hc = hpc_config;
+   >> hc.parallel_multifit = true;
+
+Parallel ``multifit`` decomposes the objects passed in into slices which are
+distributed between the processors. E.g. if we are fitting three ``IX_dataset``
+objects with 100 points between two processors, each processor will receive 50
+points from each ``IX_dataset``.
+
+This decomposition is performed differently for each of the three classes of
+fittable objects for each they are divided into ``N_items/N_procs``:
+
+- For ``sqw`` objects, the items are pixels
+- For ``dnd`` objects, the items are whole bins.
+- For ``IX_dataset`` objects, the items are points.
+
+
+.. note::
+
+   If the fitting is run with the ``-ave`` option on an ``sqw``, then the
+   decomposition will not split bins, but will distribute whole bins, which may
+   lead to load imbalance.


### PR DESCRIPTION
Migrate parallel fitting to regular multifit docs
Move advanced multifit from main docs to `unsorted` pile (as backup only)