### PR TITLE
cleaning up projection tests

### DIFF
--- a/_test/test_dnd_class/test_migrated_apis.m
+++ b/_test/test_dnd_class/test_migrated_apis.m
@@ -51,33 +51,7 @@ classdef test_migrated_apis < TestCaseWithSave
             assertEqual(en, 0);
         end
 
-        function test_calculate_qw_bins(obj)
-        end
-
-        %% Change
-        function test_change_crystal(obj)
-        end
-
-        %% Compact/slim
-        function test_compact(obj)
-        end
-        function test_slim(obj)
-        end
-
         %% Cut
-        function test_cut(obj)
-            skipTest('Incorrect test data for cut');
-            dnd_2d_obj = read_dnd(obj.test_sqw_2d_fullpath);
-            proj = line_proj([1,-1,0], [1,1,0], 'uoffset', [1,1,0], 'type', 'paa');
-            range = [0,0.2];    % range of cut
-            step = 0.01;        % Q step
-            bin = [range(1)+step/2,step,range(2)-step/2];
-            width = [-0.15,0.15];  % Width in Ang^-1 of cuts
-            ebins = [105,0,115];
-
-            w2 = dnd_2d_obj.cut(proj, bin, width, width, ebins, '-pix');
-            %            this.assertEqualToTolWithSave (w2, this.tol_sp,'ignore_str',1);
-        end
         function test_cut_sym(obj)
             skipTest('Incorrect test data for cut_sym');
             dnd_2d_obj = read_dnd(obj.test_sqw_2d_fullpath);

--- a/_test/test_multifit/linear_bkgd_sqw.m
+++ b/_test/test_multifit/linear_bkgd_sqw.m
@@ -1,0 +1,20 @@
+function y = linear_bkgd_sqw(h,~,~,~, p)
+% Straight line
+% 
+%   >> y = linear_bkgd(x,p)
+%
+% Input:
+% =======
+%   x   vector of x-axis values at which to evaluate function
+%   p   vector or parameters needed by the function:
+%           p = [const, grad]
+%
+% Output:
+% ========
+%   y       Vector of calculated y-axis values
+
+% T.G.Perring
+
+% Simply calculate function at input values
+
+y=ones(size(h))*p(1);

--- a/_test/test_multifit/test_multifit_horace_1.m
+++ b/_test/test_multifit/test_multifit_horace_1.m
@@ -107,21 +107,22 @@ classdef test_multifit_horace_1 < TestCaseWithSave
             % Example of simultaneously fitting more than one sqw object
 
             mss = multifit_sqw_sqw([obj.w4ddata]);
-            mss = mss.set_fun(@sqw_bcc_hfm,  [5,5,0,10,0]);  % set foreground function(s)
-            mss = mss.set_free([1,1,0,0,0]); % set which parameters are floating
-            mss = mss.set_bfun(@sqw_bcc_hfm, {[5,5,1.2,10,0]}); % set background function(s)
-            mss = mss.set_bfree([1,1,1,1,1]);    % set which parameters are floating
-            mss = mss.set_bbind({1,[1,-1],1},{2,[2,-1],1});
+            mss = mss.set_fun(@sqw_bcc_hfm,  [75,5,2.7,10,-75]);  % set foreground function(s)
+            mss = mss.set_free([1,1,1,1,0]); % set which parameters are floating
+            mss = mss.set_bfun(@linear_bkgd_sqw,0); % set background function(s)
+            mss = mss.set_bfree(1);    % set which parameters are floating
+            mss = mss.set_bbind({1,[1,-1],1});
 
             % Simulate at the initial parameter values
             wsim_1 = mss.simulate();
+            %c2s = cut(wsim_1,[],[],[-0.1,0.1],[100,120]);
 
             % And now fit
             [wfit_1, fitpar_1] = mss.fit();
 
             % Test against saved or store to save later; ingnore string
             % changes - these are filepaths
-            tol = [1e-10,1e-8];
+            tol = [3e-5,3e-5];
             assertEqualToTolWithSave (obj, fitpar_1, 'tol', tol, 'ignore_str', 1)
             assertEqualToTolWithSave (obj, wsim_1, 'tol', tol, 'ignore_str', 1, '-ignore_date')
             assertEqualToTolWithSave (obj, wfit_1, 'tol', tol, 'ignore_str', 1, '-ignore_date')

