### PR TITLE
Refactor sawtooth_iarray and add unit tests

### DIFF
--- a/_test/test_utilities_herbert/test_sawtooth_iarray.m
+++ b/_test/test_utilities_herbert/test_sawtooth_iarray.m
@@ -81,29 +81,23 @@ classdef test_sawtooth_iarray < TestCase
             vout_ref = [1;2;3;4;1;2];
             assertEqual(vout, vout_ref);
         end
-                
-        function test_sawtooth_iarray_real_n (~)
-            % Reals rounded down to nearest integer
-            n = 3.7;
-            vout = sawtooth_iarray (n);
-            vout_ref = [1;2;3];
-            assertEqual(vout, vout_ref);
-        end
-                
-        function test_sawtooth_iarray_real_n_ltZero (~)
-            % Negative reals equivalent to zero
-            n = -0.7;
-            vout = sawtooth_iarray (n);
-            assertEqual(vout, zeros(0,1));
+        
+        function test_negative_n_ERROR (~)
+            % Throw an error because one of the elements of n is negative
+            n = [4,-2,2];
+            f = @()sawtooth_iarray(n);
+            ME = assertExceptionThrown (f, 'HERBERT:sawtooth_iarray:invalid_argument');
+            assertTrue(contains(ME.message, ...
+                'The elements of the input argument must all be nonnegative integer values'))
         end
         
-        function test_sawtooth_iarray_realArray_n (~)
-            % Reals rounded down to nearest integer; array input that exercises
-            % this in several cases
-            n = [-0.7, 3.7, 2, 0, 4.0, -0.001];
-            vout = sawtooth_iarray (n);
-            vout_ref = [1;2;3;1;2;1;2;3;4];
-            assertEqual(vout, vout_ref);
+        function test_real_n_ERROR (~)
+            % Throw an error because one of the elements of n is non-integer
+            n = [4,1.8,2];
+            f = @()sawtooth_iarray(n);
+            ME = assertExceptionThrown (f, 'HERBERT:sawtooth_iarray:invalid_argument');
+            assertTrue(contains(ME.message, ...
+                'The elements of the input argument must all be nonnegative integer values'))
         end
                                 
     end

--- a/_test/test_utilities_herbert/test_sawtooth_iarray.m
+++ b/_test/test_utilities_herbert/test_sawtooth_iarray.m
@@ -1,0 +1,110 @@
+classdef test_sawtooth_iarray < TestCase
+    % Test behaviour of Herbert utility function sawtooth_iarray.
+    
+    methods
+        function test_sawtooth_iarray_empty_n (~)
+            % Empty input array, empty n ==> zero(0,1) output
+            n = [];
+            vout = sawtooth_iarray (n);
+            assertEqual(vout, zeros(0,1));
+        end
+        
+        function test_sawtooth_iarray_zero_n (~)
+            % Output should be zero(0,1)
+            n = 0;
+            vout = sawtooth_iarray (n);
+            assertEqual(vout, zeros(0,1));
+        end
+        
+        function test_sawtooth_iarray_scalar_n (~)
+            % Output should be a column independent of shape of input
+            n = 3;
+            vout = sawtooth_iarray (n);
+            vout_ref = [1;2;3];
+            assertEqual(vout, vout_ref);
+        end
+        
+        function test_sawtooth_iarray_row_n (~)
+            % Output should be a column independent of shape of input
+            n = [2,3,1];
+            vout = sawtooth_iarray (n);
+            vout_ref = [1;2;1;2;3;1];
+            assertEqual(vout, vout_ref);
+        end
+        
+        function test_sawtooth_iarray_col_n (~)
+            % Output should be a column independent of shape of input
+            n = [2;3;1];
+            vout = sawtooth_iarray (n);
+            vout_ref = [1;2;1;2;3;1];
+            assertEqual(vout, vout_ref);
+        end
+        
+        function test_sawtooth_iarray_arr_v_arr_n (~)
+            % Output should be a column independent of shape of input
+            n = [2,3,1;...
+                4,5,6];
+            vout = sawtooth_iarray (n);
+            vout_ref = [1;2;1;2;3;4;1;2;3;1;2;3;4;5;1;1;2;3;4;5;6];
+            assertEqual(vout, vout_ref);
+        end
+        
+        function test_sawtooth_iarray_n_all_zero (~)
+            % As the sawtooth lengths are all zeros, then output should
+            % be zeros(0,1)
+            n = [0,0,0];
+            vout = sawtooth_iarray (n);
+            vout_ref = zeros(0,1);
+            assertEqual(vout, vout_ref);
+        end
+        
+        function test_sawtooth_iarray_n_first_zero (~)
+            % Test case of first element of n is zero
+            n = [0,3,2];
+            vout = sawtooth_iarray (n);
+            vout_ref = [1;2;3;1;2];
+            assertEqual(vout, vout_ref);
+        end
+        
+        function test_sawtooth_iarray_n_last_zero (~)
+            % Test case of last element of n is zero
+            n = [4,3,0];
+            vout = sawtooth_iarray (n);
+            vout_ref = [1;2;3;4;1;2;3];
+            assertEqual(vout, vout_ref);
+        end
+        
+        function test_sawtooth_iarray_n_mid_zero (~)
+            % Test case of middle element of n is zero
+            n = [4,0,2];
+            vout = sawtooth_iarray (n);
+            vout_ref = [1;2;3;4;1;2];
+            assertEqual(vout, vout_ref);
+        end
+                
+        function test_sawtooth_iarray_real_n (~)
+            % Reals rounded down to nearest integer
+            n = 3.7;
+            vout = sawtooth_iarray (n);
+            vout_ref = [1;2;3];
+            assertEqual(vout, vout_ref);
+        end
+                
+        function test_sawtooth_iarray_real_n_ltZero (~)
+            % Negative reals equivalent to zero
+            n = -0.7;
+            vout = sawtooth_iarray (n);
+            assertEqual(vout, zeros(0,1));
+        end
+        
+        function test_sawtooth_iarray_realArray_n (~)
+            % Reals rounded down to nearest integer; array input that exercises
+            % this in several cases
+            n = [-0.7, 3.7, 2, 0, 4.0, -0.001];
+            vout = sawtooth_iarray (n);
+            vout_ref = [1;2;3;1;2;1;2;3;4];
+            assertEqual(vout, vout_ref);
+        end
+                                
+    end
+end

