### PR TITLE
Add error on attempting to cut-sym with pix

### DIFF
--- a/_test/test_sym_op/test_cut_sqw_sym.m
+++ b/_test/test_sym_op/test_cut_sqw_sym.m
@@ -92,13 +92,13 @@ classdef test_cut_sqw_sym < TestCaseWithSave
             % Range of data2's first axis which contains pixels
             ubin = [-0.5 0.05 0];
             w1sym = cut(obj.data2, obj.proj2, ubin, ...
-                obj.vbin2, obj.wbin2, obj.ebin2);
+                obj.vbin2, obj.wbin2, obj.ebin2, '-nopix');
 
             w2sym = cut(obj.data2, obj.proj2, ubin, ...
                 obj.vbin2, obj.wbin2, obj.ebin2, ...
-                {SymopIdentity(), id});
+                {SymopIdentity(), id}, '-nopix');
 
-            assertEqualToTol(w1sym.data, w2sym.data, 'ignore_str', 1);
+            assertEqualToTol(w1sym, w2sym, 'ignore_str', 1);
         end
 
         function test_cut_sym_reflect_half_to_whole_cut(obj)
@@ -110,18 +110,19 @@ classdef test_cut_sqw_sym < TestCaseWithSave
             wtmp.pix = PixelDataMemory(wtmp.pix);
 
             w1sym = cut(wtmp, obj.proj, ubin_half, ...
-                obj.width, obj.width, obj.ebins);
+                obj.width, obj.width, obj.ebins, '-nopix');
 
             w2sym = cut(obj.data, obj.proj, ubin_half, ...
                 obj.width, obj.width, obj.ebins, ...
-                {SymopIdentity(), op});
+                {SymopIdentity(), op}, '-nopix');
 
-            assertEqualToTol(w1sym.data, w2sym.data, 'ignore_str', 1);
+            assertEqualToTol(w1sym, w2sym, 'ignore_str', 1);
 
         end
 
         function test_cut_sym_with_pix(obj)
-            % Test symmetrisation, keeping pixels
+        % Test symmetrisation, keeping pixels
+            skipTest('Cut with pix disabled')
             clOb = set_temporary_config_options(hor_config, 'log_level', -1);
             w2sym = cut(obj.data, obj.proj, obj.bin,...
                 obj.width, obj.width, obj.ebins, obj.sym);
@@ -145,9 +146,12 @@ classdef test_cut_sqw_sym < TestCaseWithSave
             clOb = set_temporary_config_options(hor_config, 'log_level', -1);
             c = cut(obj.data2, obj.proj2, ...
                 obj.ubin2, obj.vbin2, obj.wbin2, obj.ebin2, ...
-                obj.sym2);
+                obj.sym2, '-nopix');
 
-            obj.assertEqualToTolWithSave(c.data, obj.tol_sp,'ignore_str',1);
+            ref = obj.getReferenceDataset('test_cut_sqw_sym_P2__1_3', ...
+                                          'test_cut_sqw_sym_P2__1_3_1')
+
+            assertEqualToTol(c, ref, obj.tol_sp,'ignore_str',1);
         end
 
         %------------------------------------------------------------------------

--- a/_test/test_sym_op/test_cut_sym_cube.m
+++ b/_test/test_sym_op/test_cut_sym_cube.m
@@ -28,13 +28,13 @@ classdef test_cut_sym_cube < TestCase
             tsqw = sqw.generate_cube_sqw(10);
 
             res_sqw = cut(tsqw, line_proj([1 0 0], [0 1 0]), ...
-                          [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5]);
+                          [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], '-nopix');
             res_sqw2 = cut(tsqw, line_proj([1 0 0], [0 1 0]), ...
                            [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], ...
-                           {SymopIdentity()});
+                           {SymopIdentity()}, '-nopix');
             res_sqw3 = cut(tsqw, line_proj([1 0 0], [0 1 0]), ...
                            [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], ...
-                           SymopIdentity());
+                           SymopIdentity(), '-nopix');
 
             assertEqual(res_sqw, res_sqw2)
             assertEqual(res_sqw, res_sqw3)
@@ -52,12 +52,12 @@ classdef test_cut_sym_cube < TestCase
             tsqw = sqw.generate_cube_sqw(10);
 
             res_sqw = cut(tsqw, line_proj([1 0 0], [0 1 0]), ...
-                          [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5]);
+                          [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], '-nopix');
             res_sqw2 = cut(tsqw, line_proj([1 0 0], [0 1 0]), ...
                            [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], ...
-                           {id});
+                           {id}, '-nopix');
 
