### PR TITLE
fixing sqw_eval for spherical projection

### DIFF
--- a/_test/test_multifit/test_multifit_horace_1.m
+++ b/_test/test_multifit/test_multifit_horace_1.m
@@ -24,6 +24,9 @@ classdef test_multifit_horace_1 < TestCaseWithSave
 
     methods
         function this = test_multifit_horace_1(name)
+            if nargin == 0
+                name = 'test_multifit_horace_1';
+            end
             % Construct object
             output_file = 'test_multifit_horace_1_output.mat';
             this = this@TestCaseWithSave(name, output_file);

--- a/_test/test_sqw_pageOpMethods/test_eval.m
+++ b/_test/test_sqw_pageOpMethods/test_eval.m
@@ -20,7 +20,18 @@ classdef test_eval < TestCase
 
         function test_disp2sqw_eval(obj)
             ds = disp2sqw_eval(obj.sqw_obj, @test_eval.disp2sqw_eval_tester2D, [], 1.0, '-all');
+        end
+        %
+        function test_func_eval_with_shpere_proj(obj)
+            spp = sphere_proj;
+            spp.offset = [0,1.5,0];
+            sp_cut = cut(obj.sqw_obj,spp,[0,0.01,2],[0,180],[-180,180],0);
 
+            % Almost zero bose correction in this case. Just to check
+            % algorighm works
+            spBose = bose(sp_cut,8);
+            diff = sp_cut-spBose;
+            assertEqualToTol(diff.data.s,zeros(size(diff.data.s)));
         end
 
         function test_func_eval_sqw(obj)

--- a/_test/test_sqw_pageOpMethods/test_eval.m
+++ b/_test/test_sqw_pageOpMethods/test_eval.m
@@ -22,13 +22,13 @@ classdef test_eval < TestCase
             ds = disp2sqw_eval(obj.sqw_obj, @test_eval.disp2sqw_eval_tester2D, [], 1.0, '-all');
         end
         %
-        function test_func_eval_with_shpere_proj(obj)
+        function test_sqw_eval_with_sphere_proj(obj)
             spp = sphere_proj;
             spp.offset = [0,1.5,0];
             sp_cut = cut(obj.sqw_obj,spp,[0,0.01,2],[0,180],[-180,180],0);
 
-            % Almost zero bose correction in this case. Just to check
-            % algorighm works
+            % Almost zero Bose correction in this case. Just to check
+            % algorithm works
             spBose = bose(sp_cut,8);
             diff = sp_cut-spBose;
             assertEqualToTol(diff.data.s,zeros(size(diff.data.s)));

--- a/herbert_core/applications/multifit/@mfclass/private/multifit_lsqr_ser.m
+++ b/herbert_core/applications/multifit/@mfclass/private/multifit_lsqr_ser.m
@@ -457,6 +457,13 @@ else
         end
 
         [~,s,v]=svd(jac,0);
