### PR TITLE
Address issues with cut-sym and `cut_sqw` syntax

### DIFF
--- a/_test/test_sym_op/test_cut_sqw_sym.m
+++ b/_test/test_sym_op/test_cut_sqw_sym.m
@@ -120,6 +120,30 @@ classdef test_cut_sqw_sym < TestCaseWithSave
 
         end
 
+        function test_cut_sym_from_file(obj)
+            op = SymopReflection([-1 1 0], [0 0 1], [0 0 0]);
+
+            ubin_half = [-0.25 0.05 0];
+
+            wtmp = symmetrise_sqw(obj.data, op);
+            wtmp.pix = PixelDataMemory(wtmp.pix);
+
+            w1sym = cut(wtmp, obj.proj, ubin_half, ...
+                obj.width, obj.width, obj.ebins, '-nopix');
+
+            w2sym = cut(obj.data_source, obj.proj, ubin_half, ...
+                obj.width, obj.width, obj.ebins, ...
+                {SymopIdentity(), op}, '-nopix');
+
+            w3sym = cut_sqw(obj.data_source, obj.proj, ubin_half, ...
+                            obj.width, obj.width, obj.ebins, ...
+                            {SymopIdentity(), op}, '-nopix');
+
+            assertEqualToTol(w1sym, w2sym, 'ignore_str', 1, 'tol', 1e-6);
+            assertEqualToTol(w1sym, w3sym, 'ignore_str', 1, 'tol', 1e-6);
+        end
+
+
         function test_cut_sym_with_pix(obj)
         % Test symmetrisation, keeping pixels
             clOb = set_temporary_config_options(hor_config, 'log_level', -1);
@@ -148,7 +172,7 @@ classdef test_cut_sqw_sym < TestCaseWithSave
                 obj.sym2, '-nopix');
 
             ref = obj.getReferenceDataset('test_cut_sqw_sym_P2__1_3', ...
-                                          'test_cut_sqw_sym_P2__1_3_1')
+                                          'test_cut_sqw_sym_P2__1_3_1');
 
             assertEqualToTol(c, ref, obj.tol_sp,'ignore_str',1);
         end

--- a/_test/test_sym_op/test_cut_sym_cube.m
+++ b/_test/test_sym_op/test_cut_sym_cube.m
@@ -35,9 +35,13 @@ classdef test_cut_sym_cube < TestCase
             res_sqw3 = cut(tsqw, line_proj([1 0 0], [0 1 0]), ...
                            [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], ...
                            SymopIdentity(), '-nopix');
+            res_sqw4 = cut_sqw(tsqw, line_proj([1 0 0], [0 1 0]), ...
+                               [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], ...
+                               SymopIdentity(), '-nopix');
 
             assertEqual(res_sqw, res_sqw2)
             assertEqual(res_sqw, res_sqw3)
+            assertEqual(res_sqw, res_sqw4)
 
         end
 
@@ -56,8 +60,47 @@ classdef test_cut_sym_cube < TestCase
             res_sqw2 = cut(tsqw, line_proj([1 0 0], [0 1 0]), ...
                            [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], ...
                            {id}, '-nopix');
+            res_sqw3 = cut_sqw(tsqw, line_proj([1 0 0], [0 1 0]), ...
+                           [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], ...
+                           {id}, '-nopix');
 
             assertEqual(res_sqw, res_sqw2)
+            assertEqual(res_sqw, res_sqw3)
+
+        end
+
+        function test_cut_sym_nonorthog_identity(obj)
+        % Test that symmetrisation works with non-orthogonal lattice
+
+            id = [obj.ref_x_op, obj.ref_x_op]; % Reflect -> reflect back
+            tsqw = sqw.generate_cube_sqw(10);
+            tsqw.data.angdeg = [90, 90, 120];
+
+            res_sqw = cut(tsqw, line_proj([1 0 0], [0 1 0]), ...
+                          [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], '-nopix');
+            res_sqw2 = cut(tsqw, line_proj([1 0 0], [0 1 0]), ...
+                           [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], ...
+                           {id}, '-nopix');
+
+            assertEqual(res_sqw, res_sqw2)
+
+        end
+
+        function test_cut_sym_nonorthog_rot(obj)
+        % Test that symmetrisation works with non-orthogonal lattice
+
+            tsqw = sqw.generate_cube_sqw(10);
+            tsqw.data.angdeg = [90, 90, 120];
+
+            wtmp = symmetrise_sqw(tsqw, SymopRotation.fold(2, [0,0,1]));
+            res_sqw = cut(wtmp, line_proj([1 0 0], [0 1 0]), ...
+                          [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5]);
+
+            res_sqw2 = cut(tsqw, line_proj([1 0 0], [0 1 0]), ...
+                           [-5 5], [0.5 1 1.5], [-1.5 1 1.5], [-5 5], ...
+                           SymopRotation.fold(2, [0,0,1]));
+
+            assertEqual(res_sqw.data, res_sqw2.data)
 
         end
 
@@ -73,8 +116,10 @@ classdef test_cut_sym_cube < TestCase
             w1sym = cut(wtmp, proj, ubin_half, all_data{:}, '-nopix');
 
             w2sym = cut(data, proj, ubin_half, all_data{:}, obj.ref_x_op, '-nopix');
+            w3sym = cut_sqw(data, proj, ubin_half, all_data{:}, obj.ref_x_op, '-nopix');
 
             assertEqualToTol(w1sym, w2sym);
+            assertEqualToTol(w1sym, w3sym);
         end
 
         function test_cut_sym_reflect_xy(obj)

--- a/documentation/user_docs/docs/manual/Cutting_data_of_interest_from_SQW_files_and_objects.rst
+++ b/documentation/user_docs/docs/manual/Cutting_data_of_interest_from_SQW_files_and_objects.rst
@@ -1009,9 +1009,9 @@ limited and mostly discouraged.
 - ``cut_sqw`` is fully equivalent to ``cut`` except that attempting to apply it
   to a ``dnd`` object or file, will raise an error.
 
-- ``cut_dnd`` is equivalent to ``cut`` except it only ever returns a ``dnd`` as
-  though ``-nopix`` had been passed.
-
+- ``cut_dnd`` is equivalent to ``cut`` on a ``dnd`` object, but for an
+  ``sqw`` object, it operates on the ``dnd`` (binned image) of the
+  ``sqw``, ignoring any pixel information and returning a ``dnd``.
 
 section
 =======

--- a/horace_core/symop/@SymopRotation/SymopRotation.m
+++ b/horace_core/symop/@SymopRotation/SymopRotation.m
@@ -70,7 +70,9 @@ classdef SymopRotation < Symop
         % belong to the irreducible set in the upper right quadrant
 
             if ~exist('proj', 'var')
-                proj = line_proj();
+                proj = line_proj([1, 0, 0], [0, 1, 0], ...
+                                 'angdeg', [90, 90, 90], ...
+                                 'alatt', [1, 1, 1]);
             end
 
             if ~isequal(proj.angdeg, [90 90 90])


### PR DESCRIPTION
- Corrected documentation on `cut_dnd`
- Add tests with `cut_sqw` syntax
- Add test of cut-sym from file.
- Fixes issue with cut-sym with non-orthogonal rotational projections

Fixes #1657 
Fixes #1665 