### PR TITLE
no spaces in wk_dir folder name

### DIFF
--- a/herbert_core/admin/tmp_dir.m
+++ b/herbert_core/admin/tmp_dir.m
@@ -18,7 +18,7 @@ if is_jenk
 end
 
 % All other machines
-folder_name = ['Horace_', herbert_version()];
+folder_name = strrep(['Horace_', herbert_version()],' ','_');
 
 if is_idaaas()
     location = userpath();


### PR DESCRIPTION
this change should remove all spaces from the name of default working folder