### PR TITLE
1157 fix multiple hashing and experiment initialisation

### DIFF
--- a/herbert_core/utilities/classes/@unique_objects_container/private/add_single_.m
+++ b/herbert_core/utilities/classes/@unique_objects_container/private/add_single_.m
@@ -1,4 +1,4 @@
-function [self,nuix] = add_single_(self,obj)
+function [self,nuix] = add_single_(self,obj,ix,hash)
 %ADD_SINGLE_ Add single object to the unique objects container
 
 
@@ -6,7 +6,24 @@ function [self,nuix] = add_single_(self,obj)
 % returned as the index to the object in the container.
 % hash is returned as the hash of the object. If ix is empty
 % then the object is not in the container.
-[ix,hash] = self.find_in_container(obj);
+%
+% Input
+% -----
+% self - the unique_objects_container in question
+% obj  - the object to be added to the container
+% ix   - the unique index of the object if it is already in the container. 
+%        this will have been found from a previous call of find_in_container
+% hash - the hash for obj previously made by that call to find_in_container
+% 
+% Output
+% ------
+% self - the modified container (modified by adding obj)
+% nuix - the insertion index at which obj is added in the container
+
+% if ix and hash are not specified, call find_in_container to get them
+if nargin<=2
+    [ix,hash] = self.find_in_container(obj);
+end
 
 % If the object is not in the container.
 % store the hash in the stored hashes

--- a/herbert_core/utilities/classes/@unique_references_container/unique_references_container.m
+++ b/herbert_core/utilities/classes/@unique_references_container/unique_references_container.m
@@ -498,10 +498,10 @@ classdef unique_references_container < serializable
                 error('HERBERT:unique_references_container:incomplete_setup', ...
                     'global name unset');
             end
-            [glindex, ~] = self.global_container('value',self.global_name_).find_in_container(inobj);
+            [glindex, hash] = self.global_container('value',self.global_name_).find_in_container(inobj);
             if isempty(glindex)
                 glcont = self.global_container('value',self.global_name_);
-                [glcont,glindex] = glcont.add(inobj);
+                [glcont,glindex] = glcont.add_single_(inobj,[],hash);
                 if glindex == 0
                     % object was not added
                     nuix = 0;

--- a/herbert_core/utilities/classes/@unique_references_container/unique_references_container.m
+++ b/herbert_core/utilities/classes/@unique_references_container/unique_references_container.m
@@ -502,11 +502,6 @@ classdef unique_references_container < serializable
             if isempty(glindex)
                 glcont = self.global_container('value',self.global_name_);
                 [glcont,glindex] = glcont.add_single_(inobj,[],hash);
-                if glindex == 0
-                    % object was not added
-                    nuix = 0;
-                    return
-                end
                 self.global_container('reset',self.global_name_,glcont);
             end
             self.idx_ = [ self.idx(:)', glindex ];

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -65,7 +65,7 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
         % The class providing brief description of a whole sqw file.
         main_header_ = main_header_cl();
 
-        experiment_info_ = Experiment();
+        experiment_info_ = []; %Experiment();
         % detectors array
         detpar_  = struct([]);
 
@@ -286,6 +286,8 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
     methods
         function obj = sqw(varargin)
             obj = obj@SQWDnDBase();
+            
+            obj.experiment_info_ = Experiment();
 
             if nargin==0 % various serializers need empty constructor
                 obj.data_ = d0d();


### PR DESCRIPTION
As per point 1 of #1157, objects are hashed twice, unnecessarily, for unique_object_containers. This does not happen for these containers themselves, but when used in unique_references_containers, this does happen, and is fixed by this PR.

This investigation also shows that sqw had its experiment_info incorrectly initialised by a property definition rather than a part of the constructor. This may also fix point 2 about clearing the container although as there are no instructions for reproducing it I cannot be certain.

It also shows that unique_references_containers are misleadingly tested by the present tests, as earlier tests perform initialisation of the persistent data which then allow later tests to proceed which would otherwise fail if run in isolation.