### PR TITLE
userpath provided to workers

### DIFF
--- a/_test/test_mpi_wrappers/test_cluster_wrapper.m
+++ b/_test/test_mpi_wrappers/test_cluster_wrapper.m
@@ -316,6 +316,10 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
         end
 
         function test_set_user_env_if_matlabpath_set_with_more(obj)
+            clow = set_temporary_warning('off','HORACE:spuff_warning');            
+            warning('HORACE:spuff_warning', ...
+                'issue specific warning to ensure no other warning is the last one');
+
             en = getenv('MATLABPATH');
             clEnv = onCleanup(@()setenv('MATLABPATH',en));
             pc = parallel_config;
@@ -336,6 +340,14 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
             assertTrue(ismember(this_path,pathes));
 
             addpath(test_dir);
+            [~,lw] = lastwarn();
+            if strcmp(lw,'MATLAB:mpath:nameNonexistentOrNotADirectory')
+                skipTest( ...
+                    sprintf(['tmp directory %s can not be added to search path' ...
+                    ' as it contains non-Matlab-path characters'],...
+                test_dir));
+            end
+            
 
             cluster = cluster.add_user_path(pc);
 
@@ -350,6 +362,10 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
 
 
         function test_set_user_env_if_matlabpath_set(obj)
+            clow = set_temporary_warning('off','HORACE:spuff_warning');
+            warning('HORACE:spuff_warning', ...
+                'issue specific warning to ensure no other warning is the last one');
+            
             en = getenv('MATLABPATH');
             clEnv = onCleanup(@()setenv('MATLABPATH',en));
             pc = parallel_config;
@@ -368,6 +384,13 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
             assertFalse(ismember(test_dir,pathes));
 
             addpath(test_dir);
+            [~,lw] = lastwarn();
+            if strcmp(lw,'MATLAB:mpath:nameNonexistentOrNotADirectory')
+                skipTest( ...
+                    sprintf(['tmp directory %s can not be added to search path' ...
+                    ' as it contains non-Matlab-path characters'],...
+                test_dir));
+            end            
 
             cluster = cluster.add_user_path(pc);
 
@@ -381,6 +404,10 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
 
 
         function test_set_user_env(obj)
+            clow = set_temporary_warning('off','HORACE:spuff_warning');
+            warning('HORACE:spuff_warning', ...
+                'issue specific warning to ensure no other warning is the last one');
+            
             en = getenv('MATLABPATH');
             clEnv = onCleanup(@()setenv('MATLABPATH',en));
             pc = parallel_config;
@@ -397,6 +424,13 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
             assertFalse(ismember(test_dir,pathes));
 
             addpath(test_dir);
+            [~,lw] = lastwarn();
+            if strcmp(lw,'MATLAB:mpath:nameNonexistentOrNotADirectory')
+                skipTest( ...
+                    sprintf(['tmp directory %s can not be added to search path' ...
+                    ' as it contains non-Matlab-path characters'],...
+                test_dir));
+            end
 
             cluster = cluster.add_user_path(pc);
 

--- a/_test/test_mpi_wrappers/test_cluster_wrapper.m
+++ b/_test/test_mpi_wrappers/test_cluster_wrapper.m
@@ -316,10 +316,6 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
         end
 
         function test_set_user_env_if_matlabpath_set_with_more(obj)
-            clow = set_temporary_warning('off','HORACE:spuff_warning');            
-            warning('HORACE:spuff_warning', ...
-                'issue specific warning to ensure no other warning is the last one');
-
             en = getenv('MATLABPATH');
             clEnv = onCleanup(@()setenv('MATLABPATH',en));
             pc = parallel_config;
@@ -340,14 +336,7 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
             assertTrue(ismember(this_path,pathes));
 
             addpath(test_dir);
-            [~,lw] = lastwarn();
-            if strcmp(lw,'MATLAB:mpath:nameNonexistentOrNotADirectory')
-                skipTest( ...
-                    sprintf(['tmp directory %s can not be added to search path' ...
-                    ' as it contains non-Matlab-path characters'],...
-                test_dir));
-            end
-            
+  
 
             cluster = cluster.add_user_path(pc);
 
@@ -362,10 +351,7 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
 
 
         function test_set_user_env_if_matlabpath_set(obj)