+        % constrain possible conditionality number and nullify small
+        % elements to inprove resulting fit comparison in case of
+        % poorly defined matrix
+        max_sv = max(abs(s));
+        degraded = abs(s/max_sv)<eps('single');
+        s(degraded) = 0;
+        %
         s=repmat((1./diag(s))',[npfree,1]);
         v=v.*s;
         cov=chisqr_red*(v*v');  % true covariance matrix;

--- a/herbert_core/utilities/classes/@data_op_interface/binary_op_manager.m
+++ b/herbert_core/utilities/classes/@data_op_interface/binary_op_manager.m
@@ -1,7 +1,8 @@
-function w = binary_op_manager(w1, w2, binary_op)
+function w = binary_op_manager(w1, w2, binary_op,ignore_cell_sorting)
 % Implements a binary operation for objects with a signal and a variance array.
 %
 %   >> w = binary_op_manager(w1, w2, binary_op)
+%   >> w = binary_op_manager(w1, w2, binary_op,ignore_cell_sorting)
 %
 % All binary operations on Matlab double arrays are permitted
 % (+, -, *, /, \) and are applied element by element to the signal and
@@ -47,6 +48,18 @@ function w = binary_op_manager(w1, w2, binary_op)
 %   binary_op   Function handle to a binary operation. All binary operations
 %               on Matlab double or single arrays are permitted (+, -, *,
 %               /, \).
+%
+% Optional:
+% ignore_cell_sorting
+%             By default false and binary operation which includes pixels
+%             sort pixels with every bin when operation is performed. 
+%
+%             if operation is performed between two sqw objects and user
+%             sure that pixels in cells of the objects have the same order
+%             (this happens if e.g. one object is build from another object
+%              within the previous operation) this property may be set to
+%              true to improve operation performance.
+%
 %
 % Output:
 % -------
@@ -100,6 +113,10 @@ function w = binary_op_manager(w1, w2, binary_op)
 % The dominant class is also this class type, for the same reason.
 %
 % Think of a numeric array as a stack of objects, each one a smaller array
+
+if nargin < 4
+    ignore_cell_sorting = false;
+end
 
 if isobject(w1)
     % w1 is not an intrinsic matlab class
@@ -186,7 +203,7 @@ nobj2 = prod(size_stack2);
 
 if (nobj1 == nobj2 && nobj1 == 1)
     % w1 and w2 both scalar instances of objects
-    w = binary_op_manager_single(w1, w2, binary_op);
+    w = binary_op_manager_single(w1, w2, binary_op,ignore_cell_sorting);
 
 elseif isequal(size_stack1, size_stack2)
     % w1 and w2 are both non-scalar arrays of objects (scalar case caught above)
@@ -205,7 +222,7 @@ elseif (nobj1 == 1 && nobj2 > 1)
     w2_2D = reshape(w2, nroot2, nobj2);
     for i = 1:nobj2
         obj2 = reshape(w2_2D(:,i), size_root2);
-        w(i) = binary_op_manager_single(w1, obj2, binary_op);
+        w(i) = binary_op_manager_single(w1, obj2, binary_op,ignore_cell_sorting);
     end
 
 elseif (nobj1 > 1 && nobj2 == 1)
@@ -214,7 +231,7 @@ elseif (nobj1 > 1 && nobj2 == 1)
     w1_2D = reshape(w1, nroot1, nobj1);
     for i = 1:nobj1
         obj1 = reshape(w1_2D(:,i), size_root1);
-        w(i) = binary_op_manager_single(obj1, w2, binary_op);
+        w(i) = binary_op_manager_single(obj1, w2, binary_op,ignore_cell_sorting);
     end
 
 else

--- a/herbert_core/utilities/classes/@data_op_interface/binary_op_manager.m
+++ b/herbert_core/utilities/classes/@data_op_interface/binary_op_manager.m
@@ -50,15 +50,18 @@ function w = binary_op_manager(w1, w2, binary_op,ignore_cell_sorting)
 %               /, \).
 %
 % Optional:
+% Optional:
 % ignore_cell_sorting
-%             By default false and binary operation which includes pixels
-%             sort pixels with every bin when operation is performed. 
+%             By default equal to false and any binary operation which
+%             involves pixels sorts pixels within every bin when operation
+%             is performed.
 %
 %             if operation is performed between two sqw objects and user
 %             sure that pixels in cells of the objects have the same order
 %             (this happens if e.g. one object is build from another object
-%              within the previous operation) this property may be set to
-%              true to improve operation performance.
+%             within the previous operation like background and foreground
+%             for the same sqw object) this property may be set to
+%             true to ignore sorting and improve operation performance.
 %
 %
 % Output:

--- a/herbert_core/utilities/classes/@data_op_interface/binary_op_manager.m
+++ b/herbert_core/utilities/classes/@data_op_interface/binary_op_manager.m
@@ -52,12 +52,15 @@ function w = binary_op_manager(w1, w2, binary_op,ignore_cell_sorting)
 % Optional:
 % Optional:
 % ignore_cell_sorting
-%             By default equal to false and any binary operation which
-%             involves pixels sorts pixels within every bin when operation
-%             is performed.
+%             The pixels in sqw object are ordered in a way that every
+%             image bin have correspondent block of pixels contributing
+%             into this bin. The order of pixels in the bin is random. 
+%             By default ignore_cell_sorting is equal to false and any 
+%             binary operation which involves pixels sorts pixels within
+%             every bin when operation is performed.
 %
 %             if operation is performed between two sqw objects and user
