### PR TITLE
sigvar set

### DIFF
--- a/_test/test_sqw_pageOpMethods/test_sigvar_set.m
+++ b/_test/test_sqw_pageOpMethods/test_sigvar_set.m
@@ -52,7 +52,7 @@ classdef test_sigvar_set < TestCase
             sqw_obj.data.s = zeros(2,3);
             sqw_obj.data.e = zeros(2,3);
             sqw_obj.data.npix = 10*ones(2,3);
-            sqw_obj.pix = PixelDataMemory(ones(9,60));
+            sqw_obj.pix = PixelDataFileBacked(ones(9,60));
 
             sigvar_obj = sigvar(struct(...
                 's', [1, 2, 3; 4, 5, 6], ...

--- a/_test/test_sqw_pageOpMethods/test_sigvar_set.m
+++ b/_test/test_sqw_pageOpMethods/test_sigvar_set.m
@@ -23,7 +23,7 @@ classdef test_sigvar_set < TestCase
                 'HORACE:DnDBase:invalid_argument');
             assertTrue(contains(ME.message, 'size'));
             assertTrue(contains(ME.message, num2str(size(sqw_obj.data.e))));
-            
+
         end
 
         function test_sigvar_set_raises_error_if_e_not_same_size_as_dnd_object(~)
@@ -43,6 +43,32 @@ classdef test_sigvar_set < TestCase
             assertTrue(contains(ME.message, num2str(size(sqw_obj.data.e))));
 
         end
+        function test_sigvar_set_updates_s_and_e_values_with_pix(~)
+            sqw_obj = sqw();
+            sqw_obj.data = d2d( ...
+                line_axes('nbins_all_dims',[2,3,1,1],'img_range',[-1,-1,-1,-1;1,1,1,1]), ...
+                line_proj('alatt',3,'angdeg',90));
+
+            sqw_obj.data.s = zeros(2,3);
+            sqw_obj.data.e = zeros(2,3);
+            sqw_obj.data.npix = 10*ones(2,3);
+            sqw_obj.pix = PixelDataMemory(ones(9,60));
+
+            sigvar_obj = sigvar(struct(...
+                's', [1, 2, 3; 4, 5, 6], ...
+                'e', [44, 55, 66; 77, 88, 99]));
+
+            result = sqw_obj.sigvar_set(sigvar_obj);
+            assertEqualToTol(result.data.s, sigvar_obj.s);
+            assertEqualToTol(result.data.e, sigvar_obj.e);
+            assertEqualToTol(result.pix.signal(1:10),ones(1,10));
+            assertEqualToTol(result.pix.signal(51:60),6*ones(1,10));
+
+            sobj_test = recompute_bin_data(result);
+
+            assertEqualToTol(result,sobj_test)
+        end
+
 
         function test_sigvar_set_updates_s_and_e_values(~)
             sqw_obj = sqw();

--- a/_test/test_sqw_pageOpMethods/test_sigvar_set.m
+++ b/_test/test_sqw_pageOpMethods/test_sigvar_set.m
@@ -59,6 +59,9 @@ classdef test_sigvar_set < TestCase
                 'e', [44, 55, 66; 77, 88, 99]));
 
             result = sqw_obj.sigvar_set(sigvar_obj);
+            ss = sigvar(result);
+            assertEqual(ss,sigvar_obj);
+
             assertEqualToTol(result.data.s, sigvar_obj.s);
             assertEqualToTol(result.data.e, sigvar_obj.e);
             assertEqualToTol(result.pix.signal(1:10),ones(1,10));
@@ -102,13 +105,13 @@ classdef test_sigvar_set < TestCase
 
             sigvar_obj = sigvar(struct('s', [1, 2, 3], 'e', [44, 55, 66]));
 