-            clow = set_temporary_warning('off','HORACE:spuff_warning');
-            warning('HORACE:spuff_warning', ...
-                'issue specific warning to ensure no other warning is the last one');
-            
+              
             en = getenv('MATLABPATH');
             clEnv = onCleanup(@()setenv('MATLABPATH',en));
             pc = parallel_config;
@@ -384,13 +370,6 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
             assertFalse(ismember(test_dir,pathes));
 
             addpath(test_dir);
-            [~,lw] = lastwarn();
-            if strcmp(lw,'MATLAB:mpath:nameNonexistentOrNotADirectory')
-                skipTest( ...
-                    sprintf(['tmp directory %s can not be added to search path' ...
-                    ' as it contains non-Matlab-path characters'],...
-                test_dir));
-            end            
 
             cluster = cluster.add_user_path(pc);
 
@@ -404,9 +383,6 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
 
 
         function test_set_user_env(obj)
-            clow = set_temporary_warning('off','HORACE:spuff_warning');
-            warning('HORACE:spuff_warning', ...
-                'issue specific warning to ensure no other warning is the last one');
             
             en = getenv('MATLABPATH');
             clEnv = onCleanup(@()setenv('MATLABPATH',en));
@@ -424,13 +400,6 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
             assertFalse(ismember(test_dir,pathes));
 
             addpath(test_dir);
-            [~,lw] = lastwarn();
-            if strcmp(lw,'MATLAB:mpath:nameNonexistentOrNotADirectory')
-                skipTest( ...
-                    sprintf(['tmp directory %s can not be added to search path' ...
-                    ' as it contains non-Matlab-path characters'],...
-                test_dir));
-            end
 
             cluster = cluster.add_user_path(pc);
 

--- a/_test/test_mpi_wrappers/test_cluster_wrapper.m
+++ b/_test/test_mpi_wrappers/test_cluster_wrapper.m
@@ -333,5 +333,25 @@ classdef test_cluster_wrapper < TestCase & FakeJenkins4Tests
                 'HERBERT:ClusterParpoolWrapper:invalid_argument');
             clob3 = onCleanup(@()finalize_all(clust));
         end
+
+        function test_set_user_env(~)
+            en = getenv('MATLABPATH');
+            clEnv = onCleanup(@()setenv('MATLABPATH',en));            
+
+            this_path = fileparts(mfilename('fullpath'));       
+            test_dir = fullfile(this_path,'test_set_user_env_path');
+            ok = mkdir(test_dir);
+            if ~ok
+                skipTest('test_cluster_wrapper:test_set_user_env. Can not create test folder. Issue with access rights?')
+            end
+            clDir = onCleanup(@()rmdir(test_dir,'s'));
+            clPath = onCleanup(@()rmpath(test_path)); 
+            addpath(test_path);
+
+            cl = ClusterWrapperTester();
+            cl = cl.add_user_path();
+
+
+        end
     end
 end

--- a/herbert_core/admin/tmp_dir.m
+++ b/herbert_core/admin/tmp_dir.m
@@ -18,7 +18,7 @@ if is_jenk
 end
 
 % All other machines
-folder_name = strrep(['Horace_', herbert_version()],' ','_');
+folder_name = regexprep(['Horace_', herbert_version()],'[\s:]','');
 
 if is_idaaas()
     location = userpath();

--- a/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
+++ b/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
@@ -48,6 +48,12 @@ classdef ClusterWrapper
         % cluster. Property used in debugging to change default framework
         pool_exchange_frmwk_name
     end
+    properties(Dependent,Hidden)
+        % return enviromental variables used by cluster. Normally for testing
+        % It is handle, so it can be used for seting it too.
+        % (Violates class logic so avoid this)
+        common_env_var
+    end
 
     properties(Access = protected)
         % The default name of the function or function handle of the function
@@ -222,7 +228,7 @@ classdef ClusterWrapper
                 obj.common_env_var_('HERBERT_PARALLEL_EXECUTOR') = obj.matlab_starter_;
             end
 
-            % Modify MATLABPATH to add path to user code, which user 
+            % Modify MATLABPATH to add path to user code, which user
             % may want to use in parallel script
             obj = obj.add_user_path(pc);
 
@@ -235,50 +241,66 @@ classdef ClusterWrapper
         end
         %
         function obj = add_user_path(obj,pc)
-            % Method adds user script path to the pathes available to
-            % parallel workers. 
+            % Method adds user script path to the path-es available to
+            % parallel workers.
+            %
+            % The scripts should not be within Horace
+            % root folder as there files should already be on path or used
+            % in tests only.
+            %
+            % WARNING!!!
             % It assumed that user view on the filesystem is the same as
