### PR TITLE
Remove duplicated menu item from toctree

### DIFF
--- a/documentation/user_docs/docs/Horace_manual.rst
+++ b/documentation/user_docs/docs/Horace_manual.rst
@@ -31,7 +31,6 @@ Horace Manual
    :caption: Horace Manual Appendix
    :maxdepth: 1
 
-   manual/Changing_Horace_settings
    manual/List_of_functions
    manual/Input_file_formats
    manual/FAQ


### PR DESCRIPTION
Fixes #1506 

"Changing Horace Settings" was accidentally duplicated between two toctrees. This simply removes the duplicate.