### PR TITLE
Add fitting file-backed tests for Toby/multifit

### DIFF
--- a/_test/test_TF_components/test_tobyfit_cuts.m
+++ b/_test/test_TF_components/test_tobyfit_cuts.m
@@ -113,7 +113,8 @@ classdef test_tobyfit_cuts < TestCaseWithSave
         function obj = test_fit_fe_single_good_par_fb(obj)
             % Single cut, starting parameters close to a good fit but file-backed
 
-            skipTest("Disabled until #760 implementation of filebacked Tobyfit")
+            skipTest(['Preliminary test ready for #760 implementation of filebacked Tobyfit, ', ...
+                      'parallel to test_multifit_horace_1:test_fit_one_dataset_fb, but as yet untested'])
 
             amp=50;  sj=40;   fwhh=50;   const=0.1;  grad=0;
 

--- a/_test/test_TF_components/test_tobyfit_cuts.m
+++ b/_test/test_TF_components/test_tobyfit_cuts.m
@@ -1,6 +1,6 @@
 classdef test_tobyfit_cuts < TestCaseWithSave
     % Test of basic fitting operations with Tobyfit
-    
+
     properties
         fe_1
         fe_2
@@ -13,11 +13,11 @@ classdef test_tobyfit_cuts < TestCaseWithSave
         seed
         rng_state
     end
-    
+
     methods
         function obj = test_tobyfit_cuts (name)
             % Initialise object properties and pre-load test cuts for faster tests
-            
+
             % Note: in the (hopefully) extremely rare case of needing to
             % regenerate the data, use the static method generate_data (see
             % elsewhere in this class definition)
@@ -26,9 +26,9 @@ classdef test_tobyfit_cuts < TestCaseWithSave
 
             % Load sqw cuts
             load (data_file, 'fe_1', 'fe_2', 'fe_arr', 'rb_arr');
-            
+
             % Add instrument and sample information to the cuts
-            
+
             % For mysterious reasons lost in time, the two sets of tests merged
             % here had different sample geometry descriptions. Stick with
             %   IX_sample(true,[1,0,0],[0,1,0],'cuboid',[0.04,0.03,0.02]);
@@ -38,7 +38,7 @@ classdef test_tobyfit_cuts < TestCaseWithSave
             %   [2.8700 2.8700 2.8700]
             % rather than
             %   [2.8504 2.8504 2.8504]
-            
+
             sample_fe = IX_sample(true,[1,0,0],[0,1,0],'cuboid',[0.04,0.03,0.02]);
             sample_fe.alatt = [2.8700 2.8700 2.8700];
             sample_fe.angdeg = [90 90 90];
@@ -50,7 +50,7 @@ classdef test_tobyfit_cuts < TestCaseWithSave
                 fe_arr(i)=set_sample_and_inst(fe_arr(i),sample_fe,...
                     @maps_instrument_obj_for_tests,'-efix',600,'S');
             end
-            
+
             % Add sample and instrument information to the RbMnF3 cuts
             sample_rb=IX_sample(true,[1,0,0],[0,1,0],'cuboid',[0.02,0.02,0.02]);
             sample_rb.alatt = [4.2240 4.2240 4.2240];
@@ -59,13 +59,13 @@ classdef test_tobyfit_cuts < TestCaseWithSave
                 rb_arr(i)=set_sample_and_inst(rb_arr(i),sample_rb,...
                     @maps_instrument_obj_for_tests,'-efix',300,'S');
             end
-                
+
             % Initialise test object properties
             obj.fe_1 = fe_1;      % short const-E cut, 150-160 meV
             obj.fe_2 = fe_2;      % long const-E cut, 150-160 meV
             obj.fe_arr = fe_arr;  % three short const-E cuts, 140-160, 160-180, 180-200 meV
             obj.rb_arr = rb_arr;    % two const-Q cuts, 2-10 meV
-            
+
             tol_sig = 0.25;        % tolerance as multiple of st. dev. of reference value
             tol_abs = 0;        % absolute tolerance
             tol_rel = 0;        % relative tolerance
@@ -84,51 +84,75 @@ classdef test_tobyfit_cuts < TestCaseWithSave
             obj.rng_state = rng(obj.seed, 'twister');
             warning('off', 'HERBERT:mask_data_for_fit:bad_points')
         end