-            assertEqual(res_sqw.data, res_sqw2.data)
+            assertEqual(res_sqw, res_sqw2)
 
         end
 
@@ -70,11 +70,11 @@ classdef test_cut_sym_cube < TestCase
             all_data = {[-5 5] [-5 5] [-5 5]};
 
             wtmp = symmetrise_sqw(data, obj.ref_x{:}, obj.nil);
-            w1sym = cut(wtmp, proj, ubin_half, all_data{:});
+            w1sym = cut(wtmp, proj, ubin_half, all_data{:}, '-nopix');
 
-            w2sym = cut(data, proj, ubin_half, all_data{:}, obj.ref_x_op);
+            w2sym = cut(data, proj, ubin_half, all_data{:}, obj.ref_x_op, '-nopix');
 
-            assertEqualToTol(w1sym.data, w2sym.data);
+            assertEqualToTol(w1sym, w2sym);
         end
 
         function test_cut_sym_reflect_xy(obj)
@@ -88,10 +88,10 @@ classdef test_cut_sym_cube < TestCase
 
             wtmp = symmetrise_sqw(data, obj.ref_xy{:}, obj.nil);
 
-            w1sym = cut(wtmp, proj, ubin_half, all_data{:});
-            w2sym = cut(data, proj, ubin_half, all_data{:}, obj.ref_xy_op);
+            w1sym = cut(wtmp, proj, ubin_half, all_data{:}, '-nopix');
+            w2sym = cut(data, proj, ubin_half, all_data{:}, obj.ref_xy_op, '-nopix');
 
-            assertEqualToTol(w1sym.data, w2sym.data);
+            assertEqualToTol(w1sym, w2sym);
         end
 
         function test_cut_sym_reflect_offset(obj)
@@ -104,13 +104,13 @@ classdef test_cut_sym_cube < TestCase
             offset = [0.5 0 0];
 
             wtmp = symmetrise_sqw(data, obj.ref_x{:}, offset);
-            w1sym = cut(wtmp, proj, ubin_half, all_data{:});
+            w1sym = cut(wtmp, proj, ubin_half, all_data{:}, '-nopix');
 
             op = obj.ref_x_op;
             op.offset = offset;
-            w2sym = cut(data, proj, ubin_half, all_data{:}, op);
+            w2sym = cut(data, proj, ubin_half, all_data{:}, op, '-nopix');
 
-            assertEqualToTol(w1sym.data, w2sym.data);
+            assertEqualToTol(w1sym, w2sym);
 
         end
 
@@ -123,13 +123,13 @@ classdef test_cut_sym_cube < TestCase
 
             wtmp = symmetrise_sqw(data, obj.ref_x{:}, obj.nil);
             wtmp = symmetrise_sqw(wtmp, obj.ref_y{:}, obj.nil);
-            w1sym = cut(wtmp, proj, ubin_half, all_data{:});
+            w1sym = cut(wtmp, proj, ubin_half, all_data{:}, '-nopix');
 
 
             op = {obj.ref_x_op, obj.ref_y_op, [obj.ref_x_op, obj.ref_y_op]};
-            w2sym = cut(data, proj, ubin_half, all_data{:}, op);
+            w2sym = cut(data, proj, ubin_half, all_data{:}, op, '-nopix');
 
-            assertEqualToTol(w1sym.data, w2sym.data);
+            assertEqualToTol(w1sym, w2sym);
 
         end
 

--- a/horace_core/sqw/@sqw/private/cut_accumulate_data_.m
+++ b/horace_core/sqw/@sqw/private/cut_accumulate_data_.m
@@ -168,6 +168,10 @@ function [npix, s, e, pix_out, unique_runid] = cut_with_pixels(pix, block_starts
     targ_proj, targ_axes, npix, s, e, ll, ...
     keep_precision, pixel_contrib_name)
 
+if numel(targ_proj) > 1
+    error('HORACE:cut:not_implemented', 'Cannot cut sym and return pixels')
+end
+
 hc = hor_config;
 chunk_size = hc.mem_chunk_size;
 fb_size    = hc.fb_scale_factor;


### PR DESCRIPTION
Quick fix for cut-sym with pixels

Partially addresses #1620 