### PR TITLE
incorrect run-id(s) in gen_sqw

### DIFF
--- a/horace_core/sqw/@rundatah/private/calc_projections_.m
+++ b/horace_core/sqw/@rundatah/private/calc_projections_.m
@@ -85,6 +85,7 @@ if use_mex
             %nThreads = 1;
             [pix_range,pix] =calc_projections_c(spec_to_cc, data, det, efix,k_to_e, emode, nThreads,proj_mode);
             if proj_mode==2
+                pix(5,:) = obj.run_id;
                 pix = PixelData(pix);
             end
         catch  ERR % use Matlab routine


### PR DESCRIPTION
fixes issue related to incorrect run-id(s) stored in sqw file
causes run_inspector to fail. 

Difficult to write proof as this is bugfix for outdated version