### PR TITLE
Remove dq_mat from distributed items

### DIFF
--- a/herbert_core/applications/multifit/@mfclass/distribute_fit_data.m
+++ b/herbert_core/applications/multifit/@mfclass/distribute_fit_data.m
@@ -54,11 +54,9 @@ if exist('tobyfit', 'var')
             for j = 1:numel(tobyfit{k}.kf)
 
                 pr = merge_data(j,i).pix_range;
-                loop_data{i}.tobyfit_data{k}.kf{j}     = tobyfit{k}.kf{j}(pr(1):pr(2));
-                loop_data{i}.tobyfit_data{k}.dt{j}     = tobyfit{k}.dt{j}(pr(1):pr(2));
-                for l=1:4
-                    loop_data{i}.tobyfit_data{k}.en{j}{l} = tobyfit{k}.en{j}{l}(pr(1):pr(2));
-                end
+                loop_data{i}.tobyfit_data{k}.kf{j} = tobyfit{k}.kf{j}(pr(1):pr(2));
+                loop_data{i}.tobyfit_data{k}.dt{j} = tobyfit{k}.dt{j}(pr(1):pr(2));
+                loop_data{i}.tobyfit_data{k}.en{j} = tobyfit{k}.en{j}(pr(1):pr(2));
             end
         end
     end

--- a/herbert_core/applications/multifit/@mfclass/distribute_fit_data.m
+++ b/herbert_core/applications/multifit/@mfclass/distribute_fit_data.m
@@ -57,7 +57,7 @@ if exist('tobyfit', 'var')
                 loop_data{i}.tobyfit_data{k}.kf{j}     = tobyfit{k}.kf{j}(pr(1):pr(2));
                 loop_data{i}.tobyfit_data{k}.dt{j}     = tobyfit{k}.dt{j}(pr(1):pr(2));
                 for l=1:4
-                    loop_data{i}.tobyfit_data{k}.qw{j}{l} = tobyfit{k}.qw{j}{l}(pr(1):pr(2));
+                    loop_data{i}.tobyfit_data{k}.en{j}{l} = tobyfit{k}.en{j}{l}(pr(1):pr(2));
                 end
             end
         end

--- a/herbert_core/applications/multifit/@mfclass/distribute_fit_data.m
+++ b/herbert_core/applications/multifit/@mfclass/distribute_fit_data.m
@@ -56,7 +56,6 @@ if exist('tobyfit', 'var')
                 pr = merge_data(j,i).pix_range;
                 loop_data{i}.tobyfit_data{k}.kf{j}     = tobyfit{k}.kf{j}(pr(1):pr(2));
                 loop_data{i}.tobyfit_data{k}.dt{j}     = tobyfit{k}.dt{j}(pr(1):pr(2));
-                loop_data{i}.tobyfit_data{k}.dq_mat{j} = tobyfit{k}.dq_mat{j}(:,:,pr(1):pr(2));
                 for l=1:4
                     loop_data{i}.tobyfit_data{k}.qw{j}{l} = tobyfit{k}.qw{j}{l}(pr(1):pr(2));
                 end


### PR DESCRIPTION
No longer need to distribute `dq_mat` as now computed on-the-fly.
Likewise `qw` is now just a vector and called `en`

Fixes #1563 