-%             sure that pixels in cells of the objects have the same order
+%             sure that pixels in bins of the objects have the same order
 %             (this happens if e.g. one object is build from another object
 %             within the previous operation like background and foreground
 %             for the same sqw object) this property may be set to

--- a/herbert_core/utilities/classes/@data_op_interface/binary_op_manager_single.m
+++ b/herbert_core/utilities/classes/@data_op_interface/binary_op_manager_single.m
@@ -1,4 +1,4 @@
-function wout = binary_op_manager_single(w1, w2, binary_op)
+function wout = binary_op_manager_single(w1, w2, binary_op,ignore_cell_sorting)
 % -----------------------------------------------------------------------------
 % <#doc_def:>
 %   doc_dir = fullfile(fileparts(which('sigvar')),'_docify')
@@ -22,7 +22,20 @@ function wout = binary_op_manager_single(w1, w2, binary_op)
 %   <#file:> <doc_file_sigvar_notes>
 % <#doc_end:>
 % -----------------------------------------------------------------------------
+% Optional:
+% ignore_cell_sorting
+%             By default false and binary operation which includes pixels
+%             sort pixels with every bin when operation is performed. 
+%
+%             if operation is performed between two sqw objects and user
+%             sure that pixels in cells of the objects have the same order
+%             (this happens if e.g. one object is build from another object
+%              within the previous operation) this property may be set to
+%              true to improve operation performance.
 
+if nargin < 4
+    ignore_cell_sorting = false;
+end
 
 op_name = func2str(binary_op);
 % identify order of operations, operands superiority and the type of 
@@ -50,6 +63,7 @@ switch(page_op_kind)
         page_op = PageOp_binary_sqw_img();
     case(3) % operation between two objects with pixels and images
         page_op = PageOp_binary_sqw_sqw();
+        page_op.sort_pixels_in_bins = ~ignore_cell_sorting;
     otherwise
         error('HERBERT:data_op_interface:invalid_argument', ...
             'unsupported type of operation %d for operation %s between objects of class %s and class %s', ...

--- a/herbert_core/utilities/classes/@data_op_interface/binary_op_manager_single.m
+++ b/herbert_core/utilities/classes/@data_op_interface/binary_op_manager_single.m
@@ -24,21 +24,23 @@ function wout = binary_op_manager_single(w1, w2, binary_op,ignore_cell_sorting)
 % -----------------------------------------------------------------------------
 % Optional:
 % ignore_cell_sorting
-%             By default false and binary operation which includes pixels
-%             sort pixels with every bin when operation is performed. 
+%             By default equal to false and any binary operation which
+%             involves pixels sorts pixels within every bin when operation
+%             is performed.
 %
 %             if operation is performed between two sqw objects and user
 %             sure that pixels in cells of the objects have the same order
 %             (this happens if e.g. one object is build from another object
-%              within the previous operation) this property may be set to
-%              true to improve operation performance.
+%             within the previous operation like background and foreground
+%             for the same sqw object) this property may be set to
+%             true to ignore sorting and improve operation performance.
 
 if nargin < 4
     ignore_cell_sorting = false;
 end
 
 op_name = func2str(binary_op);
-% identify order of operations, operands superiority and the type of 
+% identify order of operations, operands superiority and the type of
 % operation to be  performed over operands.
 [flip,page_op_kind] = data_op_interface.get_operation_order( ...
     w1,w2,op_name );

--- a/herbert_core/utilities/classes/@data_op_interface/data_op_interface.m
+++ b/herbert_core/utilities/classes/@data_op_interface/data_op_interface.m
@@ -57,7 +57,8 @@ classdef(Abstract) data_op_interface
         wout = mtimes  (w1,w2)
         wout = plus    (w1,w2)
         %------------------------------------------------------------------
-        w = binary_op_manager_single(w1, w2, op_function_handle);
+        w = binary_op_manager(w1,w2,op_function_handle,varargin);
+        w = binary_op_manager_single(w1, w2, op_function_handle,varargin);
     end
     methods(Static)
         function [priority,sv_size,has_pix,has_img] = get_priority(obj)
@@ -119,7 +120,6 @@ classdef(Abstract) data_op_interface
         end
     end
     methods(Access=protected)
-        w = binary_op_manager(w1,w2,op_function_handle);
         w = unary_op_manager (w1, op_function_handle);
     end
 