--- a/herbert_core/utilities/maths/sawtooth_iarray.m
+++ b/herbert_core/utilities/maths/sawtooth_iarray.m
@@ -17,21 +17,7 @@ function ivout = sawtooth_iarray (n)
 % -------
 %   ivout   Output array: always a column vector with length sum(n(:)).
 %           It is constructed as:
-%               ivout [(1:n(1))'; (1:n(2))'; ...] 
-%           Non-integer values of n are rounded down to the next smaller
-%           integer, and any negative values are treated as zero.
-%           Note: if the output is empty then it is still a column with zero
-%           length i.e. has size = [0,1]
-%
-% EXAMPLES
-%   ivout = sawtooth_iarray(n)
-%
-%   n                 ivout
-% ----------------------------------------------------------------------
-%   0               zeros(0,1)      % column vector with zero length
-%   [2,3,1]         [1;2;1;2;3;1]
-%   [2,0,1]         [1;2;1]         % zero length middle sawtooth section
-%   [2.3,-0.7,3.99] [1;2;1;2;3]     % reals rounded downwards
+%               ivout [1;2;3..n(1); 1;2;3...n(2); ...] 
 
 
 n = n(:);

--- a/herbert_core/utilities/maths/sawtooth_iarray.m
+++ b/herbert_core/utilities/maths/sawtooth_iarray.m
@@ -1,38 +1,47 @@
 function ivout = sawtooth_iarray (n)
-% Create array of successive runs [1,2,3..n(1),1,2,3...n(2),...]'
+% Create column vector [1;2;3..n(1); 1;2;3...n(2); ...] from integer array n
 %
 %   >> ivout = sawtooth_iarray (n)
 %
+% This is a 'sawtooth' array as each element n(i) defines a right angle triangle
+% with length n and values 1,2,3,...n(i).
+%
+%
 % Input:
 % ------
-%   n       List of length of each sawtooth section (integer)
-%          (Zeros correspond to zero length section i.e. they are
+%   n       Array with the lengths of each sawtooth section
+%           Elements should have integer values greater or equal to zero.
+%           Zeros correspond to zero length sections i.e. they are
 %           effectively ignored).
-%           Must have all(n(:)>=0).
 %
 % Output:
 % -------
-%   ivout   Output array: column vector
-%               ivout=[1:n(1),1:n(2),...]'
+%   ivout   Output array: always a column vector
+%           It is constructed as
+%               ivout [(1:n(1))'; (1:n(2))'; ...] 
+%           Non-integer values of n are rounded down to the next smaller
+%           integer, and any negative values are treated as zero
+%           Note: if the output is empty then it is still a column with zero
+%           length i.e. has size = [0,1]
 %
-% NOTE: This is designed for integer array n only, as it assumes that
-%       there are no rounding errors on addition.
-
-% Original author: T.G.Perring
+% EXAMPLES
+%   ivout = sawtooth_iarray(n)
 %