-            expected_signal = [1,1,1, 2,2,2,2,2, 3];
-            expected_varince = [3*[44,44,44],5*[55,55,55,55,55], 66];
+            expected_signal   = [1,1,1, 2,2,2,2,2, 3];
+            expected_variance = [3*[44,44,44],5*[55,55,55,55,55], 66];
 
             result = sqw_obj.sigvar_set(sigvar_obj);
 
             assertEqualToTol(result.pix.signal, expected_signal);
-            assertEqualToTol(result.pix.variance, expected_varince);
+            assertEqualToTol(result.pix.variance, expected_variance);
         end
 
         function test_sigvar_set_zero_s_and_e_where_npix_zero(~)
@@ -124,7 +127,7 @@ classdef test_sigvar_set < TestCase
             sigvar_obj = sigvar(struct('s', [1, 2, 3], 'e', [44, 55, 66]));
 
             expected_signal = [1,1,1, 3];
-            expected_varince = [3*[44,44,44], 66];
+            expected_variance = [3*[44,44,44], 66];
             expected_img_s = [1, 0, 3]';
             expected_img_e = [44, 0, 66]';
 
@@ -134,7 +137,7 @@ classdef test_sigvar_set < TestCase
             assertEqualToTol(result.data.e, expected_img_e);
 
             assertEqualToTol(result.pix.signal, expected_signal);
-            assertEqualToTol(result.pix.variance, expected_varince);
+            assertEqualToTol(result.pix.variance, expected_variance);
         end
     end
 end

--- a/_test/test_sqw_pageOpMethods/test_sigvar_set.m
+++ b/_test/test_sqw_pageOpMethods/test_sigvar_set.m
@@ -103,7 +103,7 @@ classdef test_sigvar_set < TestCase
             sigvar_obj = sigvar(struct('s', [1, 2, 3], 'e', [44, 55, 66]));
 
             expected_signal = [1,1,1, 2,2,2,2,2, 3];
-            expected_varince = [44,44,44, 55,55,55,55,55, 66];
+            expected_varince = [3*[44,44,44],5*[55,55,55,55,55], 66];
 
             result = sqw_obj.sigvar_set(sigvar_obj);
 
@@ -124,7 +124,7 @@ classdef test_sigvar_set < TestCase
             sigvar_obj = sigvar(struct('s', [1, 2, 3], 'e', [44, 55, 66]));
 
             expected_signal = [1,1,1, 3];
-            expected_varince = [44,44,44, 66];
+            expected_varince = [3*[44,44,44], 66];
             expected_img_s = [1, 0, 3]';
             expected_img_e = [44, 0, 66]';
 

--- a/horace_core/sqw/@sqw/sigvar_set.m
+++ b/horace_core/sqw/@sqw/sigvar_set.m
@@ -6,12 +6,9 @@ function w = sigvar_set(win, sigvar_obj)
 
 w = copy(win);
 w.data = sigvar_set(win.data,sigvar_obj);
-
-if has_pixels(w)
-    % RAE spotted error 8/12/2010: should only create pix field if sqw object
-    stmp = replicate_array(w.data.s, w.data.npix)';
-    etmp = replicate_array(w.data.e, w.data.npix)';
-    w.pix.signal   = stmp;  % propagate signal into the pixel data
-    w.pix.variance = etmp;
+if has_pixels(w)     % RAE spotted error 8/12/2010: should only create pix field if sqw object
+    page_op = PageOp_sigvar_set();
+    page_op = page_op.init(w);
+    w       = sqw.apply_op(w,page_op);
 end
 

--- a/horace_core/sqw/page_operations/PageOp_sigvar_set.m
+++ b/horace_core/sqw/page_operations/PageOp_sigvar_set.m
@@ -25,9 +25,10 @@ classdef PageOp_sigvar_set < PageOpBase
     end
     methods(Access=protected)
         function  does = get_changes_pix_only(~)
