### PR TITLE
Correct an error that appeared some time ago when an internal utility function of parse_arguments was refactored.

### DIFF
--- a/herbert_core/utilities/general/parse_arguments.m
+++ b/herbert_core/utilities/general/parse_arguments.m
@@ -438,7 +438,7 @@ addParameter(p, 'prefix_req', true, @islognumscalar);
 addParameter(p, 'flags_noneg', false, @islognumscalar)
 addParameter(p, 'flags_noval', false, @islognumscalar)
 addParameter(p, 'keys_exact', false, @islognumscalar)
-addParameter(p, 'keys_at_end', false, @islognumscalar)
+addParameter(p, 'keys_at_end', true, @islognumscalar)
 addParameter(p, 'keys_once', true, @islognumscalar)
 addParameter(p, 'noffset', 0, @(x) validateattributes({'numeric'}, {'nonnegative'}))
 


### PR DESCRIPTION
Solves ticket #1459. It turns out that one field of a structure had be assigned the opposite logical flag to what it should have been when transcribing the original code. The Herbert utility function parse_arguments now has its original functionality again.