--- a/herbert_core/utilities/classes/@sigvar/binary_op_manager_single.m
+++ b/herbert_core/utilities/classes/@sigvar/binary_op_manager_single.m
@@ -1,4 +1,4 @@
-function wout = binary_op_manager_single(w1, w2, binary_op)
+function wout = binary_op_manager_single(w1, w2, binary_op,varargin)
 % -----------------------------------------------------------------------------
 % <#doc_def:>
 %   doc_dir = fullfile(fileparts(which('sigvar')),'_docify')
@@ -22,7 +22,7 @@ function wout = binary_op_manager_single(w1, w2, binary_op)
 %   <#file:> <doc_file_sigvar_notes>
 % <#doc_end:>
 % -----------------------------------------------------------------------------
-
+% varargin -- not used and provided to adhere to common binary_op_manager interface
 
 
 % One or both of w1, w2 is an instance of the class for which this a method

--- a/herbert_core/utilities/classes/@sigvar/sigvar.m
+++ b/herbert_core/utilities/classes/@sigvar/sigvar.m
@@ -206,7 +206,7 @@ classdef sigvar < data_op_interface & serializable
         function wout = copy(win)
             wout = win;
         end
-        wout = binary_op_manager_single(w1, w2, binary_op);
+        wout = binary_op_manager_single(w1, w2, binary_op,varargin);
     end
 
 

--- a/horace_core/GUI/bose.m
+++ b/horace_core/GUI/bose.m
@@ -21,5 +21,5 @@ wout = binary_op_manager(win,sqw_bose,@mtimes,true);
 
 function y = bose_factor(h,k,l,en,T)
 %
-y = (1 - exp(-11.6044.*en/T));
+y = (1 - exp(-11.6044/T.*en));
 

--- a/horace_core/GUI/bose.m
+++ b/horace_core/GUI/bose.m
@@ -10,7 +10,12 @@ function wout=bose(win,T)
 %factor for all of the points:
 sqw_bose=sqw_eval(win,@bose_factor,T);
 
-wout=mtimes(win,sqw_bose);
+% as bose and sqw_bose have the same pixels, and the same pixels
+% coordinates, sorting pixels over bins are not necessary. This is why we
+% set ignore_cell_sorting to true
+wout = binary_op_manager(win,sqw_bose,@mtimes,true);
+
+
 
 %==============================
 

--- a/horace_core/sqw/axes_blocks/@AxesBlockBase/private/bin_pixels_.m
+++ b/horace_core/sqw/axes_blocks/@AxesBlockBase/private/bin_pixels_.m
@@ -84,7 +84,7 @@ if ~ok
 end
 if return_selected && nout ~= 4
     error('HORACE:AxesBlockBase:invalid_argument', ...
-          'return_selected requested for non pixel cut')
+        'return_selected requested for non pixel cut')
 end
 
 bin_array_size  = obj.nbins_all_dims; % arrays of this size will be allocated too
@@ -153,13 +153,20 @@ else
             pix_indx(on_edge(:,i),i) = n_bins(i);
         end
     end
+    reconcile_sizes = false;
     if numel(n_bins) == 1
         n_bins = [n_bins,1];
+        reconcile_sizes = true;
     end
     % mex code, if deployed below, needs pixels collected during this
     % particular accumulation.
     npix1 = accumarray(pix_indx, ones(1,size(pix_indx,1)), n_bins);
-    npix = npix + npix1;
+    % do we need to do this or it is always column array?
+    if reconcile_sizes
+        npix = npix+ resize(npix1,size(npix));
+    else
+        npix = npix + npix1;
+    end
 end
 
 if nout<3

--- a/horace_core/sqw/axes_blocks/@AxesBlockBase/private/bin_pixels_.m
+++ b/horace_core/sqw/axes_blocks/@AxesBlockBase/private/bin_pixels_.m
@@ -163,7 +163,7 @@ else
     npix1 = accumarray(pix_indx, ones(1,size(pix_indx,1)), n_bins);
     % do we need to do this or it is always column array?
     if reconcile_sizes
-        npix = npix+ resize(npix1,size(npix));
+        npix = npix+ reshape(npix1,size(npix));
     else
         npix = npix + npix1;
     end

