### PR TITLE
Generic magnetic form factor

### DIFF
--- a/_test/test_utilities/test_fix_magnetic_ff.m
+++ b/_test/test_utilities/test_fix_magnetic_ff.m
@@ -1,7 +1,4 @@
 classdef test_fix_magnetic_ff< TestCase
-    %
-    % $Revision:: 1753 ($Date:: 2019-10-24 20:46:14 +0100 (Thu, 24 Oct 2019) $)
-    %
 
     properties
         tests_folder = fileparts(fileparts(mfilename('fullpath')));
@@ -21,7 +18,7 @@ classdef test_fix_magnetic_ff< TestCase
             en = -1:1:50;
             par_file = fullfile(this.tests_folder,'common_data','gen_sqw_96dets.nxspe');
             fsqw = dummy_sqw (en, par_file, '', 51, 1,[2.8,3.86,4.86], [120,80,90],...
-                             [1,0,0],[0,1,0], 10, 1.,0.1, -0.1, 0.1, [50,50,50,50]);
+                [1,0,0],[0,1,0], 10, 1.,0.1, -0.1, 0.1, [50,50,50,50]);
             this.sample_sqw_const = copy(fsqw{1});
         end
         %
@@ -30,6 +27,18 @@ classdef test_fix_magnetic_ff< TestCase
         end
 
         % tests themself
+        function test_MagFF_with_sphere(obj)
+            sph_cut = cut(obj.sample_sqw,sphere_proj,[],[0,180],[-180,180],[]);
+            valid = sph_cut.data.s(:)~=0;
+            assertEqual(min(sph_cut.data.s(valid)),10)
+            assertEqual(max(sph_cut.data.s(valid)),10)
+
+            mff = MagneticIons('Fe1');
+            ff = mff.correct_mag_ff(sph_cut);
+            assertEqualToTol(min(ff.data.s(valid)),11.1731,'tol',[0.001,0.001])
+            assertEqualToTol(max(ff.data.s(valid)),68.7170,'tol',[0.001,0.001])
+        end
+
         function test_magnetic_Ions(~)
             mi = MagneticIons();
             [J0,J2,J4,J6] = mi.getInterpolant('Fe0');
@@ -110,8 +119,5 @@ classdef test_fix_magnetic_ff< TestCase
             assertEqualToTol(cut1,cut2,'tol',[0.01,0.01])
 
         end
-
-
     end
 end
-

--- a/horace_core/utilities/@MagneticIons/MagneticIons.m
+++ b/horace_core/utilities/@MagneticIons/MagneticIons.m
@@ -49,8 +49,9 @@ classdef MagneticIons
         % handles to functions calculating magnetic momentums of
         % appropriate order for current ion.
         J0_ff_;J2_ff_;J4_ff_;J6_ff_;
-        % matrix of coefficients used to convert hkl coordinates into A^(-1)
-        hkl_to_Qmat_ = eye(3);
+        % 
+        proj_ % the instance of the projection which converts hkl values into 
+        % Crystal Cartesian coordinate system
     end
 
     methods

--- a/horace_core/utilities/@MagneticIons/calc_mag_ff.m
+++ b/horace_core/utilities/@MagneticIons/calc_mag_ff.m
@@ -26,9 +26,9 @@ function magFF=calc_mag_ff(self,win)
 %
 % Get conversion matrix used to change from rlu to wave-vector in A^(-1)
 if isa(win,'sqw')
-    self.hkl_to_Qmat_ = win.data.proj.bmatrix();
+    self.proj_ = win.data.proj;
 else
-    self.hkl_to_Qmat_ = win.proj.bmatrix();
+    self.proj_ = win.proj;
 end
 
 magFF=sqw_eval(win,@(h,k,l,en,argi)form_factor(self,h,k,l,en,argi),[]);

--- a/horace_core/utilities/@MagneticIons/correct_mag_ff.m
+++ b/horace_core/utilities/@MagneticIons/correct_mag_ff.m
@@ -27,4 +27,4 @@ function wout=correct_mag_ff(self,win)
 %
 sqw_magFF = self.calc_mag_ff(win);
 %
-wout=mrdivide(win,sqw_magFF);
+wout=binary_op_manager(win,sqw_magFF,@mrdivide,true);

--- a/horace_core/utilities/@MagneticIons/form_factor.m
+++ b/horace_core/utilities/@MagneticIons/form_factor.m
@@ -9,9 +9,9 @@ function FF = form_factor(self,h,k,l,varargin)
 % optional:
 % en       -- unused vector of energy transfers, provided for
 %             compartibility with sqw_eval interface.
-% b_matrix -- Busing & Levy 's B-matrix (Acta Crystallographica, 1967(4) pp.457-464)
-%             used to convert from crystal cartezian to hkl coordinate system
-%             If provided, used instead of B-matix defined by sqw object
+% proj     -- Instance of aProjection base class initialized to perform
+%             transform_hkl_to_pix operation.
+%
 %
 % Returns vector of changes of magnetic form factors along input hkl vector
 % for the selected ion.
@@ -19,13 +19,12 @@ function FF = form_factor(self,h,k,l,varargin)
 %
 %
 if numel(varargin) > 1 && nargin > 5 && ~isempty(varargin{2})
-    rlu_to_Q = varargin{2};
+    proj = varargin{2};
 else
-    rlu_to_Q = self.hkl_to_Qmat_;
-
+    proj = self.proj_;
 end
-q = rlu_to_Q*[h';k';l'];
 
+q = proj.transform_hkl_to_pix([h';k';l']);
 
 q2 = (q(1,:).*q(1,:)+q(2,:).*q(2,:)+q(3,:).*q(3,:))/(16*pi*pi);
 FF=self.J0_ff_(q2).^2+self.J2_ff_(q2).^2+self.J4_ff_(q2).^2+self.J6_ff_(q2).^2;


### PR DESCRIPTION
This fixes first part of #1497, allowing Magnetic form factor calculations on `sqw` file with any projection. Trivial fixture and unit test for it. 
The second part -- optimization of this operation is extracted into ticket #1561