--- a/_test/test_multifit/test_multifit_horace_1.m
+++ b/_test/test_multifit/test_multifit_horace_1.m
@@ -118,10 +118,6 @@ classdef test_multifit_horace_1 < TestCaseWithSave
 
             % And now fit
             [wfit_1, fitpar_1] = mss.fit();
-            disp('*** FITPAR1:');
-            disp(fitpar_1);
-            disp('*** FITPAR1.corr:');            
-            disp(fitpar_1.corr);            
 
             % Test against saved or store to save later; ingnore string
             % changes - these are filepaths

--- a/_test/test_multifit/test_multifit_horace_1.m
+++ b/_test/test_multifit/test_multifit_horace_1.m
@@ -118,6 +118,10 @@ classdef test_multifit_horace_1 < TestCaseWithSave
 
             % And now fit
             [wfit_1, fitpar_1] = mss.fit();
+            disp('*** FITPAR1:');
+            disp(fitpar_1);
+            disp('*** FITPAR1.corr:');            
+            disp(fitpar_1.corr);            
 
             % Test against saved or store to save later; ingnore string
             % changes - these are filepaths

--- a/_test/test_sqw_class/test_migrated_apis.m
+++ b/_test/test_sqw_class/test_migrated_apis.m
@@ -86,19 +86,6 @@ classdef test_migrated_apis < TestCaseWithSave & common_sqw_class_state_holder
             qw=calculate_qw_pixels(sqw_obj);
             assertEqualToTolWithSave(obj,qw,'tol',2.e-7);
         end
-        %        function test_calculate_qw_pixels2(obj)
-        %            % tested as part of calc_qsqr_w_pixels
-        %        end
-        %        function test_calculate_uproj_pixels(obj)
-        %            % tested as part of test_get_nearest_pixels
-        %        end
-
-
-        %% Compact/slim
-        function test_compact(obj)
-        end
-        function test_slim(obj)
-        end
 
         %% Cut
         function test_cut_sym(obj)
@@ -324,14 +311,14 @@ classdef test_migrated_apis < TestCaseWithSave & common_sqw_class_state_holder
 
         %% shifts
         function test_shift_energy_bins(obj)
-            skipTest("Incorrect test data for shift");
+            skipTest("Re #1360  Shift is broken ");
             params = {'scale', 14};
             sqw_4d_obj = sqw(obj.test_sqw_1d_fullpath);
             wout = sqw_4d_obj.shift_energy_bins(@test_migrated_apis.disp_rln, params);
         end
 
         function test_shift_pixels(obj)
-            skipTest("Incorrect test data for shift");
+            skipTest("Re #1360  Shift is broken ");
             params = {}; % no parameters required by test shift_rln function
             sqw_4d_obj = sqw(obj.test_sqw_4d_fullpath);
             wout = shift_pixels(sqw_4d_obj, @test_migrated_apis.shift_rln, params);

--- a/_test/test_sqw_class/test_smooth.m
+++ b/_test/test_sqw_class/test_smooth.m
@@ -34,6 +34,7 @@ classdef test_smooth < TestCase
 
             d = s.smooth(10, 'hat');
             assertTrue(isa(d, 'sqw'));
+            skipTest('Re #1583 applying smooth to sqw object is questionable')
         end
 
         function test_smooth_no_args(obj)
@@ -45,6 +46,7 @@ classdef test_smooth < TestCase
             % TODO: assert data matches expected...
             %assertEqualToTol(d.data.s, expected.data.s, 1e-8);
             %assertEqualToTol(d.data.e, expected.data.e, 1e-8);
+            skipTest('Re #1583 applying smooth to sqw object is questionable')
         end
 
         function test_smooth_scalar_width_arg(obj)
@@ -56,6 +58,7 @@ classdef test_smooth < TestCase
             % TODO: assert data matches expected...
             %assertEqualToTol(d.data.s, expected.data.s, 1e-8);
             %assertEqualToTol(d.data.e, expected.data.e, 1e-8);
