### PR TITLE
Fixes to parallel multifit

### DIFF
--- a/herbert_core/applications/multifit/@mfclass/private/multifit_lsqr_par.m
+++ b/herbert_core/applications/multifit/@mfclass/private/multifit_lsqr_par.m
@@ -223,14 +223,14 @@ end
 
 jd = JobDispatcher('ParallelMF');
 
-% Allow splitting of bins if not averaged or dnd
 pars = arrayfun(@(x) x.plist, pin, 'UniformOutput', false);
 while any(cellfun(@iscell,pars)) % Flatten pars
     pars = [pars{cellfun(@iscell,pars)} pars(~cellfun(@iscell,pars))];
 end
 
-split_bins = any(cellfun(@(x) strcmp(x, '-ave'), pars)) || ...
-    any(cellfun(@(x) isa(x, 'dndbase'), w));
+% Allow splitting of bins if not averaged or dnd
+split_bins = ~any(cellfun(@(x) strcmp(x, '-ave'), pars)) && ...
+    ~any(cellfun(@(x) isa(x, 'dndbase'), w));
 
 % Potential issues follow if parallelism is used
 % Special casing for Tobyfit where arguments need to be distributed

--- a/herbert_core/applications/multifit/MFParallel_Job.m
+++ b/herbert_core/applications/multifit/MFParallel_Job.m
@@ -125,7 +125,6 @@ classdef MFParallel_Job < JobExecutor
                 obj.Store , ...
                 0);
 
-
             f = obj.merge_section(f);
             resid=obj.wt.*(obj.yval-f);
 
@@ -460,7 +459,7 @@ classdef MFParallel_Job < JobExecutor
             nw = numel(data);
 
             for iw = 1:nw
-                if merge(1, iw)
+                if merge(1, iw) % any to merge
                     for currID = obj.numLabs:-1:2
                         if merge(currID, iw)
                             if currID == obj.labIndex  % I am merging down
@@ -471,15 +470,18 @@ classdef MFParallel_Job < JobExecutor
                                 end
                                 data{iw} = data{iw}(2:end); % Drop merged element
 
-                            elseif currID == obj.labIndex+1 % I am being merged onto
+                            elseif currID-1 == obj.labIndex % I am being merged onto
                                 [ok, err_mess, in_data] = obj.mess_framework.receive_message(currID, 'data');
                                 if ~ok
                                     error('HORACE:MFParallel_Job:receive_error', err_mess)
                                 end
-                                adat = merge_data(obj.labIndex, iw).nelem(2);
-                                bdat = merge_data(currID, iw).nelem(1);
-                                data{iw}(end) = data{iw}(end)*adat + ...
-                                    in_data.payload*bdat / (adat + bdat);
+
+                                adat = merge_data(iw, currID-1).nelem(2); % Top of my data
+                                bdat = merge_data(iw, currID).nelem(1); % Bottom of theirs
+
+                                data{iw}(end) = (data{iw}(end)*adat + ...
+                                                 in_data.payload*bdat) /...
+                                                 (adat + bdat);
                             end
                         end
                     end

--- a/herbert_core/classes/MPIFramework/parallel_call/ParallelSQWEval.m
+++ b/herbert_core/classes/MPIFramework/parallel_call/ParallelSQWEval.m
@@ -28,11 +28,12 @@ classdef ParallelSQWEval < JobExecutor
 
             common = obj.common_data_;
 
-
             w_out = common.func(data.w, common.args{:});
-            if w_out.pix.is_filebacked
-                % Need to preserve tmp files
-                save(w_out, w_out.full_filename);
+            for i = 1:numel(w_out)
+                if w_out{i}.pix.is_filebacked
+                    % Need to preserve tmp files
+                    save(w_out{i}, w_out{i}.full_filename);
+                end
             end
             obj.task_outputs = w_out;
 


### PR DESCRIPTION
- Permit cell arrays of data in `ParallelSQWEval`
- Correctly index regions when assigning local segment to global array with `split_bins`
- Correct source of size of bins to merge (`nelem`) from `wout(i).data.npix` [global array, mostly 0s outside of local segment] to `npix` [local segment]
- Correctly condition `split_bins`
