### PR TITLE
join is static sqw method

### DIFF
--- a/_test/test_dnd_class/test_migrated_apis.m
+++ b/_test/test_dnd_class/test_migrated_apis.m
@@ -173,22 +173,6 @@ classdef test_migrated_apis < TestCaseWithSave
             assertEqualToTol(pbin, expected_pbin, 1e-6);
         end
 
-        %% split/join
-        %function test_split(obj)
-        %    % tested in test_join
-        %end
-        %function test_join(obj)
-        %    % tested in test_join
-        %end
-        %function test_split_and_join(obj)
-        %    % tested in test_join
-        %end
-
-        %% mask
-        %function test_mask(obj)
-        %    % tested in test_mask
-        %end
-
         %% xye
         function test_xye_returns_bin_centres_and_errors_sqw(obj)
             sqw_2d_obj = read_sqw(obj.test_sqw_2d_fullpath);

--- a/_test/test_sqw_class/test_migrated_apis.m
+++ b/_test/test_sqw_class/test_migrated_apis.m
@@ -285,22 +285,6 @@ classdef test_migrated_apis < TestCaseWithSave & common_sqw_class_state_holder
             assertEqualToTol(pbin{1}, expected_pbin', 1e-6);
         end
 
-        %% split/join
-        %function test_split(obj)
-        %    % tested in test_join
-        %end
-        %function test_join(obj)
-        %    % tested in test_join
-        %end
-        %function test_split_and_join(obj)
-        %    % tested in test_join
-        %end
-
-        %% mask
-        %function test_mask(obj)
-        %    % tested in test_mask
-        %end
-
         %% sets
         function test_set_efix(obj)
             sqw_obj = sqw(obj.test_sqw_2d_fullpath);

--- a/_test/test_sqw_pageOpMethods/test_join.m
+++ b/_test/test_sqw_pageOpMethods/test_join.m
@@ -43,7 +43,7 @@ classdef test_join < TestCase
             sqw_obj = sqw.generate_cube_sqw(10);
 
             split_obj = split(sqw_obj);
-            reformed_obj = join(sqw_obj);
+            reformed_obj = sqw.join(sqw_obj);
 
             assertEqualToTol(split_obj, reformed_obj)
             assertEqualToTol(sqw_obj, reformed_obj)
@@ -76,7 +76,7 @@ classdef test_join < TestCase
 
             assertEqual(numel(split_obj), 2)
 
-            reformed_obj = join(split_obj,sqw_obj);
+            reformed_obj = sqw.join(split_obj,sqw_obj);
 
             assertEqualToTol(sqw_obj, reformed_obj)
         end
@@ -88,19 +88,19 @@ classdef test_join < TestCase
                 'mem_chunk_size',page_size,'fb_scale_factor',3);
 
             nf = numel(obj.files_to_join);
-            split_obj = repmat(sqw(),1,nf);
+            split_obj = cell(1,nf);
             for i=1:nf
-                split_obj(i) = sqw(obj.files_to_join{i},'file_backed',true);
-                assertTrue(split_obj(i).is_filebacked);
+                split_obj{i} = sqw(obj.files_to_join{i},'file_backed',true);
+                assertTrue(split_obj{i}.is_filebacked);
             end
 
-            reformed_obj = join(split_obj);
+            reformed_obj = sqw.join(split_obj);
 
             assertTrue(reformed_obj.is_filebacked)
             targ_file = reformed_obj.full_filename;
             assertTrue(isfile(targ_file))
             % to compare filebacked and memory backed object properly, here
-            % we need to have compartible page sizes. The compariosn will
+            % we need to have compatible page sizes. The comparison will
             % fail otherwise. Re #1147 -- should be fixed.
             clear clConf;
             assertEqualToTol(obj.sample_obj, reformed_obj, [1e-7, 1e-7], 'ignore_str', true)
@@ -134,7 +134,7 @@ classdef test_join < TestCase
 
             assertTrue(all(arrayfun(@(x) x.main_header.nfiles == 1, split_obj)));
 
-            reformed_obj = join(split_obj,'-recalc_runid');
+            reformed_obj = sqw.join(split_obj,'-recalc_runid');
 
             runid = reformed_obj.runid_map.keys();
             assertEqual([runid{:}],1:reformed_obj.main_header.nfiles);
@@ -156,7 +156,7 @@ classdef test_join < TestCase
 
             assertTrue(all(arrayfun(@(x) x.main_header.nfiles == 1, split_obj)));
 
-            reformed_obj = join(split_obj,obj.sample_obj,'-recalc_runid');
+            reformed_obj = sqw.join(split_obj,obj.sample_obj,'-recalc_runid');
 
             runid = reformed_obj.runid_map.keys();
             assertEqual([runid{:}],1:reformed_obj.main_header.nfiles);
@@ -178,7 +178,7 @@ classdef test_join < TestCase
 
             assertTrue(all(arrayfun(@(x) x.main_header.nfiles == 1, split_obj)));
 
