### PR TITLE
Return error estimates from `refine_crystal`

### DIFF
--- a/_test/test_change_crystal/test_refine_crystal.m
+++ b/_test/test_change_crystal/test_refine_crystal.m
@@ -60,6 +60,22 @@ classdef test_refine_crystal < TestCase
 
             assertEqualToTol(fit_data,obj.ref_data,1e-9);
         end
+
+        function test_fit_err_est(obj)
+        % Simple test to check whether err_est can be returned and
+        % is within acceptable range.
+            [algn_inf, err_est] = refine_crystal( ...
+                obj.bragg_peak_expected, obj.alatt_base, obj.angdeg_base, ...
+                obj.bragg_peak_measured, [5.1, 5.2, 5.3], [92, 88, 91]);
+
+            ref_data = struct('alatt', [1e-9, 1e-9, 1e-9], ...
+                              'angdeg', [1e-9, 1e-9, 1e-9], ...
+                              'rotvec', [1e-9, 1e-9, 1e-9]);
+
+            assertEqualToTol(err_est, ref_data, 1e-9);
+        end
+
+
         function test_fit_from_different_lattice_and_angle(obj)
 
             algn_inf = refine_crystal( ...

--- a/_test/test_change_crystal/test_refine_crystal.m
+++ b/_test/test_change_crystal/test_refine_crystal.m
@@ -62,8 +62,8 @@ classdef test_refine_crystal < TestCase
         end
 
         function test_fit_err_est(obj)
-        % Simple test to check whether err_est can be returned and
-        % is within acceptable range.
+        % Simple test to check whether err_est can be returned by refine_crystal and
+        % is within acceptable tolerance.
             [algn_inf, err_est] = refine_crystal( ...
                 obj.bragg_peak_expected, obj.alatt_base, obj.angdeg_base, ...
                 obj.bragg_peak_measured, [5.1, 5.2, 5.3], [92, 88, 91]);

--- a/horace_core/lattice_functions/refine_crystal.m
+++ b/horace_core/lattice_functions/refine_crystal.m
@@ -1,12 +1,14 @@
-function aligment_info = refine_crystal(rlu0,alatt0,angdeg0,rlu,varargin)
+function [alignment_info, error_estimate] = refine_crystal(rlu0,alatt0,angdeg0,rlu,varargin)
 % Refine crystal orientation and lattice parameters
 %
-%   >> aligment_info = refine_crystal(rlu0, alatt0, angdeg0, rlu)
-%   >> aligment_info = refine_crystal(rlu0, alatt0, angdeg0, rlu, alatt_init, angdeg_init)
+%   >> alignment_info = refine_crystal(rlu0, alatt0, angdeg0, rlu)
+%   >> alignment_info = refine_crystal(rlu0, alatt0, angdeg0, rlu, alatt_init, angdeg_init)
+% Return estimates of the error in the crystal alignment fit
+%   >> [..., error_estimate] = refine_crystal( ... )
 %
 % In addition, there are keyword arguments to control the refinement e.g.
-%   >> aligment_info = refine_crystal(..., 'fix_angdeg')
-%   >> aligment_info = refine_crystal(..., 'free_alatt', [1,0,1])
+%   >> alignment_info = refine_crystal(..., 'fix_angdeg')
+%   >> alignment_info = refine_crystal(..., 'free_alatt', [1,0,1])
 %
 %
 % This function is used to get the information necessary to relate the coordinates of a vector (h0,k0,l0)
@@ -61,7 +63,7 @@ function aligment_info = refine_crystal(rlu0,alatt0,angdeg0,rlu,varargin)
 %
 % Output:
 % -------
-%  alighment_info  -- helper class, which contains information, necessary
+%  alignment_info  -- helper class, which contains information, necessary
 %                     for the crystal alignment. The class contains the
 %                     following fields, calculated by the procedure:
 %
@@ -77,14 +79,19 @@ function aligment_info = refine_crystal(rlu0,alatt0,angdeg0,rlu,varargin)
 %      rotangle       Angle of rotation corresponding to rotmat (to give a measure
 %                     of the misorientation) (degrees)
 %
+% error_estimate  --  Structure containing estimated errors on the fit parameters as a result of refinement
+%
+%      alatt          Error on refined lattice parameters [a,b,c] (Angstroms)
+%      angdeg         Error on refined lattice angles [alph,bet,gam] (degrees)
+%      rotmat         Error on rotation matrix
 %
 % EXAMPLES
 %   Want to refine crystal orientation only:
-%   >> alighment_info =refine_crystal (rlu0, alatt0, angdeg0, rlu, 'fix_lattice')
+%   >> alignment_info =refine_crystal (rlu0, alatt0, angdeg0, rlu, 'fix_lattice')
 %    the alignment info would contain the initial lattice values i.e.  alatt0, angdeg0
 %
 %   Want to refine lattice parameters a,b,c as well as crystal orientation:
-%   >> alighment_info=refine_crystal (rlu0, alatt0, angdeg0, rlu, 'fix_angdeg')
+%   >> alignment_info=refine_crystal (rlu0, alatt0, angdeg0, rlu, 'fix_angdeg')
 %    the alignment info would contain the initial lattice angles i.e.  angdeg0
 
 small=1e-10;
@@ -184,7 +191,11 @@ alatt  = fitpar.p(1:3);
 angdeg = fitpar.p(4:6);
 distance=sqrt(sum(reshape(distance,3,nv).^2,1))';
 
-aligment_info = crystal_alignment_info(alatt,angdeg,rotvec,distance);
+error_estimate = struct('alatt', fitpar.sig(1:3), ...
+                        'angdeg', fitpar.sig(4:6), ...
+                        'rotvec', fitpar.sig(7:9));
+
+alignment_info = crystal_alignment_info(alatt,angdeg,rotvec,distance);
 
 
 %============================================================================================================


### PR DESCRIPTION
Return a structure from `refine_crystal` containing fit error estimates.

Fixes #770 