-        
+
         function obj = tearDown(obj)
             % Undo rng state
             rng(obj.rng_state);
             warning('on', 'HERBERT:mask_data_for_fit:bad_points')
         end
-                
-        
+
+
         %% --------------------------------------------------------------------------------------
         % Fit single cut from Fe
         % --------------------------------------------------------------------------------------
         function obj = test_fit_fe_single_good_par(obj)
             % Single cut, starting parameters close to a good fit
-            
+
             amp=50;  sj=40;   fwhh=50;   const=0.1;  grad=0;
-            
+
             kk = tobyfit(obj.fe_1);
             kk = kk.set_fun(@testfunc_sqw_bcc_hfm_bkgd, [amp,sj,fwhh,const,grad], [1,1,0,1,0]);
             kk = kk.set_mc_points(obj.mc_fe);
             kk = kk.set_options('listing', obj.nlist);
             [~, fp] = kk.fit;
-            
+
             assertTestWithSave(obj, fp, @is_same_fit, obj.tolerance)
-            
+
         end
-        
+
+        function obj = test_fit_fe_single_good_par_fb(obj)
+            % Single cut, starting parameters close to a good fit but file-backed
+
+            skipTest("Disabled until #760 implementation of filebacked Tobyfit")
+
+            amp=50;  sj=40;   fwhh=50;   const=0.1;  grad=0;
+
+            clOb = set_temporary_config_options(hor_config, 'mem_chunk_size', 100);
+
+            fe_1_fb = obj.fe_1;
+            fe_1_fb.pix = PixelDataFilebacked(obj.fe_1.pix);
+
+            kk = tobyfit(obj.fe_1);
+            kk = kk.set_fun(@testfunc_sqw_bcc_hfm_bkgd, [amp,sj,fwhh,const,grad], [1,1,0,1,0]);
+            kk = kk.set_mc_points(obj.mc_fe);
+            kk = kk.set_options('listing', obj.nlist);
+            [~, fp] = kk.fit;
+
+            ref = getReferenceDataset(obj, 'test_fit_nb_multi_amplitude_global', 'fp')
+            assertTrue(is_same_fit(fp, ref, obj.tolerance))
+
+        end
+
+
         function obj = test_fit_fe_single_bad_par(obj)
             % Single cut, starting parameters well away from a good fit
-            
+
             amp=100;  sj=50;   fwhh=50;   const=0;  grad=0;
-            
+
             kk = tobyfit(obj.fe_1);
             kk = kk.set_fun(@testfunc_sqw_bcc_hfm_bkgd,[amp,sj,fwhh,const,grad],[1,1,0,1,0]);
             kk = kk.set_mc_points(obj.mc_fe);
             kk = kk.set_options('listing',obj.nlist);
             [~, fp] = kk.fit;
-            
+
             assertTestWithSave(obj, fp, @is_same_fit, obj.tolerance)
-            
+
         end
-        
+
         function obj = test_fit_fe_single_fore_back_decoupled(obj)
             % Decouple foreground and background models - get same result, so good!
             amp=100;  sj=50;   fwhh=50;   const=0;  grad=0;
-            
+
             kk = tobyfit(obj.fe_1);
             kk = kk.set_fun(@testfunc_sqw_bcc_hfm,[amp,sj,fwhh]);
             kk = kk.set_free([1,1,0]);
@@ -137,15 +161,15 @@ classdef test_tobyfit_cuts < TestCaseWithSave
             kk = kk.set_mc_points(obj.mc_fe);
             kk = kk.set_options('listing',obj.nlist);
             [~, fp] = kk.fit;
-            
+
             assertTestWithSave(obj, fp, @is_same_fit, obj.tolerance)
-            
+
         end
-        
+
         function obj = test_fit_fe_single_lin_bkgd_free(obj)
             % Allow linear background parameter to vary
             amp=100;  sj=40;   fwhh=50;   const=0;  grad=0;
-            
+
             kk = tobyfit(obj.fe_1);
             kk = kk.set_fun(@testfunc_sqw_bcc_hfm,[amp,sj,fwhh]);
             kk = kk.set_free([1,1,0]);
@@ -153,36 +177,36 @@ classdef test_tobyfit_cuts < TestCaseWithSave
             kk = kk.set_mc_points(obj.mc_fe);
             kk = kk.set_options('listing',obj.nlist);
             [~,fp]=kk.fit;