-            % the view from the parallel nodes.
-            % 
+            % the view from parallel nodes. This probably should be
+            % changed in a future.
+            %
             % Inputs:
             % obj  -- instance of ClusterWrapper getting initialized
             % pc   -- instance of parallel config class. Transmitted for
-            %         efficiency. 
+            %         efficiency.
             %
             % Returns:
             % obj  -- instance of ClusterWrapper containing modified
             %         common_env_var_ property with the key MATLABPATH
-            %         containing user path
-            % 
-            % Split path into cell of paths
-            curr_path = split(path, pathsep);
-            % Filter array for added paths
-            curr_path = curr_path(~startsWith(curr_path, matlabroot));
-            curr_path = curr_path(~startsWith(curr_path, horace_root));
-            % Join back together
-            curr_path = strjoin(curr_path, pathsep);
+            %         containing user path.
+            %
 
             % additional Matlab m-files search path to be available to
             % workers
-            existing_addpath = getenv('MATLABPATH');
-            possible_addpath = fileparts(which(pc.worker));
-
-            if  contains(existing_addpath,possible_addpath)
-                obj.common_env_var_('MATLABPATH') = existing_addpath;
-            else
-                if isempty(existing_addpath)
-                    obj.common_env_var_('MATLABPATH') = possible_addpath;
-                else
-                    obj.common_env_var_('MATLABPATH') = ...
-                        [possible_addpath,pathsep,existing_addpath];
+            existing_addpath  = getenv('MATLABPATH');
+            necessary_addpath = fileparts(which(pc.worker));
+            if contains(existing_addpath,necessary_addpath)
+                existing_addpath = split(existing_addpath, pathsep);
+                there = ismember(existing_addpath,necessary_addpath);
+                existing_addpath = existing_addpath(~there);
+                if ~isempty(existing_addpath)
+                    existing_addpath = strjoin(existing_addpath,pathsep);
                 end
             end
+            %
+            % Split path into cell of paths
+            curr_path = split(path, pathsep);
+            % Filter array for user-added paths
+            curr_path = curr_path(~startsWith(curr_path, matlabroot));
+            curr_path = curr_path(~startsWith(curr_path, horace_root));
+            curr_path = curr_path(~startsWith(curr_path,necessary_addpath));
+            if isempty(existing_addpath)
+                user_path = curr_path;
+            else
+                user_path = curr_path(~startsWith(curr_path,existing_addpath));
+            end
+            % Build user path
+            user_path = strjoin(user_path, pathsep);
 
-            % Always add curr path
-            obj.common_env_var_('MATLABPATH') = [curr_path, pathsep, obj.common_env_var_('MATLABPATH')];
-            
+            if isempty(existing_addpath)
+                obj.common_env_var_('MATLABPATH') = necessary_addpath;
+            else
+                obj.common_env_var_('MATLABPATH') = ...
+                    [necessary_addpath,pathsep,existing_addpath];
+            end
+
+            % Form necessary path
+            obj.common_env_var_('MATLABPATH') = [obj.common_env_var_('MATLABPATH'),pathsep,user_path];
         end
-        
 
         function obj = start_job(obj,je_init_message,task_init_mess,log_message_prefix)
             % send initialization information to each worker in the cluster
@@ -399,7 +421,6 @@ classdef ClusterWrapper
                 postfix_command(:)', ...
                 {'-batch'},{matlab_command}];
         end
-
 
         function [obj,ok]=wait_started_and_report(obj,check_time,varargin)
             % check for 'ready' message and report cluster ready to user.
@@ -579,10 +600,11 @@ classdef ClusterWrapper
             % default configuration.
             config = {obj.cluster_config_};
         end
-
-        %------------------------------------------------------------------
-        % SETTERS, GETTERS:
-        %------------------------------------------------------------------
+    end
+    %======================================================================
+    % SETTERS, GETTERS:
+    %----------------------------------------------------------------------
+    methods
         function isit = get.status_changed(obj)
             isit = obj.status_changed_;
         end
@@ -658,8 +680,11 @@ classdef ClusterWrapper
             % Part of check_progress method. Exposed for testing purposes
             [completed,failed,mess] = check_progress_from_messages_(obj,varargin{:});
         end
+        function val = get.common_env_var(obj)
+            val = obj.common_env_var_;
+        end
     end