+            skipTest('Re #1583 applying smooth to sqw object is questionable')
         end
 
         function test_smooth_array_width_arg(obj)
@@ -67,6 +70,7 @@ classdef test_smooth < TestCase
             % TODO: assert data matches expected...
             %assertEqualToTol(d.data.s, expected.data.s, 1e-8);
             %assertEqualToTol(d.data.e, expected.data.e, 1e-8);
+            skipTest('Re #1583 applying smooth to sqw object is questionable')
         end
 
         function test_smooth_resolution_shape_arg(obj)
@@ -90,6 +94,7 @@ classdef test_smooth < TestCase
             % TODO: assert data matches expected...
             %assertEqualToTol(d.data.s, expected.data.s, 1e-8);
             %assertEqualToTol(d.data.e, expected.data.e, 1e-8);
+            skipTest('Re #1583 applying smooth to sqw object is questionable')
         end
 
         function test_smooth_gaussian_shape_arg(obj)
@@ -101,6 +106,7 @@ classdef test_smooth < TestCase
             % TODO: assert data matches expected...
             %assertEqualToTol(d.data.s, expected.data.s, 1e-8);
             %assertEqualToTol(d.data.e, expected.data.e, 1e-8);
+            skipTest('Re #1583 applying smooth to sqw object is questionable')
         end
 
         function test_smooth_raises_error_with_invalid_shape_arg(obj)

--- a/_test/test_transformation/test_line_proj_construction.m
+++ b/_test/test_transformation/test_line_proj_construction.m
@@ -50,7 +50,7 @@ classdef test_line_proj_construction<TestCase
             assertEqual(proj.v,[0,1,0]);
             assertEqual(proj.w,[0,0,1]);
             assertEqual(proj.alatt,[2,3,4]);
-            assertEqual(proj.angdeg,[90,90,90]);
+            assertTrue(isempty(proj.angdeg));
             assertEqual(proj.type,'aaa');
             assertEqual(proj.nonorthogonal,true);
         end
@@ -62,7 +62,7 @@ classdef test_line_proj_construction<TestCase
             assertEqual(proj.v,[0,1,0]);
             assertEqual(proj.w,[0,0,1]);
             assertEqual(proj.alatt,[2,3,4]);
-            assertEqual(proj.angdeg,[90,90,90]);
+            assertTrue(isempty(proj.angdeg));
             assertEqual(proj.type,'aaa');
         end
 

--- a/_test/test_transformation/test_line_proj_construction.m
+++ b/_test/test_transformation/test_line_proj_construction.m
@@ -434,5 +434,16 @@ classdef test_line_proj_construction<TestCase
             tpixr = projr.transform_pix_to_img(pix_cc);
             assertElementsAlmostEqual(tpixo,tpixr);
         end
+
+        function test_default_param_constructor(~)
+            param_list = {'u','v','w','nonorthogonal','type','alatt','angdeg',...
+                           'offset','label','title'};
+            param_values = {[1,0,0],[0,1,0],[0,0,1],true,'aaa',[1,2,3],...
+                [80,70,120],[1,0,0,1],{'xx','yy','zz','ee'},'Some custom title'};
+            lp = line_proj(param_values{:});
+            for i=1:numel(param_list)
+                assertEqual(lp.(param_list{i}),param_values{i});
+            end
+        end
     end
 end

--- a/_test/test_transformation/test_line_proj_transf_nonorth.m
+++ b/_test/test_transformation/test_line_proj_transf_nonorth.m
@@ -42,8 +42,6 @@ classdef test_line_proj_transf_nonorth<TestCase
         end
 
         function test_getset_nonortho_proj_ppp_100(~)