-            
+
             assertTestWithSave(obj, fp, @is_same_fit, obj.tolerance)
-            
+
         end
-        
+
         %% --------------------------------------------------------------------------------------
         % Fit multiple datasets from Fe
         % ---------------------------------------------------------------------------------------
-        
+
         function obj = test_fit_fe_multi_all_free(obj)
             % Global foreground; allow all parameters to vary
             amp=100;  sj=40;   fwhh=50;   const=0;  grad=0;
-            
+
             kk = tobyfit(obj.fe_arr);
             kk = kk.set_fun(@testfunc_sqw_bcc_hfm,[amp,sj,fwhh]);
             kk = kk.set_bfun(@testfunc_bkgd,[const,grad]);
             kk = kk.set_mc_points(obj.mc_fe);
             kk = kk.set_options('listing',obj.nlist);
             [~,fp] = kk.fit;
-            
+
             assertTestWithSave(obj, fp, @is_same_fit, obj.tolerance)
-            
+
         end
-        
+
         function obj = test_fit_fe_multi_sj_and_gamma_global(obj)
             % Local foreground; constrain SJ and gamma as global but allow
             % amplitude and gamma to vary locally
-            
+
             amp=100;  sj=40;   fwhh=50;   const=0;  grad=0;
-            
+
             kk = tobyfit(obj.fe_arr);
             kk = kk.set_local_foreground;
             kk = kk.set_fun(@testfunc_sqw_bcc_hfm,[amp,sj,fwhh]);
@@ -192,19 +216,19 @@ classdef test_tobyfit_cuts < TestCaseWithSave
             kk = kk.set_mc_points(obj.mc_fe);
             kk = kk.set_options('listing',obj.nlist);
             [~,fp] = kk.fit;
-            
+
             assertTestWithSave(obj, fp, @is_same_fit, obj.tolerance)
 
         end
-        
+
         function obj = test_fit_fe_multi_sj_global(obj)
             % Local foreground; constrain SJ as global but allow amplitude
             % and gamma to vary locally.
             % The intensity and lifetime are very highly correlated, so not
             % actually a discriminating test.
-            
+
             amp=100;  sj=40;   fwhh=50;   const=0;  grad=0;
-            
+
             kk = tobyfit(obj.fe_arr);
             kk = kk.set_local_foreground;
             kk = kk.set_fun(@testfunc_sqw_bcc_hfm,[amp,sj,fwhh]);
@@ -213,20 +237,20 @@ classdef test_tobyfit_cuts < TestCaseWithSave
             kk = kk.set_mc_points(obj.mc_fe);
             kk = kk.set_options('listing',obj.nlist);
             [~,fp] = kk.fit;
-            
+
             assertTestWithSave(obj, fp, @is_same_fit, obj.tolerance)
 
         end
-        
+
         %% --------------------------------------------------------------------------------------
         % Fit multiple datasets from RbMnF3
         % ---------------------------------------------------------------------------------------
-        
+
         function obj = test_fit_rb_multi_sj_global(obj)
             % Local foreground; constrain SJ as global, fix gamma and gap,
             % but allow intensity to vary locally
             Seff = 6000; SJ = 8.8; gap = 0.01; gam=0.04;   const=0;  grad=0;
-            
+
             kk = tobyfit(obj.rb_arr);
             kk = kk.set_local_foreground;
             kk = kk.set_fun(@testfunc_rbmnf3_sqw,[Seff, SJ, gap, gam],[1,1,0,0]);
@@ -235,12 +259,12 @@ classdef test_tobyfit_cuts < TestCaseWithSave
             kk = kk.set_mc_points(obj.mc_rb);
             kk = kk.set_options('listing',obj.nlist);
             [~,fp] = kk.fit;
-            
+
             assertTestWithSave(obj, fp, @is_same_fit, obj.tolerance)
-            
+
         end
-        
-        
+
+
         %% --------------------------------------------------------------------------------------
         % Fit multiple datasets from Fe and RbMnF3
         % ---------------------------------------------------------------------------------------
@@ -249,43 +273,43 @@ classdef test_tobyfit_cuts < TestCaseWithSave
             % This is a fit of Fe and Rb arrays of cuts that are independent,
             % but intermixed as a really testing exercise of multifit and
             % Tobyfit input parsing and functionality.
