### PR TITLE
 inaccuracies and improvements to docs about binary operations

### DIFF
--- a/documentation/user_docs/docs/manual/Binary_operations.rst
+++ b/documentation/user_docs/docs/manual/Binary_operations.rst
@@ -37,7 +37,8 @@ into each image cell, so its priority in operations is higher then ``IX_dataset`
    e.g. operation between ``PixelDataMemory`` (pixels) and ``dnd`` object (image) is undefined. 
 
 ``sqw`` objects contain both pixels and image information and this information is consistent. 
-(See `Tips and Tricks`_ on more about this)  As top priority Horace object, ``sqw`` object may participate in operations with any other primary Horace object.
+(See `Binary operations manager`_ on more about this)  As top priority Horace object,
+``sqw`` object may participate in operations with any other primary Horace object.
 
 For two objects to be able to participate in binary operation their image size and shape and ``pixel`` size (number of elements)
 must be equal. Other possibility is that some information (pixel or image) is missing. 
@@ -199,8 +200,12 @@ with respectively commensurate array sizes, or a scalar object as the same size
 of each.
 
 
+
+Tips and Tricks
+===============
+
 List of operations and their equivalent code
-============================================
+--------------------------------------------
 
 The arithmetic operations above correspond to equivalent MATLAB functions. You
 should never need to use these, but for reference the corresponding functions
@@ -231,13 +236,12 @@ are:
 	If you do ``w_out = w1+w2`` and ``w1_out = w_out-w2`` ``w1_out ~= w1``. 
 	
 	Actually ``w1.data.s==w1_out.data.s`` and ``w1.pix.signal==w1_out.pix.signal`` but
-	errors are accumulated for each operation so:
+	errors are accumulated in each operation so:
 	
 	``w1.data.e<w1_out.data.e`` and ``w1.pix.variance<w1_out.pix.variance``
 
-
-Tips and Tricks
-===============
+Binary operations manager
+--------------------------------------------
 
 ``sqw`` objects contain both pixels and image information and this information is consistent, i.e. 
 image is calculated from pixels and pixels are sorted within ``PixelData`` array in such a way that the block of
@@ -250,7 +254,7 @@ are random.
 When you perform binary operation between two objects containing pixels, the pixels have to be sorted within the bin to ensure
 the operation performed between correspondent pixels. In many cases, user may be sure that the operation is performed between two 
 objects with pixels ordered in the same way. For example, you calculate foreground and background on the same ``sqw`` object and now want 
-to add them together. In this case, you may decrease time of your operation avoiding sorting as follows:
+to add them together. In this case, you may decrease time of your operation by avoiding sorting pixels within the bins as follows:
 
 .. code-block:: matlab
 

--- a/documentation/user_docs/docs/manual/Binary_operations.rst
+++ b/documentation/user_docs/docs/manual/Binary_operations.rst
@@ -10,7 +10,7 @@ Horace. You can either use the symbolic form (``+``, ``-`` , ``*``, ``/``,
 ``\``), or you can use the explicit function names (``plus, minus, mtimes,
 mrdivide``, ``mldivide``, etc.).
 
-Main from binary operation point of view Horace data objects have binary operations defined between them
+Main Horace data objects (main from this chapter point of view) have binary operations defined between them
 excluding some special cases below.
 Here we call "main" the objects which are related to results of experiment and contain arrays of data
 obtained from experiment. These objects in order of their priority are:
@@ -50,7 +50,7 @@ Scalar number is the only exception from this rule, as operation with this is ap
    Wen operation with array is performed, pixels in ``sqw`` object are modified to maintain consistency with
    modified image.
 
-The more information object have, the higher priority it has in operation, 
+The more information an object has, the higher priority it has in operation,
 e.g. if you want to add ``sqw`` (Pixel + image information) and ``IX_dataset`` information, 
 the result would be ``sqw`` object as it has both pixel and image information. The resulting ``sqw`` object 
 pixel information is calculated from the images resulting in operation to maintain image-pixels consistency. 

--- a/documentation/user_docs/docs/manual/Binary_operations.rst
+++ b/documentation/user_docs/docs/manual/Binary_operations.rst
@@ -47,8 +47,9 @@ Scalar number is the only exception from this rule, as operation with this is ap
 .. note::
    When you perform operation between numeric arrays and ``sqw`` object, the array modifies image first. 
    This means that shape and size of the array have to be consistent with shape and size of image. 
-   Wen operation with array is performed, pixels in ``sqw`` object are modified to maintain consistency with
-   modified image.
+   When operation with array is performed, pixels in ``sqw`` object are modified to maintain consistency with
+   modified image. Similar rules are applicable for operations between ``sqw`` object and other objects containing
+   image i.e. ``dnd``,``IX_dataset`` and ``sigvar`` objects.
 
 The more information an object has, the higher priority it has in operation,
 e.g. if you want to add ``sqw`` (Pixel + image information) and ``IX_dataset`` information, 
@@ -207,9 +208,8 @@ Tips and Tricks
 List of operations and their equivalent code
 --------------------------------------------
 
-The arithmetic operations above correspond to equivalent MATLAB functions. You
-should never need to use these, but for reference the corresponding functions
-are:
+The arithmetic operations above correspond to equivalent MATLAB functions. For reference,
+the corresponding functions are:
 
 ::
 
@@ -252,9 +252,9 @@ formula: :math:`i_1 = cumsum(sqw.data.npix(1:n-1))+1` and the last by: :math:`i_
 are random. 
 
 When you perform binary operation between two objects containing pixels, the pixels have to be sorted within the bin to ensure
-the operation performed between correspondent pixels. In many cases, user may be sure that the operation is performed between two 
+the operation is performed between correspondent pixels. In many cases, user may be sure that the operation is performed between two 
 objects with pixels ordered in the same way. For example, you calculate foreground and background on the same ``sqw`` object and now want 
-to add them together. In this case, you may decrease time of your operation by avoiding sorting pixels within the bins as follows:
+to add them together. In this case, you may decrease time of your ``plus`` operation by avoiding sorting pixels within the bins as follows:
 
 .. code-block:: matlab
 
@@ -264,3 +264,8 @@ to add them together. In this case, you may decrease time of your operation by a
 	w_sum  = binary_op_manager(w_fg,w_bg,@plus,true);
 	
 Last parameter of ``binary_op_manager`` set to ``true`` disables sorting pixels in bins while performing binary operations.
+
+.. warning::
+
+	Use this option carefully. If you do binary operation between two objects with pixels sorted differently, the first result would look correct. 
+	Unfortunately, any future operations on the result of such operation may produce completely unexpected results.


### PR DESCRIPTION
The main part of the ticket #1472 is done within ticket related to spherical projection but many minor changes and inaccuracies remain. 

As there is the request to make changes to doc separate, I am using this ticket as the base of addressing remaining issues and would be doing doc PR for every block of this changes. 

This PR is about improvements to description of binary operations. 