-            % this test does not work. Should it? With current
-            % nonorthogonal lattice definition, such recovery is impossible
 
             prj_or = line_projTester('alatt',[3, 4 5], ...
                 'angdeg',[85 95 90],'nonorthogonal',true,...
@@ -75,9 +73,7 @@ classdef test_line_proj_transf_nonorth<TestCase
 
 
         function test_getset_nonortho_proj_rrr_100(~)
-            % this test does not work. Should it? With current
-            % nonorthogonal lattice definition, such recovery is impossible
-
+ 
             prj_or = line_projTester('alatt',[3, 4 5], ...
                 'angdeg',[85 95 90],'nonorthogonal',true,...
                 'type','rrr','u',[1,0,0],'v',[0,1,0],'w',[1,1,1]);

--- a/_test/test_transformation/test_line_proj_transf_nonorth.m
+++ b/_test/test_transformation/test_line_proj_transf_nonorth.m
@@ -14,6 +14,32 @@ classdef test_line_proj_transf_nonorth<TestCase
             end
             this=this@TestCase(name);
         end
+        function w = hkl_bragg(~,h,k,l,e,p)
+            grid_h = round(h);
+            grid_k = round(k);
+            grid_l = round(l);
+            w = p(1)*exp(-((h-grid_h).^2+(k-grid_k).^2+(l-grid_l).^2)/p(2));
+        end
+        function test_nonortho_cut_image(obj)
+            proj = line_proj([1,0,0],[0,1,0],[],false,'rrr',[2,2,4],[90,90,70]);
+            ax   = line_axes('nbins_all_dims',[200,200,1,1],'img_range',[-4,-3,-0.1,-5;4,3,0.1,5]);
+            tsqw = sqw.generate_cube_sqw(ax,proj);
+            tsqw = sqw_eval(tsqw,@(h,k,l,e,p)(hkl_bragg(obj,h,k,l,e,p)),[1,0.01]);
+
+            % Ugly comparison of image
+            bp1 = [-3.3,-2.0]; % location of the first "bragg" peak not on the edge
+            ij_pos = round((bp1-[-4,-3]).*[200,200]./[8,6])+1;
+            assertTrue(tsqw.data.s(ij_pos(1),ij_pos(2))>0.5)
+
+            proj_n = line_proj([1,0,0],[0,1,0],[],true,'rrr',[2,2,4],[90,90,70]);
+            tso  = sqw.generate_cube_sqw(ax,proj_n);
+            tso = sqw_eval(tso,@(h,k,l,e,p)(hkl_bragg(obj,h,k,l,e,p)),[1,0.01]);
+
+            % Ugly comparison of image
+            bp1 = [-3.,-2.0]; % location of the first "bragg" peak not on the edge
+            ij_pos = round((bp1-[-4,-3]).*[200,200]./[8,6])+1;
+            assertTrue(tso.data.s(ij_pos(1),ij_pos(2))>0.5)
+        end
 
         function test_getset_nonortho_proj_ppp_100(~)
             % this test does not work. Should it? With current
@@ -43,7 +69,7 @@ classdef test_line_proj_transf_nonorth<TestCase
             % and the matrices are correct!
             assertTrue(prj_or.nonorthogonal);
             assertTrue(prj_rec.nonorthogonal);
-  
+
             assertEqualToTol(prj_or,prj_rec,1.e-9);
         end
 
@@ -78,7 +104,7 @@ classdef test_line_proj_transf_nonorth<TestCase
             assertTrue(prj_rec.nonorthogonal);
 
 
-            assertEqualToTol(prj_or,prj_rec,1.e-9);            
+            assertEqualToTol(prj_or,prj_rec,1.e-9);
         end
         %
         function test_getset_nonortho_proj_ppp_110(~)

--- a/herbert_core/applications/multifit/@mfclass/private/multifit_lsqr_ser.m
+++ b/herbert_core/applications/multifit/@mfclass/private/multifit_lsqr_ser.m
@@ -458,9 +458,9 @@ else
 
         [~,s,v]=svd(jac,0);
         % constrain possible conditionality number and nullify small
-        % elements to inprove resulting fit comparison in case of
-        % poorly defined matrix
-        max_sv = max(abs(s));
+        % elements to inprove resulting fit comparison in tests in 
+        % case of poorly defined matrix
+        max_sv = max(abs(s(:)));
         degraded = abs(s/max_sv)<eps('single');
         s(degraded) = 0;
         %

--- a/horace_core/lattice_functions/crystal_alignment_info.m
+++ b/horace_core/lattice_functions/crystal_alignment_info.m
@@ -5,9 +5,9 @@ classdef crystal_alignment_info < serializable
     % Created to support common interface between legacy alignment,
     % applicable for orthonormal or triclinic coordinate systems only and
     % generic alignment, applicable for any projections
-    % 
+    %
     % by default class is defined by lattice parameters and angles which
-    % describe modified lattice and 3-element rotvect, which defines 
+    % describe modified lattice and 3-element rotvect, which defines
     % 3-D rotations (rotation matrix) necessary to align the crystal.
     %
     % It also contans and may be redefined using the following class
@@ -47,14 +47,14 @@ classdef crystal_alignment_info < serializable
         rotangle %  Angle of rotation corresponding to rotmat (to give a
         %           measure of the misorientation) (degrees)
 
-        % True or false specifies if one wants to get corrections for image 
-        % or for pixel, where if true changes involve B-matrix together with 
+        % True or false specifies if one wants to get corrections for image
+        % or for pixel, where if true changes involve B-matrix together with
         % U matrix, wehere false retunrs only corrections to U-matrix
         hkl_mode;
-        
+
     end
     properties(Dependent, Hidden)
-        legacy_mode % == hkl_mode; legacy corrections were perfomed in hkl 
+        legacy_mode % == hkl_mode; legacy corrections were perfomed in hkl
         % mode only
     end
     properties(Access = protected)
@@ -66,7 +66,7 @@ classdef crystal_alignment_info < serializable
         %          argument rlu, in the refined crystal lattice. (Ang^-1)
         rotvec_ =  zeros(3,1)% Angle of rotation corresponding to rotmat
         %          (to give a measure of the misorientation) (radia)
-        hkl_mode_ = false;        
+        hkl_mode_ = false;
     end
 
 
@@ -76,6 +76,19 @@ classdef crystal_alignment_info < serializable
             % crystal_alignent_info class using default serializable
             % constructor, assigning values to all properties in order of
             % saveableFields or as 'field_name',field_value pairs.
+            %
+            % Inputs:
+            % alatt   -- new (aligned) lattice parameters
+            % angdeg  -- new (aligned) lattice angles
+            % rotvec  -- 3-component vector which defines
+            %            rotation from misaligned to aligned Crystal Cartesian coordinate
+            %            system
+            % Optional:
+            % distance -- the vector which contains distances between
+            %             ideal Bragg positions in aligned lattice and
+            %             actually measured Bragg positions. This parameter
+            %             describes quality of alignment.
+            %
             if nargin == 0
                 return;
             end
@@ -162,7 +175,7 @@ classdef crystal_alignment_info < serializable
         end
         function obj = set.legacy_mode(obj,val)
             obj.hkl_mode = val;
-        end       
+        end
         %======================================================================
         function corr_mat = get_corr_mat(obj,varargin)
             % Return corrections, necessary for modifying sqw object
@@ -189,7 +202,7 @@ classdef crystal_alignment_info < serializable
             %  hkl_mode == true -> corr_mat == rlu_corr
             %
             %   rlu_corr   Conversion matrix to relate notional rlu to true
-            %              rlu, accounting for the the refined crystal 
+            %              rlu, accounting for the the refined crystal
             %              lattice parameters and orientation
             %                       qhkl(i) = rlu_corr(i,j) * qhkl_0(j)
             % b)

