### PR TITLE
Remove ok, mess from `size_array_split` to avoid error obfuscation

### DIFF
--- a/herbert_core/utilities/classes/@data_op_interface/binary_op_manager.m
+++ b/herbert_core/utilities/classes/@data_op_interface/binary_op_manager.m
@@ -111,12 +111,17 @@ elseif isnumeric(w1)
     % w1 is a double array; w2 must have class 'classname'
     if ~isscalar(w1)
         size_stack1 = size(w2);
-        [size_root1, ok] = size_array_split (size(w1), size(w2));
-        if ~ok
-            error('HERBERT:data_op_interface:invalid_argument', ...
-                ['Unable to resolve the numeric array into a stack of arrays, ',...
-                'with stack size matching the object array size.']);
+
+        try
+            size_root1 = size_array_split (size(w1), size(w2));
+        catch ME
+            err = MException('HERBERT:data_op_interface:invalid_argument', ...
+                             ['Unable to resolve the numeric array into a stack of arrays, ',...
+                              'with stack size matching the object array size.']);
+            err = err.addCause(ME);
+            throw(err);
         end
+
     else
         size_stack1 = [1,1];    % want the scalar to apply to each object in w2
         size_root1 = [1,1];
@@ -143,12 +148,17 @@ elseif isnumeric(w2)
     % w1 is a double array; w2 must have class 'classname'
     if ~isscalar(w2)
         size_stack2 = size(w1);
-        [size_root2, ok] = size_array_split (size(w2), size(w1));
-        if ~ok
-            error('HERBERT:data_op_interface:invalid_argument', ...
-                ['Unable to resolve the numeric array into a stack of arrays, ',...
-                'with stack size matching the object array size.']);
+
+        try
+            size_root2 = size_array_split (size(w2), size(w1));
+        catch ME
+            err = MException('HERBERT:data_op_interface:invalid_argument', ...
+                             ['Unable to resolve the numeric array into a stack of arrays, ',...
+                              'with stack size matching the object array size.']);
+            err = err.addCause(ME);
+            throw(err);
         end
+
     else
         size_stack2 = [1,1];    % want the scalar to apply to each object in w1
         size_root2 = [1,1];

--- a/herbert_core/utilities/classes/@object_lookup/private/split_args.m
+++ b/herbert_core/utilities/classes/@object_lookup/private/split_args.m
@@ -34,13 +34,11 @@ for i=1:numel(args)
     % Turn argument into 2D array, first dimension has length equal to
     % the number of elements in the inner arrays, the second has length
     % equal to the number of elements in the stacking array
-    [sz_root, ok, mess] = size_array_split (size(args{i}), sz_stack);
+    sz_root = size_array_split (size(args{i}), sz_stack);
     nroot = prod(sz_root);
-    if ~ok
-        error ('HERBERT:split_args:invalid_argument', mess);
-    end
+
     tmp = reshape(args{i}, [nroot, nstack]);
-    
+
     % Split argument into a cell array of 2D arrays, re-ordered first if
     % requested
     if ~isempty(ix)
@@ -48,7 +46,7 @@ for i=1:numel(args)
     else
         args_split_tmp = mat2cell(tmp, nroot, nelmts);
     end
-    
+
     % Reshape so that the original inner dimensions are recovered but the
     % the outer dimensions are flattened
     sz_full = arrayfun(@(x)size_array_stack(sz_root,[x,1]), nelmts,...

--- a/herbert_core/utilities/classes/@testsigvar/private/binary_op_manager.m
+++ b/herbert_core/utilities/classes/@testsigvar/private/binary_op_manager.m
@@ -44,12 +44,17 @@ elseif isa(w1, 'double')
     % w1 is a double array; w2 must have class 'classname'
     if ~isscalar(w1)
         size_stack1 = size(w2);
-        [size_root1, ok] = size_array_split (size(w1), size(w2));
-        if ~ok
-            mess = ['Unable to resolve the numeric array into a stack of arrays, ',...
-                'with stack size matching the object array size.'];
-            error([upper(thisClassname),':binary_op_manager'], mess);
+
+        try
+            size_root1 = size_array_split (size(w1), size(w2));
+        catch ME
+            err = MException(['HERBERT:',upper(thisClassname),':invalid_argument'], ...
+                             ['Unable to resolve the numeric array into a stack of arrays, ',...
+                              'with stack size matching the object array size.']);
+            err = err.addCause(ME);
+            throw(err);
         end
+
     else
         size_stack1 = [1,1];    % want the scalar to apply to each object in w2
         size_root1 = [1,1];
@@ -75,12 +80,17 @@ elseif isa(w2, 'double')
     % w1 is a double array; w2 must have class 'classname'
     if ~isscalar(w2)
         size_stack2 = size(w1);
-        [size_root2, ok] = size_array_split (size(w2), size(w1));
-        if ~ok
-            mess = ['Unable to resolve the numeric array into a stack of arrays, ',...
-                'with stack size matching the object array size.'];
-            error([upper(thisClassname),':binary_op_manager'], mess);
+
+        try
+            size_root2 = size_array_split (size(w2), size(w1));
+        catch ME
+            err = MException(['HERBERT:',upper(thisClassname),':invalid_argument'], ...
+                             ['Unable to resolve the numeric array into a stack of arrays, ',...
+                              'with stack size matching the object array size.']);
+            err = err.addCause(ME);
+            throw(err);
         end
+
     else
         size_stack2 = [1,1];    % want the scalar to apply to each object in w1
         size_root2 = [1,1];


### PR DESCRIPTION
Remove `ok`, `mess` as part of #564 error handling.
Slightly refactor `size_array_split` to flatten function.
Make functions which previously used `ok`, `mess` use the error generated a as a cause.