### PR TITLE
1D plots are plotted on a single image

### DIFF
--- a/_test/test_IX_classes/test_plot_IX_dataset.m
+++ b/_test/test_IX_classes/test_plot_IX_dataset.m
@@ -218,17 +218,11 @@ classdef test_plot_IX_dataset < TestCase
                 meth = pl_methods{i};
 
                 [objh,axh,plh] = meth(IX1d_arr);
-
+                assertEqual(numel(objh),1);
+                assertEqual(numel(axh),1);
                 if is_plot(i)
-                    assertEqual(numel(objh),2);
-                    assertEqual(numel(axh),2);
                     assertTrue(numel(plh)==2);
                 else
-                    assertEqual(numel(axh),1);
-                    assertEqual(numel(objh),1);
-                end
-                if is_plot(i)
-                    close(objh(2));
                 end
 
                 assertTrue(isa(objh,'matlab.ui.Figure'));
@@ -249,7 +243,7 @@ classdef test_plot_IX_dataset < TestCase
 
                 meth = opl_methods{i};
 
-                [objh,axh,plh] = meth(IX1d_obj);
+                [objh,axh,plh] = meth(IX1d_obj*(1+0.1*i));
 
                 assertEqual(numel(objh),1);
                 assertEqual(numel(axh),1);
@@ -288,25 +282,36 @@ classdef test_plot_IX_dataset < TestCase
             end
 
         end
+        function test_IX1d_plot1D_line_cycles_on_array(obj)
+            % there are 4 line styles defined. 5th line has the same line
+            % style as the first one
+            IX1d_arr = [obj.IX_data{1},1.1*obj.IX_data{1},...
+                1.2*obj.IX_data{1},1.3*obj.IX_data{1},1.4*obj.IX_data{1}];
+            [objh,axh,plh] = pl(IX1d_arr);
+
+            assertEqual(numel(objh),1);
+            assertEqual(numel(axh),1);
+            assertEqual(numel(plh),5);
+            assertTrue(isa(objh,'matlab.ui.Figure'));
+            assertTrue(isa(axh,'matlab.graphics.axis.Axes'));
+            assertTrue(isa(plh,'matlab.graphics.primitive.Data'));
+
+            assertEqual(plh(1).LineStyle,plh(5).LineStyle)
+            close(objh);
+        end
 
         function test_IX1d_plot1D_methods_work_on_array(obj)
             IX1d_arr = [obj.IX_data{1},2*obj.IX_data{1}];
             tstd = obj.interface_tester;
             pl_methods = [tstd.dnd_methods(:);tstd.d1d_methods(:)];
-            is_overplot = [tstd.dnd_overplot(:);tstd.d1d_overplot(:)];
 
             for i=1:numel(pl_methods)
                 meth = pl_methods{i};
 
                 [objh,axh,plh] = meth(IX1d_arr);
