### PR TITLE
Simplify c_deserialise code

### DIFF
--- a/_LowLevelCode/cpp/serialiser/c_deserialize.cpp
+++ b/_LowLevelCode/cpp/serialiser/c_deserialize.cpp
@@ -309,15 +309,10 @@ mxArray* deserialize(uint8_t* data, size_t& memPtr, size_t size, bool recursed) 
     case STRUCT:
     {
         uint32_t nFields;
-        std::vector<uint32_t> fNameLens(0);
-        if ((nDims == 2) && (memPtr >= size)) {
-            nFields = 0;
-        }
-        else {
-            deser(data, memPtr, &nFields, types_size[UINT32]);
-            fNameLens.resize(nFields);
-            deser(data, memPtr, fNameLens, nFields* types_size[UINT32]);
-        }
+
+        deser(data, memPtr, &nFields, types_size[UINT32]);
+        std::vector<uint32_t> fNameLens(nFields);
+        deser(data, memPtr, fNameLens, nFields * types_size[UINT32]);
 
         std::vector<std::vector<char>> fNames(nFields);
         std::vector<char*> mxData(nFields);
@@ -329,7 +324,11 @@ mxArray* deserialize(uint8_t* data, size_t& memPtr, size_t size, bool recursed) 
         }
 
         output = mxCreateStructArray(nDims, dims, nFields, (const char**)mxData.data());
-        if (nFields == 0) break;
+
+        // If no fields, no cellData bit to read.
+        if (!nFields) {
+          break;
+        }
 
         mxArray* cellData = deserialize(data, memPtr, size, 1);
 


### PR DESCRIPTION
Remove special case and standardise `if` block, adding comment to describe reasoning.

This is not an issue in `c_serial_size` as it has the following block:
```
      if (nFields > 0) {
        mxArray* arr = const_cast<mxArray *>(input);
        mxArray* conts;
        mexCallMATLAB(1, &conts, 1, &arr, "struct2cell");
        data_size = get_size(conts);
      }
```

Fixes #1328 