--- a/horace_core/sqw/coord_transform/@aProjectionBase/private/may_contribute_.m
+++ b/horace_core/sqw/coord_transform/@aProjectionBase/private/may_contribute_.m
@@ -8,7 +8,8 @@ function  [may_contributeND,may_contribute_dE] = may_contribute_(source_proj,...
 % values on TCS and zero values outside of TCS.
 %
 
-% build bin edges for the target grid and bin centres for reference grid
+% build grid with points at bin edges for the target grid and bin centres
+% for reference grid
 if source_proj.do_3D_transformation_
     [targ_nodes,dEnodes] = targ_axes_block.get_bin_nodes('-3D','-ngrid','-halo');
     [source_grid,baseEdges]  = source_axes_block.get_bin_nodes('-bin_centre','-3D');

--- a/horace_core/sqw/coord_transform/@aProjectionBase/private/transform_pix_to_hkl_.m
+++ b/horace_core/sqw/coord_transform/@aProjectionBase/private/transform_pix_to_hkl_.m
@@ -27,7 +27,7 @@ else % if pix_input is 4-d,
 
 end
 
-if ~isempty(obj.ub_inv_legacy) % legacy alignment
+if ismethod(obj,'ub_inf_legaccy') && ~isempty(obj.ub_inv_legacy) % legacy alignment
     transf_to_hkl = inv(obj.ub_inv_legacy(1:3,1:3));
 else
     transf_to_hkl = obj.bmatrix();

--- a/horace_core/sqw/coord_transform/@line_proj/line_proj.m
+++ b/horace_core/sqw/coord_transform/@line_proj/line_proj.m
@@ -409,6 +409,32 @@ classdef line_proj<aProjectionBase
             pix_cc = transform_img_to_pix_(obj,pix_hkl);
         end
         %
+        function [pix_hkl,en] = transform_pix_to_hkl(obj,pix_coord,varargin)
+            % Converts from pixel coordinate system (Crystal Cartesian)
+            % to hkl coordinate system.
+            %
+            % Overloaded generic method to support legacy alignment
+            % appropriate for line_proj only.
+            %
+            % Inputs:
+            % obj       -- current projection, describing the system of
+            %              coordinates where the input pixels vector is
+            %              expressed in.
+            %
+            % pix_coord -- 4xNpix or 3xNpix vector of pixels coordinates
+            %              expressed in the coordinate system, defined by
+            %              this projection
+            %
+            % Output:
+            % pix_hkl  -- 4xNpix or 3xNpix array of pixel coordinates in
+            %             hkl (physical) coordinate system (4-th
+            %             coordinate, if requested, is the energy transfer)
+            [pix_hkl,en] = transform_pix_to_hkl_(obj,pix_coord,varargin{:});
+            if nargout == 1
+                pix_hkl = [pix_hkl;en];
+            end
+        end
+        %
         %
         function pix_target = from_this_to_targ_coord(obj,pix_origin,varargin)
             % Converts from current to target projection coordinate system.

--- a/horace_core/sqw/coord_transform/@line_proj/private/transform_pix_to_hkl_.m
+++ b/horace_core/sqw/coord_transform/@line_proj/private/transform_pix_to_hkl_.m
@@ -27,8 +27,11 @@ else % if pix_input is 4-d,
 
 end
 
-transf_to_hkl = obj.bmatrix();
-
+if ~isempty(obj.ub_inv_legacy) % legacy alignment
+    transf_to_hkl = inv(obj.ub_inv_legacy(1:3,1:3));
+else
+    transf_to_hkl = obj.bmatrix();
+end
 %
 if alignment_needed
     pix_hkl= (transf_to_hkl\alignment_mat)*pix_cc;


### PR DESCRIPTION
Addresses Re #1533 -- second part.
bunch of minor bugs fixing `sqw_eval` (and `bose`) for spherical projection.

Nothing more to tell -- unit tests confirming bug  presense now passes so it is the fixture.

Summary of changes (summary by CM from PR review)
- the Bose factor method has been corrected, and a test added that now passes
- in bin_pixels, the shape of the accumulated npix1 array is properly controlled
- handling of the ub_inf_legacy method is altered.
- uniformity of the binary_op_manager methods' interface has been improved
- efficiency of the binary_op managers has been improved by allowing pixel sorting not to be performed when not needed
- comments have been improved