### PR TITLE
legacy alignment for legacy files

### DIFF
--- a/herbert_core/classes/instrument_classes/instrument/@IX_experiment/IX_experiment.m
+++ b/herbert_core/classes/instrument_classes/instrument/@IX_experiment/IX_experiment.m
@@ -9,7 +9,7 @@ classdef IX_experiment < goniometer
         filename; % name of the file which was the source of data for this
         %         % experiment
         filepath; % path where the experiment data were initially stored
-        run_id    % the identifier, which uniquely defines this experiment
+        run_id;   % the identifier, which uniquely defines this experiment
         %         % this identifier is also stored within the PixelData,
         %         % providing connection between the particular pixel and
         %         % the experiment info
@@ -26,6 +26,13 @@ classdef IX_experiment < goniometer
         % with legacy alignment, as it multiplies it by alignment rotation
         % matrix and keeps legacy alignment matrix this way.
         u_to_rlu;
+    end
+    properties(Hidden)
+        % these properties are not used in Horace-4 but left for compartibility
+        % with Horace-3 file format when it read/updated from/to Horace-3
+        % format files.
+        ulabel = {'','','',''};
+        ulen = [1,1,1,1];
     end
     properties(Constant)
         % the list of properties which define IX_experiment uniques

--- a/horace_core/change_crystal.m
+++ b/horace_core/change_crystal.m
@@ -53,6 +53,9 @@ for i=1:numel(in_data)
     else
         out{i} = in_data{i};
         ld = sqw_formats_factory.instance().get_loader(in_data{i});
+        if ld.faccess_version<4
+            alignment_info.legacy_mode = true;
+        end
         data    = ld.get_dnd();
         ld = ld.set_file_to_update();
         if ld.sqw_type

--- a/horace_core/sqw/file_io/@const_blocks_map/const_blocks_map.m
+++ b/horace_core/sqw/file_io/@const_blocks_map/const_blocks_map.m
@@ -19,10 +19,13 @@ classdef const_blocks_map
             'pix',...
             'instr_head','instrument',...
             'sample_head','sample'}
+           % blocks starts at field cpecified by first cellarray block and
+           % ends at position, specified by the last field. Two fields specify second order structure 
+           % in the form struc.field1.field2
         block_positions_ = {...
             {{'main_head_pos_info_','nfiles_pos_'},'header_pos_'},... %main header
             {{'header_pos_info_','efix_pos_'},'detpar_pos_'},...      % the only one or last header
-            {{'header_pos_info_','filename_pos_'},{'header_pos_info_','efix_pos_'}},...  % n-header
+            {{'header_pos_info_','start_pos_'},{'header_pos_info_','efix_pos_'}},...  % n-header
             {{'detpar_pos_info_','ndet_pos_'},'data_pos_'},...      % detpar
             {{'data_fields_locations_','alatt_pos_'},'s_pos_'},...  % metadata block positions
             {'s_pos_','dnd_eof_pos_'},...                           % data block positions

--- a/horace_core/sqw/file_io/@const_blocks_map/private/init_map_.m
+++ b/horace_core/sqw/file_io/@const_blocks_map/private/init_map_.m
@@ -27,14 +27,12 @@ for i=1:numel(keys2check )
             bsm(theKey) =[];
         end
     else
-        if strncmp(theKey,'$0',2)
+        if strncmp(theKey,'$0',2) % last header's position and constant block size
                 bsm(theKey) =[s1(end); s2(end)-s1(end)];
         elseif strncmp(theKey,'$n',2)
-            res = zeros(2,numel(s1)-1);
-            for j=1:numel(s1)-1
-                res(:,j) = [s2(j); s1(j+1)-s2(j)];
-            end
-            bsm(theKey) =res;
+            start = s2(1:end-1);
+            size  = s1(2:end)-s2(1:end-1);
+            bsm(theKey) =[start;size];
         elseif isempty(s1) || isempty(s2)
             bsm(theKey) =[];
         else

--- a/horace_core/sqw/file_io/@sqw_binfile_common/put_headers.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/put_headers.m
@@ -96,7 +96,7 @@ for i=1:n_files2_process
         bytes = obj.sqw_serializer_.serialize(data_2save(i),head_form);
     end
     if update
-        if numel(bytes) ~= size_list(i)
+        if numel(bytes) > size_list(i)
             error('HORACE:put_headers:runtime_error',...
                 'SQW_BINFILE_COMMON::put_headers : size of upgraded header N%d (%d)  different from one on hdd (%d)',...
                 i,numel(bytes),size_list(i));

--- a/horace_core/sqw/file_io/@sqw_serializer/private/serialize_.m
+++ b/horace_core/sqw/file_io/@sqw_serializer/private/serialize_.m
@@ -21,20 +21,20 @@ for i=1:numel(fn)
     end
     if isa(fmt,'sqw_field_format_interface')
         if isa(fmt,'iVirt_field')
-            bytes{i} = fmt.bytes_from_field(struc);
+            ser_field = fmt.bytes_from_field(struc);
         else
-            bytes{i} = fmt.bytes_from_field(val);
+            ser_field = fmt.bytes_from_field(val);
         end
     else
         if ischar(val)
             % strings have length written in the beginning
-            bytes{i} = [typecast(uint32(numel(val)),'uint8'),uint8(val)];
+            ser_field = [typecast(uint32(numel(val)),'uint8'),uint8(val)];
         elseif iscell(val)
             tBytes = cell(1,numel(val));
             for j=1:numel(val)
                 tBytes{j} = serialize_(obj,val{j})';
             end
-            bytes{i} = [tBytes{:}];
+            ser_field = [tBytes{:}];
             
         else % convert according to known exisiting format definitions
             type  = class(val);
@@ -57,10 +57,10 @@ for i=1:numel(fn)
                 if nel >1
                     val = reshape(val,1,nel);
                 end
-                bytes{i} = typecast(val,'uint8');
+                ser_field = typecast(val,'uint8');
             else % can it be structure?
                 if isstruct(val)
-                    bytes{i} = serialize_(obj,val)';
+                    ser_field = serialize_(obj,val)';
                 else
                     error('STRUCT_SERIALIZER:invalid_argument',...
                         'Unsupported type for: field %s, type: %s',...
@@ -69,6 +69,7 @@ for i=1:numel(fn)
             end
         end
     end
+    bytes{i}= ser_field(:)';
 end
 bytes = [bytes{:}]';
 


### PR DESCRIPTION
I've enabled legacy alignment for legacy files as need this for running my tests. As we would not support legacy files for much longer and the changes will hopefully will be rarely used, I am not writing unit tests for these changes relying on existing tests to pass. 