-            % pageOp calculates pixels only using image as source. No point
-            % of calculating image from pixels again as it would be in
-            % usual PageOp
+            % Usual pageOp calculates image from modified pixels. 
+            % PageOp_sigvar_set works with algorithm which already have
+            % the image so no point of calculating it again. It changes
+            % pixels only.
             does = true;
         end
     end

--- a/horace_core/sqw/page_operations/PageOp_sigvar_set.m
+++ b/horace_core/sqw/page_operations/PageOp_sigvar_set.m
@@ -16,8 +16,9 @@ classdef PageOp_sigvar_set < PageOpBase
 
         function obj = apply_op(obj,~,npix_idx)
             npix = obj.npix(npix_idx(1):npix_idx(2));
+            e   = obj.img_.e(npix_idx(1):npix_idx(2));
             s = repelem(obj.img_.s(npix_idx(1):npix_idx(2)),npix  );
-            e = repelem(obj.img_.e(npix_idx(1):npix_idx(2)).*npix,npix);
+            e = repelem(e(:).*npix(:),npix);
             obj.page_data_(obj.signal_idx,:)   = s(:)';
             obj.page_data_(obj.var_idx,:)      = e(:)';
         end

--- a/horace_core/sqw/page_operations/PageOp_sigvar_set.m
+++ b/horace_core/sqw/page_operations/PageOp_sigvar_set.m
@@ -15,8 +15,9 @@ classdef PageOp_sigvar_set < PageOpBase
         end
 
         function obj = apply_op(obj,~,npix_idx)
-            s = repelem(obj.img_.s(npix_idx(1):npix_idx(2)), obj.npix(npix_idx(1):npix_idx(2)));
-            e = repelem(obj.img_.e(npix_idx(1):npix_idx(2)), obj.npix(npix_idx(1):npix_idx(2)));
+            npix = obj.npix(npix_idx(1):npix_idx(2));
+            s = repelem(obj.img_.s(npix_idx(1):npix_idx(2)),npix  );
+            e = repelem(obj.img_.e(npix_idx(1):npix_idx(2)).*npix,npix);
             obj.page_data_(obj.signal_idx,:)   = s(:)';
             obj.page_data_(obj.var_idx,:)      = e(:)';
         end

--- a/horace_core/sqw/page_operations/PageOp_sigvar_set.m
+++ b/horace_core/sqw/page_operations/PageOp_sigvar_set.m
@@ -1,0 +1,32 @@
+classdef PageOp_sigvar_set < PageOpBase
+    % Single pixel page operation used by sigvar_set method
+    %
+
+    methods
+        function obj = PageOp_sigvar_set(varargin)
+            obj = obj@PageOpBase(varargin{:});
+            obj.op_name_ = 'sigvar_set';
+            obj.split_at_bin_edges = true;
+        end
+        function obj = init(obj,sqw_obj)
+            % sqw object here already have modified image so we use
+            % modified image to set pixels
+            obj  = init@PageOpBase(obj,sqw_obj);
+        end
+
+        function obj = apply_op(obj,~,npix_idx)
+            s = repelem(obj.img_.s(npix_idx(1):npix_idx(2)), obj.npix(npix_idx(1):npix_idx(2)));
+            e = repelem(obj.img_.e(npix_idx(1):npix_idx(2)), obj.npix(npix_idx(1):npix_idx(2)));
+            obj.page_data_(obj.signal_idx,:)   = s(:)';
+            obj.page_data_(obj.var_idx,:)      = e(:)';
+        end
+    end
+    methods(Access=protected)
+        function  does = get_changes_pix_only(~)
+            % pageOp calculates pixels only using image as source. No point
+            % of calculating image from pixels again as it would be in
+            % usual PageOp
+            does = true;
+        end
+    end
+end


### PR DESCRIPTION
This is PageOp implementation of sigvar_set algorithm, expanding current implementation to object with pixels including filebacked pixels. 

In addition, previous implementation was apparently incorrect as pixel's variance was assigned image variance though consistent asignment should be `img_variance.*npix`