### PR TITLE
Enforce orthogonal projection for SymopRotation

### DIFF
--- a/horace_core/sqw/@sqw/symmetrise_sqw.m
+++ b/horace_core/sqw/@sqw/symmetrise_sqw.m
@@ -20,7 +20,10 @@ function wout=symmetrise_sqw(win,varargin)
 %          ** N.B. ** 360/theta_deg MUST be integral
 %
 % proj
-%    Projection axis for rotational reduction
+%    Projection used for rotational reduction
+%
+%    Symmetrisation affects pixels in HKL and should take place in
+%    orthogonal basis even if the projection is not.
 %
 % v1 and v2 are two vectors which lie in the plane of the reflection plane.
 % v3 is a vector connecting the plane to the origin (i.e. specifies an
@@ -57,21 +60,22 @@ if ~has_pixels(win)
 end
 
 if isa(varargin{end}, 'aProjectionBase')
-    proj = varargin(end);
+    % Projection under which transformation takes place (HKL).
+    transf_proj = varargin(end);
     varargin = varargin(1:end-1);
 
-    if proj{1}.nonorthogonal
+    if transf_proj{1}.nonorthogonal
         error('HORACE:symmetrise_sqw:invalid_argument', ...
               'Cannot symmetrise to non-orthogonal projection');
     end
 
 else
-    proj = {line_proj([1 0 0], [0 1 0], ...
-                      'alatt', win.data.proj.alatt, ...
-                      'angdeg', win.data.proj.angdeg)};
+    % Also projection under which transformation takes place (HKL [orthogonal, so 90, 90, 90]).
+    % alatt, however, is retained as the symmetrisation should not rescale.
+    transf_proj = {line_proj([1 0 0], [0 1 0], ...
+                             'alatt', win.data.proj.alatt, ...
+                             'angdeg', [90, 90, 90])};
 end
-
-
 
 
 if numel(varargin) == 1 && isa(varargin{1}, 'Symop') || ...
@@ -97,7 +101,7 @@ transforms = arrayfun(@(x) @x.transform_pix, sym, 'UniformOutput', false);
 % for each symmetry operation we're applying, since the first cell array
 % may be unwrapped as an argument if 1 arg (as in this case), need
 % double wrapped cellarray
-wout = wout.apply(transforms, {{proj(:)}}, false);
+wout = wout.apply(transforms, {{transf_proj(:)}}, false);
 
 %=========================================================================
 % Transform Ranges:

--- a/horace_core/symop/@SymopRotation/SymopRotation.m
+++ b/horace_core/symop/@SymopRotation/SymopRotation.m
@@ -73,6 +73,12 @@ classdef SymopRotation < Symop
                 proj = line_proj();
             end
 
+            if ~isequal(proj.angdeg, [90 90 90])
+                error('HORACE:SymopRotation:invalid_argument', ...
+                      ['Rotational reduction is only supported for an orthogonal projection. ', ...
+                       'If using symmetrise_sqw, please pass through an orthogonal projection'])
+            end
+
             n = obj.n / norm(obj.n);
             if sum(abs(n - [1; 0; 0])) > 1e-1
                 u = [1; 0; 0];
@@ -88,7 +94,7 @@ classdef SymopRotation < Symop
             normvec_u = cross(n, u);
             normvec_v = cross(v, n);
 
-            selected = (coords'*normvec_u > 0 & ...
+            selected = (coords'*normvec_u >= 0 & ...
                         coords'*normvec_v > 0);
         end
 


### PR DESCRIPTION
As described in #1510, ultimate issue is symmetrising a non-orthogonal crystal.

This is checked where the projection is given, but if not provided, the default projection accidentally copies non-orthogonal lattice. 

- Extra check put in `SymopRotation.is_irreducible`
- Ensure any points which lie on the plane of the irreducible zone are not transformed
- Make default projection always orthogonal 

Fixes #1510 