--- a/horace_core/sqw/@DnDBase/section.m
+++ b/horace_core/sqw/@DnDBase/section.m
@@ -82,18 +82,18 @@ for n=1:numel(win)
 
     for i=1:ndim
 
-        curr_range = varargin{i};
+        req_cut_range = varargin{i};
         pax = win(n).dax(i);
 
-        if isempty(curr_range) || isequal(curr_range, 0)
+        if isempty(req_cut_range) || isequal(req_cut_range, 0)
 
             irange(1,pax) = 1;
             irange(2,pax) = sz(pax);
             array_section{pax} = irange(1,pax):irange(2,pax);
 
-        elseif numel(curr_range) == 2
+        elseif numel(req_cut_range) == 2
 
-            if curr_range(1) > curr_range(2)
+            if req_cut_range(1) > req_cut_range(2)
                 error ('HORACE:section:invalid_argument', ...
                        'Lower limit larger than upper limit for axis %d',i)
             end
@@ -102,12 +102,12 @@ for n=1:numel(win)
             pcent = 0.5*(p{pax}(2:end)+p{pax}(1:end-1));
 
             % index of bins whose centres lie in the sectioning range
-            lis=find(pcent >= (curr_range(1)-tol) & pcent <= (curr_range(2)+tol));
+            lis=find(pcent >= (req_cut_range(1)-tol) & pcent <= (req_cut_range(2)+tol));
 
             if isempty(lis)
                 error ('HORACE:section:invalid_argument', ...
                        'No data along axis %d in the range [%g, %g]', ...
-                       i, curr_range(1), curr_range(2))
+                       i, req_cut_range(1), req_cut_range(2))
             end
 
             irange(1,pax) = lis(1);