-                if is_overplot(i)
-                    assertEqual(numel(objh),1);
-                    assertEqual(numel(axh),1);
-                    assertEqual(numel(plh),2);
-                else
-                    assertEqual(numel(objh),2);
-                    assertFalse(isequal(objh(1),objh(2)))
-                end
+                assertEqual(numel(objh),1);
+                assertEqual(numel(axh),1);
+                assertEqual(numel(plh),2);
                 assertTrue(isa(objh,'matlab.ui.Figure'));
                 assertTrue(isa(axh,'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plh,'matlab.graphics.primitive.Data'));

--- a/_test/test_IX_classes/test_plot_IX_dataset.m
+++ b/_test/test_IX_classes/test_plot_IX_dataset.m
@@ -190,6 +190,57 @@ classdef test_plot_IX_dataset < TestCase
             close(objh);
 
         end
+        %------------------------------------------------------------------
+        function test_IX1d_plot1D_all_types_on_array(obj)
+            all_types = get_global_var('genieplot','marker_types');
+            n_types = numel(all_types);
+            IX1d_arr = repmat(obj.IX_data{1},1,n_types+2);
+            [objh,axh,plh] = dp(IX1d_arr);
+
+            assertEqual(numel(objh),1);
+            assertEqual(numel(axh),1);
+            assertEqual(numel(plh),n_types+2);
+            assertTrue(isa(objh,'matlab.ui.Figure'));
+            assertTrue(isa(axh,'matlab.graphics.axis.Axes'));
+            assertTrue(isa(plh,'matlab.graphics.primitive.Data'));
+
+            close(objh);
+        end
+
+        function test_IX1d_plot1D_all_colour_on_array(obj)
+            all_col = get_global_var('genieplot','colors');
+            n_colours = numel(all_col);
+            IX1d_arr = repmat(obj.IX_data{1},1,n_colours+2);
+            [objh,axh,plh] = pl(IX1d_arr);
+
+            assertEqual(numel(objh),1);
+            assertEqual(numel(axh),1);
+            assertEqual(numel(plh),n_colours+2);
+            assertTrue(isa(objh,'matlab.ui.Figure'));
+            assertTrue(isa(axh,'matlab.graphics.axis.Axes'));
+            assertTrue(isa(plh,'matlab.graphics.primitive.Data'));
+
+            close(objh);
+        end
+
+        function test_IX1d_plot1D_line_cycles_on_array(obj)
+            % there are 4 line styles defined. 5th line has the same line
+            % style as the first one
+            IX1d_arr = [obj.IX_data{1},1.1*obj.IX_data{1},...
+                1.2*obj.IX_data{1},1.3*obj.IX_data{1},1.4*obj.IX_data{1}];
+            [objh,axh,plh] = pl(IX1d_arr);
+
+            assertEqual(numel(objh),1);
+            assertEqual(numel(axh),1);
+            assertEqual(numel(plh),5);
+            assertTrue(isa(objh,'matlab.ui.Figure'));
+            assertTrue(isa(axh,'matlab.graphics.axis.Axes'));
+            assertTrue(isa(plh,'matlab.graphics.primitive.Data'));
+
+            assertEqual(plh(1).LineStyle,plh(5).LineStyle)
+            close(objh);
+        end
+
         function test_IX1d_overplot2_work_with_overlpot1(obj)
             IX1d_arr = [obj.IX_data{1},2*obj.IX_data{1}];
 
@@ -204,7 +255,6 @@ classdef test_plot_IX_dataset < TestCase
             assertEqual(numel(plh),3);
             close(objh);
         end
-
 
         function test_IX1d_all_methods_work_together_on_array(obj)
             IX1d_arr = [obj.IX_data{1},2*obj.IX_data{1}];
@@ -257,7 +307,6 @@ classdef test_plot_IX_dataset < TestCase
             close(objh);
         end
 
-
         function test_IX1d_overplot1D_methods_work_on_array(obj)
             IX1d_arr = [obj.IX_data{1},2*obj.IX_data{1}];
             tstd = obj.interface_tester;
@@ -282,23 +331,6 @@ classdef test_plot_IX_dataset < TestCase
             end
 
         end
-        function test_IX1d_plot1D_line_cycles_on_array(obj)
-            % there are 4 line styles defined. 5th line has the same line
-            % style as the first one
-            IX1d_arr = [obj.IX_data{1},1.1*obj.IX_data{1},...
-                1.2*obj.IX_data{1},1.3*obj.IX_data{1},1.4*obj.IX_data{1}];
-            [objh,axh,plh] = pl(IX1d_arr);
-
-            assertEqual(numel(objh),1);
-            assertEqual(numel(axh),1);
-            assertEqual(numel(plh),5);
-            assertTrue(isa(objh,'matlab.ui.Figure'));
-            assertTrue(isa(axh,'matlab.graphics.axis.Axes'));
-            assertTrue(isa(plh,'matlab.graphics.primitive.Data'));
-
-            assertEqual(plh(1).LineStyle,plh(5).LineStyle)
-            close(objh);
-        end
 
         function test_IX1d_plot1D_methods_work_on_array(obj)
             IX1d_arr = [obj.IX_data{1},2*obj.IX_data{1}];
@@ -319,6 +351,7 @@ classdef test_plot_IX_dataset < TestCase
                 close(objh);
             end
         end
+
         function test_IX1d_plot1D_methods_work(obj)
             IX1d_obj = obj.IX_data{1};
             tstd = obj.interface_tester;

--- a/herbert_core/graphics/genieplot_init.m
+++ b/herbert_core/graphics/genieplot_init.m
@@ -3,9 +3,12 @@ function genieplot_init
 
 % Initialise graphics styles
 genieplot.color{1} = 'k';
+genieplot.colors = {'r','g','b','c','m','k','#0072BD','#D95319','#EDB120','#7E2F8E','#77AC30','#4DBEEE','#A2142F'};
 genieplot.line_style{1} = '-';
+genieplot.line_styles = {'-','--',':','-.'};
 genieplot.line_width = 0.5;
 genieplot.marker_type{1} = 'o';
+genieplot.marker_types = {'o','+','*','.','x','_','|','square','diamond','^','v','>','<','pentagram','hexagram'};
 genieplot.marker_size = 6;
 genieplot.xscale = 'linear';
 genieplot.yscale = 'linear';
@@ -28,3 +31,5 @@ genieplot.name_sliceomatic = 'Sliceomatic';
 
 % Set global variable
 set_global_var('genieplot',genieplot)
+
+

--- a/herbert_core/graphics/genieplot_init.m
+++ b/herbert_core/graphics/genieplot_init.m
@@ -3,16 +3,24 @@ function genieplot_init
 
 % Initialise graphics styles
 genieplot.color{1} = 'k';
-genieplot.colors = {'r','g','b','c','m','k','#0072BD','#D95319','#EDB120','#7E2F8E','#77AC30','#4DBEEE','#A2142F'};
+
 genieplot.line_style{1} = '-';
 genieplot.line_styles = {'-','--',':','-.'};
 genieplot.line_width = 0.5;
 genieplot.marker_type{1} = 'o';
-genieplot.marker_types = {'o','+','*','.','x','_','|','square','diamond','^','v','>','<','pentagram','hexagram'};
 genieplot.marker_size = 6;
 genieplot.xscale = 'linear';
 genieplot.yscale = 'linear';
 genieplot.zscale = 'linear';
+
+if verLessThan('MATLAB','9.9')
+    genieplot.colors = {'r','g','b','c','m','k'};
+    genieplot.marker_types = {'o','+','*','.','x','s','d','^','v','>','<','p','h'};    
+else
+    genieplot.colors = {'r','g','b','c','m','k','#0072BD','#D95319','#EDB120','#7E2F8E','#77AC30','#4DBEEE','#A2142F'};
+    genieplot.marker_types = {'o','+','*','.','x','_','|','square','diamond','^','v','>','<','pentagram','hexagram'};
+end
+
 
 genieplot.oned_maxspec = 1000;
 genieplot.oned_binning = 1;

--- a/herbert_core/utilities/classes/@IX_dataset_1d/dd.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/dd.m
@@ -12,7 +12,7 @@ function varargout = dd(w,varargin)
 %   >> [fig_handle, axes_handle, plot_handle] = dd(w,...)
 
 
-[fig_,axes_,plot_] = plot_1d_nd_(w,nargout,'d',varargin{:});
+[fig_,axes_,plot_] = plot_1d_nd_(w,'d',varargin{:});
 
 % Output only if requested
 if nargout>0

--- a/herbert_core/utilities/classes/@IX_dataset_1d/de.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/de.m
@@ -13,7 +13,7 @@ function varargout = de(w,varargin)
 
 
 
-[fig_,axes_,plot_] = plot_1d_nd_(w,nargout,'e',varargin{:});
+[fig_,axes_,plot_] = plot_1d_nd_(w,'e',varargin{:});
 
 % Output only if requested
 if nargout>0

--- a/herbert_core/utilities/classes/@IX_dataset_1d/dh.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/dh.m
@@ -12,7 +12,7 @@ function varargout = dh(w,varargin)
 %   >> [fig_handle, axes_handle, plot_handle] = dh(w,...) 
 
 
-[fig_,axes_,plot_] = plot_1d_nd_(w,nargout,'h',varargin{:});
+[fig_,axes_,plot_] = plot_1d_nd_(w,'h',varargin{:});
 
 % Output only if requested
 if nargout>0

--- a/herbert_core/utilities/classes/@IX_dataset_1d/dl.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/dl.m
@@ -12,7 +12,7 @@ function varargout = dl(w,varargin)
 %   >> [fig_handle, axes_handle, plot_handle] = dl(w,...) 
 
 
-[fig_,axes_,plot_] = plot_1d_nd_(w,nargout,'l',varargin{:});
+[fig_,axes_,plot_] = plot_1d_nd_(w,'l',varargin{:});
 
 % Output only if requested
 if nargout>0

--- a/herbert_core/utilities/classes/@IX_dataset_1d/dm.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/dm.m
@@ -12,7 +12,7 @@ function varargout = dm(w,varargin)
 %   >> [fig_handle, axes_handle, plot_handle] = dm(w,...) 
 
 
-[fig_,axes_,plot_] = plot_1d_nd_(w,nargout,'m',varargin{:});
+[fig_,axes_,plot_] = plot_1d_nd_(w,'m',varargin{:});
 
 % Output only if requested
 if nargout>0

--- a/herbert_core/utilities/classes/@IX_dataset_1d/dp.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/dp.m
@@ -12,7 +12,7 @@ function varargout = dp(w,varargin)
 %   >> [fig_handle, axes_handle, plot_handle] = dp(w,...)
 
 
-[fig_,axes_,plot_] = plot_1d_nd_(w,nargout,'p',varargin{:});
+[fig_,axes_,plot_] = plot_1d_nd_(w,'p',varargin{:});
 
 % Output only if requested
 if nargout>0

--- a/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_1d_nd_.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_1d_nd_.m
@@ -1,11 +1,9 @@
-function [fig_,axes_,plot_] = plot_1d_nd_(w,nout,type,varargin)
+function varargout = plot_1d_nd_(w,type,varargin)
 %plot_1d_nd_ Plot one or array of 1D datasets on separate plots
 %
 %
 % Inputs:
 % w     -- one or array of 1D datasets
-% nout  -- number of output arguements requested by the calling routine
-%          This defines the form output arguments of this routine will
 %          have.
 % type  -- type of plot to perform. See calling routines for details
 % varargin
@@ -23,23 +21,12 @@ function [fig_,axes_,plot_] = plot_1d_nd_(w,nout,type,varargin)
 opt=struct('newplot',true,'lims_type','xy');
 [~,lims,fig]=genie_figure_parse_plot_args(opt,varargin{:});
 
-n_plots = numel(w);
-fig_ = cell(n_plots,1);
-axes_ = cell(n_plots,1);
-plot_ = cell(n_plots,1);
 
 % perform plot
-[fig_{1},axes_{1},plot_{1}]=plot_oned (w(1),opt.newplot,type,fig,lims{:});
-opt.newplot = false;
-for i=2:n_plots
-    fig = figure;
-    % perform another plot
-    [fig_{i},axes_{i},plot_{i}]=plot_oned (w(i),opt.newplot,type,fig,lims{:});
-end
+[fig_,axes_,plot_]=plot_oned (w,opt.newplot,type,fig,lims{:});
+
 
 % if output requested, combine output in array of graphical objects
-if nout>0
-    fig_  = [fig_{:}];
-    axes_ = [axes_{:}];
-    plot_ = [plot_{:}];
+if nargout>0
+    varargout = data_plot_interface.set_argout(nargout,fig_,axes_,plot_);
 end

--- a/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_line.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_line.m
@@ -6,8 +6,10 @@ line_style=get_global_var('genieplot','line_style');
 color=get_global_var('genieplot','color');
 
 nw = numel(w);
-icol = mod(0:nw-1,length(color))+1;
-ilin = mod(0:nw-1,length(line_style))+1;
+
+[color,icol]       = types_list_(color,'colors',nw);
+[line_style,ilin]  = types_list_(line_style,'line_styles',nw);
+
 iwid = mod(0:nw-1,length(line_width))+1;
 for i=1:nw
     if i==2; hold on; end   % hold on for array input

--- a/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_markers.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_markers.m
@@ -6,9 +6,10 @@ marker_type=get_global_var('genieplot','marker_type');
 color=get_global_var('genieplot','color');
 
 nw = numel(w);
-icol = mod(0:nw-1,length(color))+1;
+
+[color,icol]       = types_list_(color,'colors',nw);
+[marker_type,ityp] = types_list_(marker_type,'marker_types',nw);
 isiz = mod(0:nw-1,length(marker_size))+1;
-ityp = mod(0:nw-1,length(marker_type))+1;
 for i=1:nw
     if i==2; hold on; end   % hold on for array input
     x = w(i).x;

--- a/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_markers_errors.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_markers_errors.m
@@ -7,10 +7,10 @@ marker_type=get_global_var('genieplot','marker_type');
 color=get_global_var('genieplot','color');
 
 nw = numel(w);
-icol = mod(0:nw-1,length(color))+1;
+[color,icol]       = types_list_(color,'colors',nw);
+[marker_type,ityp] = types_list_(marker_type,'marker_types',nw);
 isiz = mod(0:nw-1,length(marker_size))+1;
-ityp = mod(0:nw-1,length(marker_type))+1;
-iwid = mod(0:nw-1,length(line_width))+1;
+iwid = mod(0:nw-1,length(line_width)) +1;
 for i=1:nw
     if i==2; hold on; end   % hold on for array input
     x = w(i).x;

--- a/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_markers_errors_lines.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_markers_errors_lines.m
@@ -8,11 +8,13 @@ marker_type=get_global_var('genieplot','marker_type');
 color=get_global_var('genieplot','color');
 
 nw = numel(w);
-icol = mod(0:nw-1,length(color))+1;
 isiz = mod(0:nw-1,length(marker_size))+1;
-ityp = mod(0:nw-1,length(marker_type))+1;
-ilin = mod(0:nw-1,length(line_style))+1;
-iwid = mod(0:nw-1,length(line_width))+1;
+iwid = mod(0:nw-1,length(line_width)) +1;
+
+[color,icol]       = types_list_(color,'colors',nw);
+[marker_type,ityp] = types_list_(marker_type,'marker_types',nw);
+[line_style,ilin]  = types_list_(line_style,'line_styles',nw);
+
 for i=1:nw
     if i==2; hold on; end   % hold on for array input
     x = w(i).x;

--- a/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_oned.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_oned.m
@@ -34,8 +34,6 @@ default_fig_name=get_global_var('genieplot','name_oned');
 
 par=varargin;
 
-fig_=[]; axes_=[]; plot_=[];
-
 
 % Check input arguments
 % ---------------------
@@ -63,7 +61,6 @@ if is_string(plot_type) && ~isempty(plot_type)
     else
         error('HERBERT:graphics:invalid_argument', ...
             'Plot type %s is not recognised',plot_type);
-
     end
 else
     error('HERBERT:graphics:invalid_argument', ...

--- a/herbert_core/utilities/classes/@IX_dataset_1d/private/types_list_.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/private/types_list_.m
@@ -1,0 +1,37 @@
+function [var_list,var_idx] = types_list_(type,all_types_name,nw)
+% Distribute list of m input parameters over nw objects
+% 
+% Inputs:
+% type             -- single parameter, used for for first object
+% all_types_name   -- list of all parameters to use
+% nw               -- number of objects to provide with parameters
+% 
+% Returns:
+% var_list         -- list of input parameters, used for object
+% var_idx          -- array of parameter indices with length nw, providing
+%                     parameter index (from var_list) for each input object
+if nw == 1
+    var_list = type;
+    var_idx  = 1;
+else
+    if numel(type)>1
+        var_list = type;
+        var_idx  = mod(0:nw-1,numel(type))+1;
+    else
+        var_list     = get_global_var('genieplot',all_types_name);
+        n_parameters = numel(var_list);
+        var_idx      = 1:n_parameters;
+        this_type_n  = find(ismember(var_list,type));
+        var_idx      = circshift(var_idx,-this_type_n+1);
+        if n_parameters > nw
+            var_idx   = var_idx(1:nw);
+        elseif n_parameters < nw
+            n_copies = floor(nw/n_parameters);
+            if n_copies*n_parameters<nw
+                n_copies = n_copies +1;
+            end
+            var_idx = repmat(var_idx,1,n_copies);
+            var_idx = var_idx(1:nw);
+        end
+    end
+end


### PR DESCRIPTION
fixes #1619 
array of 1D object is plotted on single plot with line parameters choosen from specified variable. The old behaviour when you may support array of plot parameters is also supported. 

fixed separate plots in 1D case