### PR TITLE
Fix docs bug - missing semicolon

### DIFF
--- a/horace_core/configuration/@hpc_config/hpc_config.m
+++ b/horace_core/configuration/@hpc_config/hpc_config.m
@@ -192,7 +192,7 @@ classdef hpc_config < config_base
             'mex_combine_buffer_size',...
             'parallel_multifit'...
 
-            }
+            };
         combine_sqw_options_ = {'matlab','mex_code','mpi_code'};
     end
     methods(Static)


### PR DESCRIPTION
Missing semi-colon meant that Sphinx could not find the class constructor method and hangs.