@@ -125,7 +125,9 @@ for n=1:numel(win)
 
         else
             error ('HORACE:section:invalid_argument', ...
-                   'Limits for axis %d must be [], [0] or [min max]', i)
+                   ['Limits for axis %d must be [], [0] or [min max]\n' ...
+                   'where at least min or max belong to existing image range  [%g, %g]'], ...
+                   i,req_cut_range(1), req_cut_range(2))
         end
     end
 

--- a/horace_core/sqw/@Experiment/remove_legacy_alignment.m
+++ b/horace_core/sqw/@Experiment/remove_legacy_alignment.m
@@ -6,7 +6,7 @@ function obj=remove_legacy_alignment(obj,deal_info)
 % Inputs:
 % obj    -- legacy realigned dnd object. Algorithm throws if the object has
 %           not been realigned using legacy algorithm.
-% deal_info 
+% deal_info
 %       -- instance of crystal_alignment_info class, containing information
 %          about de-alignment
 %
@@ -21,6 +21,11 @@ angdeg0 = deal_info.angdeg;
 deal_info.hkl_mode = true;
 
 
+s = sam{1};
+alatt_al0  = s.alatt;
+angdeg_al0 = s.angdeg;
+rlu_corr = deal_info.get_corr_mat(alatt_al0,angdeg_al0);
+
 for i=1:obj.n_runs
     s = sam{i};
     alatt_al  = s.alatt;
@@ -29,8 +34,12 @@ for i=1:obj.n_runs
     s.angdeg=angdeg0;
     sam{i} = s;
 