-            
+
             % Fe: Local foreground; constrain SJ and gamma as global but allow
             % amplitude and gamma to vary locally
             %
             % RbMnF3: Local foreground; constrain SJ as global, fix gamma and gap,
             % but allow intensity to vary locally
-            
+
             amp=100;  sj=40;   fwhh=50;
             Seff = 6000; SJ = 8.8; gap = 0.01; gam=0.04;
             const=0;  grad=0;
-            
+
             datasets = [obj.fe_arr(1), obj.rb_arr(1), obj.rb_arr(2),...
                 obj.fe_arr(2), obj.fe_arr(3), obj.rb_arr(3)];
             ind_fe = [1,4,5];
             ind_rb = [2,3,6];
-            
+
             kk = tobyfit(datasets);
             kk = kk.set_local_foreground;
-            
+
             kk = kk.set_fun(ind_fe,@testfunc_sqw_bcc_hfm,[amp,sj,fwhh]);
             kk = kk.set_bind(ind_fe,{2,[2,1]});
             kk = kk.add_bind(ind_fe,{3,[3,1]});
             kk = kk.set_bfun(ind_fe,@testfunc_bkgd,[const,grad]);
-            
+
             kk = kk.set_fun(ind_rb,@testfunc_rbmnf3_sqw,[Seff, SJ, gap, gam],[1,1,0,0]);
             kk = kk.add_bind(ind_rb,{2,[2,1],0.245});
             kk = kk.set_bfun(ind_rb,@testfunc_bkgd,[const,grad],[1,0]);
-            
+
             kk = kk.set_mc_points(obj.mc_rb);
             kk = kk.set_options('listing',obj.nlist);
             [~, fp] = kk.fit();
-            
+
             assertTestWithSave(obj, fp, @is_same_fit, obj.tolerance)
-            
+
         end
 
-      
+
     end
 
     %------------------------------------------------------------------
@@ -302,31 +326,31 @@ classdef test_tobyfit_cuts < TestCaseWithSave
             %               e.g. fullfile(tempdir,'test_tobyfit_cuts_data.mat')
             %               Normal practice is to write to tempdir to check contents
             %               before manually replacing the file in the repository.
-            
+
             % sqw files from which to take cuts for setup
             % These are private to Toby's computer as of 22/1/2023
             % Long term solution needed for data source locations
             data_source_fe = 'T:\data\Fe\sqw_Toby\Fe_ei787.sqw';
             data_source_rb = 'T:\data\RbMnF3\sqw\rbmnf3_ref_newformat.sqw';
-            
+
             % Cuts from iron
             % --------------
             proj_fe.u = [1,1,0];
             proj_fe.v = [-1,1,0];
-            
+
             % Short cut along [1,1,0]
             fe_1=cut_sqw(data_source_fe,proj_fe,[0.95,1.05],[-0.6,0.05,0.6],[-0.05,0.05],[150,160]);
-            
+
             % Long cut along [1,1,0]
             fe_2=cut_sqw(data_source_fe,proj_fe,[0.95,1.05],[-2,0.05,3],[-0.05,0.05],[150,160]);
-            
+
             % Create cuts to simulate or fit simultaneously
             tmp_1=cut_sqw(data_source_fe,proj_fe,[0.95,1.05],[-0.6,0.05,0.6],[-0.05,0.05],[140,160]);
             tmp_2=cut_sqw(data_source_fe,proj_fe,[0.95,1.05],[-0.6,0.05,0.6],[-0.05,0.05],[160,180]);
             tmp_3=cut_sqw(data_source_fe,proj_fe,[0.95,1.05],[-0.6,0.05,0.6],[-0.05,0.05],[180,200]);
-            
+
             fe_arr=[tmp_1,tmp_2,tmp_3];
-            
+
             % Cuts from RbMnF3
             % ----------------
             proj_rb.u = [1,1,0];
@@ -334,14 +358,14 @@ classdef test_tobyfit_cuts < TestCaseWithSave
             tmp_1 = cut_sqw(data_source_rb,proj_rb,[0.45,0.55],[-0.05,0.05],[-0.05,0.05],[5,0,11]);
             tmp_2 = cut_sqw(data_source_rb,proj_rb,[0.45,0.55],[0.25,0.35],[-0.05,0.05],[2,0,10]);
             tmp_3 = cut_sqw(data_source_rb,proj_rb,[0.45,0.55],[0.15,0.25],[-0.05,0.05],[2,0,10]);