-            reformed_obj = join(split_obj);
+            reformed_obj = sqw.join(split_obj);
 
             assertEqualToTol(obj.sample_obj, reformed_obj, [1e-7, 1e-7], 'ignore_str', true)
         end

--- a/_test/test_sqw_pageOpMethods/test_join.m
+++ b/_test/test_sqw_pageOpMethods/test_join.m
@@ -115,7 +115,7 @@ classdef test_join < TestCase
             clOb = onCleanup(@()delete(targ_file));
 
             split_obj = obj.sqw_to_join;
-            reformed_obj = join(split_obj,targ_file);
+            reformed_obj = sqw.join(split_obj,targ_file);
 
             assertTrue(reformed_obj.is_filebacked)
             assertTrue(isfile(targ_file));

--- a/admin/run_docify.m
+++ b/admin/run_docify.m
@@ -4,7 +4,7 @@ function run_docify()
     docifiable_folders = {'applications/multifit', ...
                           'utilities'};
     for ii = 1:numel(docifiable_folders)
-        fld = join([base_dir '/' docifiable_folders{ii}], '');
+        fld = fullfile(base_dir,docifiable_folders{ii});
         docify(fld, '-recursive', '-list', 3, '-all')
     end
 end

--- a/herbert_core/admin/parse_path.m
+++ b/herbert_core/admin/parse_path.m
@@ -3,7 +3,7 @@ function my_path=parse_path(in_path)
 %
 %   >> my_path=parse_path(in_path)
 %
-% Recall that './' refers to current directoy, and '../' to parent directory.
+% Recall that './' refers to current directory, and '../' to parent directory.
 %
 % If in_path starts with ./ or ../ the function appends in_path to the current
 % working directory to the path specified as input argument.
@@ -26,9 +26,6 @@ function my_path=parse_path(in_path)
 %       adds working directory path to it.
 %
 
-% Written by: Alex Buts 27/08/2009
-
-
 dirs = regexp(in_path,'[\/\\]','split');
 
 if( size(dirs)==0)
@@ -50,7 +47,8 @@ for i=1:length(dirs)
     elseif(strcmp(dirs{i},'..'))
         path_length=path_length-1;
         if(path_length<=0)
-            error(' parse_path => wrong path; path %s points above the root folder',in_path)
+            error('HERBERT:admin:invalid_argument', ...
+                ' parse_path => wrong path; path %s points above the root folder',in_path)
         end
         continue
     else
@@ -60,24 +58,10 @@ for i=1:length(dirs)
 end
 
 
-my_path = join(filesep,dirs,path_length);
+my_path = join(dirs,filesep);
 if(~strncmp(computer,'PC',2)) % linux root folder -- separate treatment
     if(my_path(1)~='/')
         my_path=['/',my_path];
     end
 end
-
-
-end
-
-%-----------------------------------------------------------------------------------------------
-function joined=join(sep,array,length)
-% functions glues array into a string with separator sep between words
-% should work similarly to Perl join
-
-joined = array{1};
-for i=2:length
-    joined=[joined sep array{i}];
-end
-
 end

--- a/herbert_core/classes/data_loaders/@rundata/private/serialize_.m
+++ b/herbert_core/classes/data_loaders/@rundata/private/serialize_.m
@@ -5,7 +5,8 @@ function output_byte_array = serialize_(run)
 [undefined,~,fields_undef] = check_run_defined(run);
 if (undefined>2)
     undef_str = strjoin(fields_undef,'; ');
-    error('RUNDATA:to_string','Can not confvert to string undefined rundata class due to undefined fields %s',undef_str)
+    error('HERBERT:rundata:invalid_argument',...
+    'Can not convert to string undefined rundata class due to undefined fields %s',undef_str)
 end
 %
 out_struct = run.saveobj();

--- a/herbert_core/utilities/maths/array_common.m
+++ b/herbert_core/utilities/maths/array_common.m
@@ -28,7 +28,7 @@ function [c1joint,c1unique,c2unique]=array_common(c1,c2,opt)
 %              [Column array]
 %
 %   c1unique    Unique elements of first array in the order they appeared
-%              in the original arrays according to first or last occurence
+%              in the original arrays according to first or last occurrence
 %              determined by input argument opt (see above)
 %              [Column array]
 %