-
+    %
     methods(Access=protected)
         function env = set_env(obj,env)
             % helper function to set enviroment for a java process.
@@ -819,7 +844,7 @@ classdef ClusterWrapper
             end
         end
     end
-
+    %
     methods(Static)
         function mpi_exec = get_mpiexec()
             % Get the appropriate mpiexec program for running MPI jobs

--- a/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
+++ b/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
@@ -237,14 +237,6 @@ classdef ClusterWrapper
             else
                 obj.common_env_var_('DO_PARALLEL_MATLAB_LOGGING') = 'false';
             end
-            if is_idaaas()
-                % clear idaaas control variables as they force default
-                % Horace to be initialized, and we want current Horace to
-                % be initialized.
-                setenv('MATLAB_INIT_HORACE','');
-                setenv('MATLAB_INIT_MSLICE','');
-            end
-
         end
         %
         function obj = add_user_path(obj,pc)

--- a/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
+++ b/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
@@ -279,9 +279,15 @@ classdef ClusterWrapper
             % Split path into cell of paths
             curr_path = split(path, pathsep);
             % Filter array for user-added paths
-            curr_path = curr_path(~startsWith(curr_path, matlabroot));
-            curr_path = curr_path(~startsWith(curr_path, horace_root));
-            curr_path = curr_path(~startsWith(curr_path,necessary_addpath));
+            %
+            % Horace path to remove:
+            hor = fullfile(horace_root,'horace_core');
+            her = fullfile(horace_root,'herbert_core');
+            adm = fullfile(horace_root,'admin');
+            to_remove = {matlabroot,hor,her,adm,necessary_addpath};
+            for i=1:numel(to_remove)
+                curr_path = curr_path(~startsWith(curr_path,to_remove{i}));
+            end
             if isempty(existing_addpath)
                 user_path = curr_path;
             else

--- a/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
+++ b/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
@@ -237,6 +237,13 @@ classdef ClusterWrapper
             else
                 obj.common_env_var_('DO_PARALLEL_MATLAB_LOGGING') = 'false';
             end
+            if is_idaaas()
+                % clear idaaas control variables as they force default
+                % Horace to be initialized, and we want current Horace to
+                % be initialized.
+                setenv('MATLAB_INIT_HORACE','');
+                setenv('MATLAB_INIT_MSLICE','');
+            end
 
         end
         %

--- a/horace_core/horace_off.m
+++ b/horace_core/horace_off.m
@@ -24,6 +24,3 @@ catch ME
     error('Problems removing "%s" and sub-directories from Matlab path. Reason: %s', ...
         rootpath,ME.message)
 end
-% Make sure we're not removing any global paths
-addpath(getenv('MATLABPATH'));
-

--- a/horace_core/horace_off.m
+++ b/horace_core/horace_off.m
@@ -32,3 +32,4 @@ catch ME
     error('Problems removing "%s" and sub-directories from Matlab path. Reason: %s', ...
         rootpath,ME.message)
 end
+clear classes

--- a/horace_core/horace_off.m
+++ b/horace_core/horace_off.m
@@ -8,15 +8,23 @@ function horace_off
 
 % root directory is assumed to be that in which this function resides
 rootpath = fileparts(fileparts(which('horace_init')));
-on_path  = fileparts(which('horace_on')); % 
+on_path  = fileparts(which('horace_on')); %
 warn_state=warning('off','all');    % turn of warnings (so don't get errors if remove non-existent paths)
+if is_idaaas()
+    % clear idaaas control variables as they force default
+    % Horace to be initialized, and we want requested Horace to
+    % be initialized.
+    setenv('MATLAB_INIT_HORACE','');
+    setenv('MATLAB_INIT_MSLICE','');
+end
+
 clear mex;
 try
     paths = genpath(rootpath);
     % make sure we are not removing the path to horace_on
     if ~isempty(on_path) % if horace_on is on the path, ensure you keep it
         paths = strrep(paths,[on_path,pathsep],'');
-    end    
+    end
     rmpath(paths);
     warning(warn_state);    % return warnings to initial state
 catch ME


### PR DESCRIPTION
Fixes #1390.  Number of issues have been identified on iDAAAS related to path-es stored/not stored in MATLABPATH and other enviromental variables. Normally it is invisible but becomes an issue when one dynamically switches from one Horace version to another. Hopefully all fixed now -- switching with parallel cluster works