-            
+
             rb_arr = [tmp_1;tmp_2;tmp_3];
-            
+
             % Save data
             % ---------
             save(datafile,'fe_1','fe_2','fe_arr','rb_arr');
             disp(['Saved data for future use in ',datafile])
-            
+
         end
     end
 

--- a/_test/test_TF_let/test_tobyfit_let_cuts.m
+++ b/_test/test_TF_let/test_tobyfit_let_cuts.m
@@ -1,6 +1,6 @@
 classdef test_tobyfit_let_cuts < TestCaseWithSave
     % Test of basic fitting operations with Tobyfit for LET type instrument
-    
+
     properties
         nb_arr
         mc
@@ -9,34 +9,34 @@ classdef test_tobyfit_let_cuts < TestCaseWithSave
         seed
         rng_state
     end
-    
+
     methods
         function obj = test_tobyfit_let_cuts (name)
             % Initialise object properties and pre-load test cuts for faster tests
-            
+
             data_file = 'test_tobyfit_let_cuts_data.mat';   % filename where cuts for tests are stored
             obj = obj@TestCaseWithSave(name);
 
             % Load sqw cuts
             load (data_file, 'w1a', 'w1b');
-            
+
             % Add instrument and sample information to the cuts
             efix = 8.04;
             instru = let_instrument_obj_for_tests (efix, 280, 140, 20, 2, 2);
             sample = IX_sample(true,[1,1,0],[0,0,1],'cuboid',[0.012,0.012,0.04]);
             sample.alatt = w1a.data.alatt;
             sample.angdeg = w1a.data.angdeg;
-            
+
             w1a = set_instrument (w1a, instru);
             w1a = set_sample (w1a, sample);
-            
+
             w1b = set_instrument (w1b, instru);
             w1b = set_sample (w1b, sample);
-            
-                
+
+
             % Initialise test object properties
             obj.nb_arr = [w1a,w1b];
-            
+
             tol_sig = 0.25;     % tolerance as multiple of st. dev. of reference value
             tol_abs = 0;        % absolute tolerance
             tol_rel = 0;        % relative tolerance
@@ -54,24 +54,24 @@ classdef test_tobyfit_let_cuts < TestCaseWithSave
             obj.rng_state = rng(obj.seed, 'twister');
             warning('off', 'HERBERT:mask_data_for_fit:bad_points')
         end
-        
+
         function obj = tearDown(obj)
             % Undo rng state
             rng(obj.rng_state);
             warning('on', 'HERBERT:mask_data_for_fit:bad_points')
         end
-                
-        
+
+
         %% --------------------------------------------------------------------------------------
         % Fit multiple datasets from Nb
         % ---------------------------------------------------------------------------------------
-        
+
         function obj = test_fit_nb_multi_amplitude_global(obj)
             % Local foreground; constrain amplitude as global but allow
             % width to vary locally.
-            
+
             amp=6000;    fwhh=0.2;
-            
+
             kk = tobyfit(obj.nb_arr);
             kk = kk.set_local_foreground;
             kk = kk.set_fun(@testfunc_nb_sqw,[amp,fwhh]);
@@ -81,11 +81,41 @@ classdef test_tobyfit_let_cuts < TestCaseWithSave
             kk = kk.set_options('listing',obj.nlist);
             kk = kk.set_options('fit',[1e-4,20,0.01]);
             [~,fp] = kk.fit;
-            
+
             assertTestWithSave(obj, fp, @is_same_fit, obj.tolerance)
 
         end
-        
+
+        function obj = test_fit_nb_multi_amplitude_global_fb(obj)
+            % Local foreground; constrain amplitude as global but allow
+            % width to vary locally.
+
+            skipTest("Disabled until #760 implementation of filebacked Tobyfit")
+
+            amp=6000;    fwhh=0.2;
+
+            clOb = set_temporary_config_options(hor_config, 'mem_chunk_size', 100);
+
+            nb_fb = obj.nb_arr;
+            for i = 1:numel(nb_fb)
+                nb_fb(i).pix = PixelDataFileBacked(obj.nb_arr(i).pix);
+            end
+
+            kk = tobyfit(nb_fb);
+            kk = kk.set_local_foreground;
+            kk = kk.set_fun(@testfunc_nb_sqw,[amp,fwhh]);
+            kk = kk.set_bind({2,[2,1]});
+            kk = kk.set_bfun(@testfunc_bkgd,[0,0],[1,0]);
+            kk = kk.set_mc_points(obj.mc);
+            kk = kk.set_options('listing',obj.nlist);
+            kk = kk.set_options('fit',[1e-4,20,0.01]);
+            [~,fp] = kk.fit();
+
+            ref = getReferenceDataset(obj, 'test_fit_nb_multi_amplitude_global', 'fp')
+            assertTrue(is_same_fit(fp, ref, obj.tolerance))
+
+        end
+
     end
 
 end