-    rlu_corr = deal_info.get_corr_mat(alatt_al,angdeg_al);
-
+    if any(abs(alatt_al-alatt_al0)>4*eps('single'))|| ...
+            any(abs(angdeg_al-angdeg_al0)>4*eps('single'))
+        alatt_al0  = alatt_al;
+        angdeg_al0 = angdeg_al;
+        rlu_corr = deal_info.get_corr_mat(alatt_al0,angdeg_al0);
+    end
     exper(i).cu=(rlu_corr*exper(i).cu')';
     exper(i).cv=(rlu_corr*exper(i).cv')';
     off = exper(i).uoffset(1:3);

--- a/horace_core/sqw/@sqw/compact.m
+++ b/horace_core/sqw/@sqw/compact.m
@@ -27,5 +27,3 @@ wout = copy(win);
 for n = 1:numel(win)
     wout(n).data = win(n).data.compact();
 end
-
-end

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -345,7 +345,7 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
             elseif isempty(val) && obj.experiment_info_.detector_arrays.n_runs > 0
                 ; % pass, do nothing, info already in experiment_info
             else
-                error('HORACE:sqw-set.detpar:invalid_argument','incorrect type');
+                error('HORACE:sqw_set_detpar:invalid_argument','incorrect type');
             end
         end
         %

--- a/horace_core/sqw/axes_blocks/@line_axes/line_axes.m
+++ b/horace_core/sqw/axes_blocks/@line_axes/line_axes.m
@@ -20,7 +20,11 @@ classdef line_axes < AxesBlockBase
     %        fields are returned by saveableFields function.
     %5) ab = line_axes('img_range',img_range,'nbins_all_dims',nbins_all_dims)
     %    -- particularly frequent case of building axes block (case 4)
-    %       from the image range and number of bins in all directions.
+    %       from the image range and number of bins in all directions. E.g:
+    %    ab = line_axes('img_range',[-4,-4,-0.1,-5;4,4,0.1,5],'nbins_all_dims',[100,100,1,1]);
+    %    -- defines 2D cut along first two dimensions (the meaning of the
+    %    dimensions is defined by aProjection class)
+    %
     properties(Dependent)
         % the matrix which describes the directions of the each axis in
         % hkl-dE coordinate system. Each column provides vector of the

--- a/horace_core/sqw/coord_transform/@line_proj/private/build_from_old_data_struct_.m
+++ b/horace_core/sqw/coord_transform/@line_proj/private/build_from_old_data_struct_.m
@@ -15,7 +15,15 @@ proj = proj.from_bare_struct(data_struct);
 % recover from old data, where u_to_rlu matrix is stored instead of
 % projection itself
 if use_u_to_rlu_transitional
-    % correct transformation seems division from right. There is the difference
+    % this normally happens for prototype sqw. Only such old structure
+    % does not have alatt
+    if ~proj.alatt_defined
+        proj.alatt_ = [2*pi,2*pi,2*pi];
+    end
+    if ~proj.angdeg_defined
+        proj.angdeg_ = [90,90,90];
+    end
+    % correct transformation seems division from right. There is the difference        
     u_transf = inv(data_struct.u_to_rlu(1:3,1:3))/bmatrix(proj.alatt,proj.angdeg);
     proj = proj.set_from_data_mat(u_transf,data_struct.ulen(1:3));
 end

--- a/horace_core/sqw/coord_transform/@line_proj/private/check_combo_arg_.m
+++ b/horace_core/sqw/coord_transform/@line_proj/private/check_combo_arg_.m
@@ -30,14 +30,9 @@ end
 % do not bother calculating real transformation if lattice is undefined
 % more important for debugging than anything else, as you do not debug
 % empty constructor
-calc_transformation = true;
-if ~obj.alatt_defined
-    obj.alatt_ = 2*[pi,pi,pi];
-    calc_transformation  = false;
-end
-if ~obj.angdeg_defined
-    obj.angdeg_ = 90*ones(1,3);
-    calc_transformation  = false;
+calc_transformation  = false;
+if obj.alatt_defined && obj.angdeg_defined
+    calc_transformation = true;
 end
 
 if calc_transformation

--- a/horace_core/sqw/coord_transform/@line_proj/private/init_.m
+++ b/horace_core/sqw/coord_transform/@line_proj/private/init_.m
@@ -32,7 +32,7 @@ function obj = init_by_input_parameters_(obj,varargin)
 %
 
 
-opt =  [line_proj.fields_to_save_(1:end-1);aProjectionBase.init_params(:)];
+opt =  [line_proj.fields_to_save_(1:end-2);aProjectionBase.init_params(:)];
 % check if the type is defined explicitly
 n_type = find(ismember(opt,'type'));
 text_in = cellfun(@(x)char(string(x)),varargin,'UniformOutput',false); 

--- a/horace_core/sqw/coord_transform/@line_proj/private/projtransf_to_img_.m
+++ b/horace_core/sqw/coord_transform/@line_proj/private/projtransf_to_img_.m
@@ -1,11 +1,12 @@
 function [q_to_img,ulen,b_mat,obj] = projtransf_to_img_(obj)
-% Determine matrices to convert rlu <=> projection axes, and the scaler
+% Determine matrices to convert betwen Crystal Cartesian and Image
+% coordinate systems.
 %
 %
 %   >> [q_to_img,ulen,b_mat,obj] = projaxes_to_rlu_(proj)
 %
 % The projection axes are three vectors that may or may not be orthogonal
-% which are used to create the bins in an sqw object. The bin sizes are in ustep
+% which are used to create the bins in an sqw object.
 %
 % Input:
 % ------


### PR DESCRIPTION
This PR contains various minor changes and improvements I have identified while trying to summarize the tests available for `line_proj` and recovery of `line_proj` from legacy aligned data.

Its not directly connected to `legacy_alignment` but still useful as there are small improvements identified while looking at all projection usage. It is committed now not to polute the alignment operations itself.