+%   n                 ivout
+% ----------------------------------------------------------------------
+%   0               zeros(0,1)      % column vector with zero length
+%   [2,3,1]         [1;2;1;2;3;1]
+%   [2,0,1]         [1;2;1]         % zero length middle sawtooth section
+%   [2.3,-0.7,3.99] [1;2;1;2;3]     % reals rounded downwards
 
 
-nn0=n(n>0);
-nn0=nn0(:);
-if ~isempty(nn0)
-    nend=cumsum(nn0);
-    tmp=ones(nend(end),1);
-    ix=1+nend(1:end-1);
-    if ~isempty(ix)
-        tmp(ix)=tmp(ix)-double(nn0(1:end-1));
-    end
-    ivout=cumsum(tmp);
+n = floor(n(:));
+n = n(n>0);
+if isempty(n)
+    ivout = zeros(0,1);
+elseif isscalar(n)
+    ivout = (1:n)';
 else
-    ivout=[];
+    offset = cumsum([0;n]);
+    ivout = (1:offset(end))' - repelem(offset(1:end-1), n);
 end
-

--- a/herbert_core/utilities/maths/sawtooth_iarray.m
+++ b/herbert_core/utilities/maths/sawtooth_iarray.m
@@ -3,24 +3,23 @@ function ivout = sawtooth_iarray (n)
 %
 %   >> ivout = sawtooth_iarray (n)
 %
-% This is a 'sawtooth' array as each element n(i) defines a right angle triangle
-% with length n and values 1,2,3,...n(i).
-%
 %
 % Input:
 % ------
-%   n       Array with the lengths of each sawtooth section
-%           Elements should have integer values greater or equal to zero.
-%           Zeros correspond to zero length sections i.e. they are
-%           effectively ignored).
+%   n       Array with the lengths of each section of the output column vector.
+%           - Each section is created as the column vector (1:n(i))'
+%           - The elements of n should have integer values greater or equal to zero.
+%           - Zeros correspond to zero length sections i.e. they are ignored).
+%             This is consistent with Matlab which constructs M:N as an empty
+%             array if N < M.
 %
 % Output:
 % -------
-%   ivout   Output array: always a column vector
-%           It is constructed as
+%   ivout   Output array: always a column vector with length sum(n(:)).
+%           It is constructed as:
 %               ivout [(1:n(1))'; (1:n(2))'; ...] 
 %           Non-integer values of n are rounded down to the next smaller
-%           integer, and any negative values are treated as zero
+%           integer, and any negative values are treated as zero.
 %           Note: if the output is empty then it is still a column with zero
 %           length i.e. has size = [0,1]
 %
@@ -35,7 +34,12 @@ function ivout = sawtooth_iarray (n)
 %   [2.3,-0.7,3.99] [1;2;1;2;3]     % reals rounded downwards
 
 
-n = floor(n(:));
+n = n(:);
+if any(n<0) || any(round(n)~=n)
+    error('HERBERT:sawtooth_iarray:invalid_argument',...
+        'The elements of the input argument must all be nonnegative integer values')
+end
+
 n = n(n>0);
 if isempty(n)
     ivout = zeros(0,1);

--- a/herbert_core/utilities/maths/sawtooth_iarray.m
+++ b/herbert_core/utilities/maths/sawtooth_iarray.m
@@ -26,12 +26,28 @@ if any(n<0) || any(round(n)~=n)
         'The elements of the input argument must all be nonnegative integer values')
 end
 
-n = n(n>0);
 if isempty(n)
+    % No values of n: empty column vector output
     ivout = zeros(0,1);
+    
 elseif isscalar(n)
+    % Single value of n: return is (1:n)'. Note: this is correct when n = 0 as
+    % well
     ivout = (1:n)';
+    
 else
+    % How the following two lines work:
+    % * First step is to create the array (1:sum(n(:))'. 
+    % * To get the required output, it is necessary to subtract n(1) from
+    % elements with indices (n(1)+1) to (n(1)+n(2)), then subtract
+    % (n(1)+n(2)) from the elements with indices (n(1)+n(2)+1) to
+    % (n(1)+n(2)+n(3)) etc. This can be achieved by feeding the cumulative sum
+    % of [0; n(:)] into the function repelem with repeat values n:
+    % - First elements are: 0  repeated n(1) times
+    % -        followed by: n(1)  repeated n(2) times
+    % -        followed by: n(1)+n(2)  repeated n(3) times
+    %                etc
+    % This algorithm works even when there are some or all n(i) == 0
     offset = cumsum([0;n]);
     ivout = (1:offset(end))' - repelem(offset(1:end-1), n);
 end


### PR DESCRIPTION
Add copious unit tests of Herbert utility function sawtooth_iarray, correct an inconsistency of output array size if the output is empty, and make robust to non-integer input array elements with consistent behaviour with Matlab colon operator.

sawtooth_iarray is called alongside replicate_iarray in some Horace methods that manipulate sqw objects. It is appropriate that sawtooth_iarray is made similarly robust and tested.

The refactoring of sawtooth_iarray has left the speed of the function essentially unchanged. Fairly wide testing yields same time +/- 35%