--- a/horace_core/algorithms/collect_sqw_metadata.m
+++ b/horace_core/algorithms/collect_sqw_metadata.m
@@ -9,7 +9,7 @@ function [sqw_out,pix_data_range,job_disp] = collect_sqw_metadata(inputs,varargi
 %
 % Inputs:
 % inputs  -- cellarray of files containing sqw objects or cellarray or array
-%            of filebacked or memorybased sqw objects to combine.
+%            of filebacked or memory-based sqw objects to combine.
 % Optional:
 % '-allow_equal_headers'
 %         -- if two objects or files from the list of input files contain
@@ -17,7 +17,7 @@ function [sqw_out,pix_data_range,job_disp] = collect_sqw_metadata(inputs,varargi
 %            otherwise.
 % '-keep_runid'
 %         -- if provided, keep existing run_id(s) according to numbers,
-%            stored in headers. If not, recaluclate runID according to number
+%            stored in headers. If not, recalculate runID according to number
 %            of input files.
 %
 % Returns:

--- a/horace_core/algorithms/read_horace.m
+++ b/horace_core/algorithms/read_horace.m
@@ -2,7 +2,7 @@ function varargout = read_horace(files,varargin)
 % Read sqw object from named file or an array of sqw objects from a cell array of file names
 %
 %   >> w=read_horace(file)   % read named file or cell array of file names
-%                             into array of sqw objects or cellarray of sqw/dnd ojects
+%                             into array of sqw objects or cellarray of sqw/dnd objects
 %Main options:
 %   >> w=read_horace(file(s),'-get_dnd') --  read dnd parts of all (dnd and sqw) objects
 %                                            only.

--- a/horace_core/sqw/@sqw/join.m
+++ b/horace_core/sqw/@sqw/join.m
@@ -7,13 +7,14 @@ function wout = join(w,varargin)
 %
 % Input:
 % ------
-%   w       array of sqw objects, each one made from a single spe data file
+%   w       array or cellarray of sqw objects or cellarray of names of sqw 
+%           files, each one made from a single spe data file
 % Optional:
 %   wi      initial pre-split sqw object (optional, recommended).
 % outfile   if provided and input objects are filebacked, does resulting
 %           combined object filebacked regardless of the fact that it may
 %           fit memory.
-%           Normally restulting object is filebacked or memory-based
+%           Normally resulting object is filebacked or memory-based
 %           depending on its size and hor_config mem_chunk_size and fb_scale_factor
 %           settings.
 % modifiers:
@@ -23,7 +24,7 @@ function wout = join(w,varargin)
 % '-recalc_runid'
 %         -- if provided, recalculate existing run-id(s) stored in headers
 %            in such way that pixels run-ids correspond to number of header
-%            (IX_experiment) this run desctibes in the array of
+%            (IX_experiment) this run describes in the array of
 %            Experiment.expdata headers (IX_experiments).
 %
 % Output:

--- a/horace_core/sqw/@sqw/join.m
+++ b/horace_core/sqw/@sqw/join.m
@@ -7,7 +7,7 @@ function wout = join(w,varargin)
 %
 % Input:
 % ------
-%   w       array or cellarray of sqw objects or cellarray of names of sqw 
+%   w       array or cellarray of sqw objects or cellarray of names of sqw
 %           files, each one made from a single spe data file
 % Optional:
 %   wi      initial pre-split sqw object (optional, recommended).
@@ -84,7 +84,11 @@ else
         argi = [argi(:),'-keep_runid'];
     end
     wout = collect_sqw_metadata(w,argi{:});
-    [fp,fn] = fileparts(w(1).full_filename);
+    if iscell(w)
+        [fp,fn] = fileparts(w{1}.full_filename);
+    else
+        [fp,fn] = fileparts(w(1).full_filename);
+    end
     wout.full_filename = fullfile(fp,['combined_',fn,'.sqw']);
 end
 

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -109,6 +109,8 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
             %              modifications to pixels.
             obj = obj.pix.apply_op(obj,operation);
         end
+        % build sqw from multiple compatible-sqw parts.
+        wout = join(w,varargin);
     end
     %======================================================================
     % PageOp methods -- methods, which use PageOp for implementation, so
@@ -117,7 +119,6 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
     methods
         % combine together various sqw objects, containing the same size images
         wout = combine_sqw(w1,varargin);
-        wout = join(w,varargin);
         wout = split(w,varargin);
 
         [wout,mask_array] = mask(win, mask_array);

--- a/horace_core/sqw/coord_transform/@line_proj/private/eq_.m
+++ b/horace_core/sqw/coord_transform/@line_proj/private/eq_.m
@@ -1,7 +1,7 @@
 function [is,mess] = eq_(obj,other_obj,narg_out,names,varargin)
 % Check equality of two ortho projections or two arrays of
 % line_projections comparting the projection transformation
-% instrad of  all projection properties
+% instead of  all projection properties
 %
 % Different projection property values may define the same
 % transformation, so the projections, which define the same

--- a/horace_core/sqw/page_operations/PageOp_join_sqw.m
+++ b/horace_core/sqw/page_operations/PageOp_join_sqw.m
@@ -92,7 +92,7 @@ classdef PageOp_join_sqw < PageOpBase
         function obj = get_page_data(obj,idx,npix_blocks)
             % join-specific access to block of page data
             %
-            % reads data from mutiple sources and combines them together
+            % reads data from multiple sources and combines them together
             % into single page of data.
             %
             bin_start = cumsum(npix_blocks{idx});


### PR DESCRIPTION
This should be looked at after #1428 is merged. 

This is @oerc0122-style PR, containing only one change. `join` opeation for `sqw` object made static and various small changes related to search for join within the code base and fixing various small issues in the code (like typos) identified while looking for `join` within the code. 

I normally would not do such PR, because such changes are part of development, but because these changes produce working code at this stage, I do not mind making them into a separtate PR. 