--- a/_test/test_TF_let/test_tobyfit_let_cuts.m
+++ b/_test/test_TF_let/test_tobyfit_let_cuts.m
@@ -90,7 +90,8 @@ classdef test_tobyfit_let_cuts < TestCaseWithSave
             % Local foreground; constrain amplitude as global but allow
             % width to vary locally.
 
-            skipTest("Disabled until #760 implementation of filebacked Tobyfit")
+            skipTest(['Preliminary test ready for #760 implementation of filebacked Tobyfit, ', ...
+                      'parallel to test_multifit_horace_1:test_fit_one_dataset_fb, but as yet untested'])
 
             amp=6000;    fwhh=0.2;
 

--- a/_test/test_multifit/test_multifit_horace_1.m
+++ b/_test/test_multifit/test_multifit_horace_1.m
@@ -66,12 +66,14 @@ classdef test_multifit_horace_1 < TestCaseWithSave
             assertEqualToTolWithSave (this, wfit_1, 'tol', tol, 'ignore_str', 1, '-ignore_date')
         end
 
-        function this = test_fit_one_dataset_fb(this)
+        function obj = test_fit_one_dataset_fb(obj)
             % Example of fitting one sqw object
 
-            clOb = set_temporary_config_options(hor_config, 'mem_chunk_size', 100);
-            w1data_fb = this.w1data;
-            w1data_fb.pix = PixelDataFileBacked(this.w1data.pix);
+            clWarn = set_temporary_warning('off','HOR_CONFIG:set_mem_chunk_size');
+            clOb = set_temporary_config_options(hor_config, 'mem_chunk_size', ...
+                obj.w1data.pix.num_pixels/4);
+            w1data_fb = obj.w1data;
+            w1data_fb.pix = PixelDataFileBacked(obj.w1data.pix);
 
             mss = multifit_sqw_sqw([w1data_fb]);
             mss = mss.set_fun(@sqw_bcc_hfm,  [5,5,0,10,0]);  % set foreground function(s)
@@ -88,9 +90,9 @@ classdef test_multifit_horace_1 < TestCaseWithSave
             [wfit_1, fitpar_1] = mss.fit();
             % Test against saved or store to save later; ignore string
             % changes - these are filepaths
-            ref_fitpar = getReferenceDataset(this, 'test_fit_one_dataset', 'fitpar_1');
-            ref_wfit = getReferenceDataset(this, 'test_fit_one_dataset', 'wfit_1')
-            ref_wsim = getReferenceDataset(this, 'test_fit_one_dataset', 'wsim_1')
+            ref_fitpar = getReferenceDataset(obj, 'test_fit_one_dataset', 'fitpar_1');
+            ref_wfit = getReferenceDataset(obj, 'test_fit_one_dataset', 'wfit_1');
+            ref_wsim = getReferenceDataset(obj, 'test_fit_one_dataset', 'wsim_1');
 
             assertEqualToTol(wsim_1, ref_wsim, 'tol', tol, 'ignore_str', 1, '-ignore_date')
             assertTrue(is_same_fit(fitpar_1, ref_fitpar, [1 0 0]))


### PR DESCRIPTION
Add simple tests to verify file-backed fitting algorithms for use in #760 refactor of Tobyfit and as part of verification of #1420

Tobyfit currently does not work with file-backed objects and fails with a size mismatch in assignment in `tobyfit_*_resconv`, so these tests remain disabled for now. 

The unskipped multifit test is the multifit equivalent of these skipped Tobyfit tests which use filebacked sqws in the calculation and are the supporting evidence for the skipped Tobyfit tests.

As part of #760 they will be used in developing file-backed Tobyfit.

Fixes #1423 