### PR TITLE
removing old interface to write handle

### DIFF
--- a/_test/test_sym_op/test_cut_sym_cube.m
+++ b/_test/test_sym_op/test_cut_sym_cube.m
@@ -24,7 +24,7 @@ classdef test_cut_sym_cube < TestCase
             obj@TestCase(name)
         end
 
-        function test_cut_sym_identity_stripped(obj)
+        function test_cut_sym_identity_stripped(~)
             tsqw = sqw.generate_cube_sqw(10);
 
             res_sqw = cut(tsqw, line_proj([1 0 0], [0 1 0]), ...

--- a/horace_core/algorithms/cut.m
+++ b/horace_core/algorithms/cut.m
@@ -66,11 +66,13 @@ if is_string(source)
     % We expect either a .sqw or .dnd file, throw an error otherwise.
     ldr = sqw_formats_factory.instance().get_loader(source);
     % If we're cutting, don't ever want to load whole file
-    sqw_dnd_obj=obj_from_faccessor(ldr, n_object, sqw_only, dnd_only);
+    sqw_dnd_obj=obj_from_faccessor(ldr, n_object, sqw_only, dnd_only, ...
+        'file_backed',true);
 
 elseif isa(source,'horace_binfile_interface')
     % If we're cutting, don't ever want to load whole file
-    sqw_dnd_obj=obj_from_faccessor(source,n_object,sqw_only,dnd_only);
+    sqw_dnd_obj=obj_from_faccessor(source,n_object,sqw_only,dnd_only, ...
+        'file_backed',true);
 elseif isa(source, 'SQWDnDBase')
     sqw_dnd_obj = source;
     if sqw_only || dnd_only

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -83,8 +83,8 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
     properties(Access=private)
         % holder for the class, which deletes temporary file when holding
         % object goes out of scope.
-        % Has to be present on sqw level, as pix level can not delete file
-        % due to object destruction rules.
+        % Has to be present on sqw level, as its copy on pix level can not
+        % delete sqw file due to object destruction rules.
         tmp_file_holder_;
     end
 

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -86,8 +86,6 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
         % Has to be present on sqw level, as pix level can not delete file
         % due to object destruction rules.
         tmp_file_holder_;
-        % Re #1302 TODO: delete old interface
-        file_holder_
     end
 
     methods(Static)
@@ -413,13 +411,12 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
         end
     end
     %======================================================================
-    % supporting function for apply_op
+    % supporting methods for apply_op
     methods
         %----------------------------------
         new_sqw = copy(obj, varargin)
-        [obj, ldr] = get_new_handle(obj, outfile)
         wh  = get_write_handle(obj, outfile)
-        obj = finish_dump(obj,varargin);
+        obj = finish_dump(obj,page_op);
         %
     end
     %======================================================================

--- a/horace_core/sqw/PixelData/@PixelDataBase/PixelDataBase.m
+++ b/horace_core/sqw/PixelData/@PixelDataBase/PixelDataBase.m
@@ -358,13 +358,10 @@ classdef (InferiorClasses = {?DnDBase,?IX_dataset,?sigvar},Abstract) ...
         % operation, possibly using new file name
         [obj,varargout] = activate(obj,filename,varargin);
 
-        obj = prepare_dump(obj)
         obj = get_write_handle(obj, varargin)
         obj = store_page_data(obj,data_page)
-
-        obj = get_new_handle(obj, varargin)
         %
-        obj = finish_dump(obj,varargin)
+        obj = finish_dump(obj,page_op)
         %
         % Sets file, associated with object to be removed when obj gets out of scope
         obj =set_as_tmp_obj(obj,filename);

--- a/horace_core/sqw/PixelData/@PixelDataFileBacked/PixelDataFileBacked.m
+++ b/horace_core/sqw/PixelData/@PixelDataFileBacked/PixelDataFileBacked.m
@@ -420,7 +420,7 @@ classdef (InferiorClasses = {?DnDBase,?IX_dataset,?sigvar}) PixelDataFileBacked 
                 % input is a file path
                 init = sqw_formats_factory.instance().get_loader(val.data);
             end
-            obj = obj.init(init);ni
+            obj = obj.init(init);
         end
         %------------------------------------------------------------------
         function data  = get_data(obj,page_number)

--- a/horace_core/sqw/PixelData/@PixelDataFileBacked/PixelDataFileBacked.m
+++ b/horace_core/sqw/PixelData/@PixelDataFileBacked/PixelDataFileBacked.m
@@ -79,9 +79,10 @@ classdef (InferiorClasses = {?DnDBase,?IX_dataset,?sigvar}) PixelDataFileBacked 
         % by `distribute` to send file portions to workers
         offset_ = 0;
 
-        % handle-class holding tmp file produced by filebacked
-        % operations. If all referring classes go out of scope the file
-        % gets deleted.
+        % Place for handle-class holding tmp pixel file produced by filebacked
+        % operations with pixels only (no sqw object). If all referring
+        % classes go out of scope the file gets deleted. See similar
+        % property on SQW object for operations with full sqw object.
         tmp_file_holder_ = [];
     end
 

--- a/horace_core/sqw/PixelData/@PixelDataFileBacked/PixelDataFileBacked.m
+++ b/horace_core/sqw/PixelData/@PixelDataFileBacked/PixelDataFileBacked.m
@@ -79,33 +79,17 @@ classdef (InferiorClasses = {?DnDBase,?IX_dataset,?sigvar}) PixelDataFileBacked 
         % by `distribute` to send file portions to workers
         offset_ = 0;
 
-        % Re #1302 TODO: delete old interface
-        % handle to the class used to perform pixel writing
-        write_handle_ = []; %  in operations, involving move pixels
-        % from source file to the file, which is the target of operation.
-
         % handle-class holding tmp file produced by filebacked
         % operations. If all referring classes go out of scope the file
         % gets deleted.
         tmp_file_holder_ = [];
     end
-    properties (Hidden, Access=private)
-        % Re #1302 TODO: delete old interface
-        pix_written = 0;
-    end
-
 
     properties(Dependent,Hidden)
         % defines offset from the beginning of the pixels in the binary file
         % accessed through memmapfile.
         offset;
     end
-
-    properties(Dependent, Hidden)
-        has_open_file_handle;
-    end
-
-
     properties (Constant)
         is_filebacked = true;
     end
@@ -247,10 +231,6 @@ classdef (InferiorClasses = {?DnDBase,?IX_dataset,?sigvar}) PixelDataFileBacked 
         function offset = get.offset(obj)
             offset = obj.offset_;
         end
-
-        function has = get.has_open_file_handle(obj)
-            has = ~isempty(obj.write_handle_);
-        end
     end
 
     %======================================================================
@@ -288,47 +268,10 @@ classdef (InferiorClasses = {?DnDBase,?IX_dataset,?sigvar}) PixelDataFileBacked 
             obj = set_as_tmp_obj_(obj,filename);
         end
         %
-        function obj = prepare_dump(obj)
-            % Get new handle iff not already opened by sqw
-            if ~obj.has_open_file_handle
-                obj = obj.get_new_handle();
-            end
-        end
-        function obj = get_new_handle(obj, f_accessor)
-            % Always create a new PixTmpFile object
-            % If others point to it, file will be kept
-            % otherwise file will be cleared
-
-            if exist('f_accessor', 'var') && ~isempty(f_accessor)
-                obj.write_handle_ = f_accessor;
-                obj.full_filename = f_accessor.full_filename;
-            else
-                if isempty(obj.full_filename)
-                    obj.full_filename = 'in_mem';
-                end
-                obj.tmp_file_holder_ = TmpFileHandler(obj.full_filename);
-
-                obj.write_handle_ = sqw_fopen(obj.tmp_file_holder_.file_name, 'wb+');
-            end
-            obj.pix_written = 0;
-        end
-        function obj = format_dump_data(obj, data)
-            if ~obj.has_open_file_handle
-                error('HORACE:PixelDataFileBacked:runtime_error', ...
-                    'Cannot dump data, object does not have open filehandle')
-            end
-            if isa(obj.write_handle_, 'sqw_file_interface')
-                obj.write_handle_.put_raw_pix(data, obj.pix_written+1);
-            else
-                fwrite(obj.write_handle_, single(data), 'single');
-            end
-            obj.pix_written = obj.pix_written + size(data, 2);
-        end
-
-        function obj = finish_dump(obj,varargin)
+        function obj = finish_dump(obj,page_op)
             % complete pixel write operation, close writing to the target
             %  file and open pixel dataset for access operations.
-            obj = finish_dump_(obj,varargin{:});
+            obj = finish_dump_(obj,page_op);
         end
 
         function format = get_memmap_format(obj, tail,new)
@@ -476,7 +419,7 @@ classdef (InferiorClasses = {?DnDBase,?IX_dataset,?sigvar}) PixelDataFileBacked 
                 % input is a file path
                 init = sqw_formats_factory.instance().get_loader(val.data);
             end
-            obj = obj.init(init);
+            obj = obj.init(init);ni
         end
         %------------------------------------------------------------------
         function data  = get_data(obj,page_number)

--- a/horace_core/sqw/PixelData/@PixelDataFileBacked/private/finish_dump_.m
+++ b/horace_core/sqw/PixelData/@PixelDataFileBacked/private/finish_dump_.m
@@ -3,52 +3,9 @@ function obj = finish_dump_(obj,page_op)
 % open pixel dataset for read operations.
 %
 %
-if nargin>1 % new interface
-    wh = page_op.write_handle;
-    init_info = wh.release_pixinit_info();
-    if wh.is_tmp_file
-        obj = obj.set_as_tmp_obj(wh.write_file_name);
-    end
-    obj = obj.init(init_info);
-    return
+wh = page_op.write_handle;
+init_info = wh.release_pixinit_info();
+if wh.is_tmp_file
+    obj = obj.set_as_tmp_obj(wh.write_file_name);
 end
-
-% Re #1302 TODO: DELETE Old interface. Letf to maintain the tests which
-% are not yet transformed as part of #1302.
-if ~obj.has_open_file_handle
-    error('HORACE:PixelDataFileBacked:runtime_error', ...
-        'Cannot finish dump writing, object does not have open filehandle')
-end
-
-obj.num_pixels_ = obj.pix_written;
-
-if isa(obj.write_handle_, 'sqw_file_interface')
-    obj.full_filename = obj.write_handle_.full_filename;
-    obj.write_handle_ = obj.write_handle_.put_pix_metadata(obj);
-    % Force pixel update
-    obj.write_handle_ = obj.write_handle_.put_num_pixels(obj.num_pixels);
-
-    obj = init_from_file_accessor_(obj,obj.write_handle_, false, true);
-    obj.write_handle_.delete();
-    obj.write_handle_ = [];
-
-else
-    if ~isempty(obj.write_handle_)
-        fclose(obj.write_handle_);
-    end
-    if obj.num_pixels_ == 0
-        obj = PixelDataMemory();
-        return;
-    end
-
-    obj.write_handle_ = [];
-    obj.f_accessor_ = [];
-    obj.offset_ = 0;
-    obj.full_filename = obj.tmp_file_holder_.file_name;
-    obj.f_accessor_ = memmapfile(obj.full_filename, ...
-        'format', obj.get_memmap_format(), ...
-        'Repeat', 1, ...
-        'Writable', true, ...
-        'offset', obj.offset_);
-    obj.page_num_ = 1;
-end
+obj = obj.init(init_info);

--- a/horace_core/sqw/PixelData/@PixelDataMemory/PixelDataMemory.m
+++ b/horace_core/sqw/PixelData/@PixelDataMemory/PixelDataMemory.m
@@ -105,7 +105,7 @@ classdef (InferiorClasses = {?DnDBase,?IX_dataset,?sigvar}) PixelDataMemory  < P
     end
     %======================================================================
     % File handling/migration. Does nothing on membased except dump_data
-    % which recets raw data with input.
+    % which resets raw data with input.
     methods
         function obj = deactivate(obj)
             % close all open file handles to allow file movements to new
@@ -121,12 +121,6 @@ classdef (InferiorClasses = {?DnDBase,?IX_dataset,?sigvar}) PixelDataMemory  < P
             end
         end
 
-        function obj = prepare_dump(obj)
-            % does nothing on Mem-based
-        end
-        function obj = get_new_handle(obj, varargin)
-            % does nothing on Mem-based
-        end
         function wh = get_write_handle(~, varargin)
             % does nothing on Mem-based
             wh = [];

--- a/horace_core/symop/@Symop/Symop.m
+++ b/horace_core/symop/@Symop/Symop.m
@@ -162,9 +162,9 @@ classdef(Abstract) Symop < matlab.mixin.Heterogeneous & serializable
                 for i = 1:pix.num_pages
                     pix.page_num = i;
                     curr_page = pix.data;
-                    for i = numel(obj):-1:1
-                        sel = ~obj(i).in_irreducible(curr_page(1:3, :), proj{:});
-                        curr_page(1:3, sel) = obj(i).transform_vec(curr_page(1:3, sel));
+                    for j = numel(obj):-1:1
+                        sel = ~obj(j).in_irreducible(curr_page(1:3, :), proj{:});
+                        curr_page(1:3, sel) = obj(j).transform_vec(curr_page(1:3, sel));
                     end
                     pix = pix.format_dump_data(curr_page);
                 end

--- a/horace_core/symop/@Symop/Symop.m
+++ b/horace_core/symop/@Symop/Symop.m
@@ -159,16 +159,8 @@ classdef(Abstract) Symop < matlab.mixin.Heterogeneous & serializable
                     pix.q_coordinates(:, ~sel) = obj(i).transform_vec(pix.q_coordinates(:, ~sel));
                 end
             else
-                for i = 1:pix.num_pages
-                    pix.page_num = i;
-                    curr_page = pix.data;
-                    for j = numel(obj):-1:1
-                        sel = ~obj(j).in_irreducible(curr_page(1:3, :), proj{:});
-                        curr_page(1:3, sel) = obj(j).transform_vec(curr_page(1:3, sel));
-                    end
-                    pix = pix.format_dump_data(curr_page);
-                end
-                pix = pix.finalise();
+                error('HORACE:Symop:not_implemented', ...
+                    'Transforming filebased pixels is not currently implemented');
             end
 
         end

--- a/horace_core/symop/@Symop/Symop.m
+++ b/horace_core/symop/@Symop/Symop.m
@@ -160,7 +160,7 @@ classdef(Abstract) Symop < matlab.mixin.Heterogeneous & serializable
                 end
             else
                 error('HORACE:Symop:not_implemented', ...
-                    'Transforming filebased pixels is not currently implemented');
+                    'Transforming file-backed pixels is not currently implemented');
             end
 
         end


### PR DESCRIPTION
This PR should be condidered #1435 is merged.  It addresses ticket #1403
These change remove all instances of internal write handle and `get_new_handle` functions from code base so all filebacked operations are performed through external write handle connected with PageOp class.