### PR TITLE
changes to fix idaaas crash

### DIFF
--- a/_test/test_sqw_file/test_faccess_sqw_v3_3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3_3.m
@@ -201,6 +201,8 @@ classdef test_faccess_sqw_v3_3< TestCase
             so = faccess_sqw_v3_3(tf);
             so = so.reopen_to_write();
 
+            % file will be probably broken but actually faccessor recovers
+            % it from metadata (binary reader will not)
             so = so.put_num_pixels(10);
             so.delete();
 
@@ -212,8 +214,8 @@ classdef test_faccess_sqw_v3_3< TestCase
             fseek(fh,pix_pos,'bof');
             npix = fread(fh,1,'uint64');
             fclose(fh);
-           assertEqual(npix,unit64(10));
-        end        
+            assertEqual(npix,unit64(10));
+        end
         %
         function obj = test_save_load_sqwV3_3(obj)
             samp_f = fullfile(obj.sample_dir,...

--- a/_test/test_sqw_file/test_faccess_sqw_v3_3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3_3.m
@@ -214,7 +214,7 @@ classdef test_faccess_sqw_v3_3< TestCase
             fseek(fh,pix_pos,'bof');
             npix = fread(fh,1,'uint64');
             fclose(fh);
-            assertEqual(npix,unit64(10));
+            assertEqual(npix,10);
         end
         %
         function obj = test_save_load_sqwV3_3(obj)

--- a/_test/test_sqw_file/test_faccess_sqw_v3_3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3_3.m
@@ -192,6 +192,28 @@ classdef test_faccess_sqw_v3_3< TestCase
                 'relative',5.e-6) % is this the accuracy of conversion from
             % double to single?
         end
+        function obj = test_put_npix(obj)
+
+            tf = fullfile(tmp_dir,'test_put_npix.sqw');
+            clOb = onCleanup(@()del_memmapfile_files(tf));
+            copyfile(obj.sample_file,tf,'f');
+
+            so = faccess_sqw_v3_3(tf);
+            so = so.reopen_to_write();
+
+            so = so.put_num_pixels(10);
+            so.delete();
+
+            ldr = sqw_formats_factory.instance().get_loader(tf);
+            pix_pos = ldr.pix_position;
+            ldr.delete();
+            fh = fopen(tf,'rb');
+            assertTrue(fh>0)
+            fseek(fh,pix_pos,'bof');
+            npix = fread(fh,1,'uint64');
+            fclose(fh);
+           assertEqual(npix,unit64(10));
+        end        
         %
         function obj = test_save_load_sqwV3_3(obj)
             samp_f = fullfile(obj.sample_dir,...

--- a/_test/test_sqw_file/test_sqw_formats_factory.m
+++ b/_test/test_sqw_file/test_sqw_formats_factory.m
@@ -19,6 +19,30 @@ classdef test_sqw_formats_factory <  TestCase %WithSave
             hc = horace_paths;
             obj.test_data_folder  = hc.test_common;
         end
+        function test_pref_accessor_d0d(~)
+            tobj = d0d();
+            test_facc = faccess_dnd_v2();
+            %------ retriave defaults            
+            ref_acc_any = sqw_formats_factory.instance.get_pref_access();
+            ref_acc_d0d = sqw_formats_factory.instance.get_pref_access(tobj);
+            clOb = onCleanup(@() sqw_formats_factory.instance().set_pref_access(tobj,''));
+
+            sqw_formats_factory.instance().set_pref_access(tobj,test_facc);
+
+            acc = sqw_formats_factory.instance.get_pref_access();
+            assertEqual(acc,test_facc);
+
+            acc = sqw_formats_factory.instance.get_pref_access(tobj);
+            assertEqual(acc,test_facc);
+            %------ clear to defaults
+            sqw_formats_factory.instance().set_pref_access(tobj,'');
+
+            acc = sqw_formats_factory.instance.get_pref_access();
+            assertEqual(acc,ref_acc_any);
+
+            acc = sqw_formats_factory.instance.get_pref_access(tobj);
+            assertEqual(acc,ref_acc_d0d);
+        end
         %-----------------------------------------------------------------
         function test_selection_v3_3(obj)
 
@@ -47,7 +71,7 @@ classdef test_sqw_formats_factory <  TestCase %WithSave
         %
         function test_selection_v3_old(obj)
 
-            clob = set_temporary_warning('off','SQW_FILE_IO:legacy_data')
+            clob = set_temporary_warning('off','SQW_FILE_IO:legacy_data');            
 
             file_v3_old = fullfile(obj.test_folder,...
                 'test_sqw_file_read_write_v3.sqw');
@@ -84,7 +108,7 @@ classdef test_sqw_formats_factory <  TestCase %WithSave
         function test_selection_v0(obj)
             file_v0 = fullfile(obj.test_folder,...
                 'test_sqw_read_write_v0_t.sqw');
-            clob = set_temporary_warning('off','SQW_FILE_IO:legacy_data')
+            clob = set_temporary_warning('off','SQW_FILE_IO:legacy_data');
 
             loader = sqw_formats_factory.instance().get_loader(file_v0);
             assertTrue(isa(loader,'faccess_sqw_prototype'));

--- a/herbert_core/classes/MPIFramework/@JobDispatcher/JobDispatcher.m
+++ b/herbert_core/classes/MPIFramework/@JobDispatcher/JobDispatcher.m
@@ -74,9 +74,6 @@ classdef JobDispatcher
         % how often (in seconds) JobDispatcher should query the task status
         task_check_time;
 
-        % Short drop-out time (in seconds) for querying task status
-        task_wait_time;
-
         % Number of times to try action until deciding the action has failed
         fail_limit;
 
@@ -88,9 +85,6 @@ classdef JobDispatcher
     properties(Access=protected, Hidden = true)
         % How often (in seconds) JobDispatcher should display the task status
         task_check_time_ = 4;
-
-        % Short drop-out time (in seconds) for querying task status
-        task_wait_time_ = 0.1;
 
         fail_limit_ = 100; % number of times to try for changes in job status file until
                            % decided the job has failed
@@ -260,17 +254,6 @@ classdef JobDispatcher
             this = reset_fail_limit_(this,this.time_to_fail/val);
         end
 
-        function time = get.task_wait_time(this)
-            time = this.task_wait_time_;
-        end
-
-        function this = set.task_wait_time(this,val)
-            if val<=0
-                error('JOB_DISPATCHER:invalid_argument',...
-                    'time to wait jobs has to be positive');
-            end
-            this.task_wait_time_ =val;
-        end
 
         function time = get.time_to_fail(this)
             time = this.time_to_fail_;

--- a/herbert_core/classes/MPIFramework/@JobDispatcher/private/submit_and_run_job_.m
+++ b/herbert_core/classes/MPIFramework/@JobDispatcher/private/submit_and_run_job_.m
@@ -1,6 +1,6 @@
 function [outputs,n_failed,task_ids,obj] = submit_and_run_job_(obj,...
-                                                      task_class_name, common_params,loop_params,return_results,...
-                                                      cluster_wrp,keep_workers_running)
+    task_class_name, common_params,loop_params,return_results,...
+    cluster_wrp,keep_workers_running)
 % submit parallel job to run on cluster
 %
 %Inputs:
@@ -19,53 +19,43 @@ function [outputs,n_failed,task_ids,obj] = submit_and_run_job_(obj,...
 %
 
 
-    exit_worker_when_job_ends = cluster_wrp.exit_worker_when_job_ends;
-    n_workers                 = cluster_wrp.n_workers;
+exit_worker_when_job_ends = cluster_wrp.exit_worker_when_job_ends;
+n_workers                 = cluster_wrp.n_workers;
 
-    % build jobExecutor initialization message used by each worker
-    je_init_message = JobExecutor.build_worker_init(task_class_name,...
-                                                    exit_worker_when_job_ends,keep_workers_running);
-
-
-    % determine the way of splitting job among workers and construct the
-    % messages to initialize each worker's job
-    [task_ids,taskInitMessages] = obj.split_tasks(common_params,loop_params,return_results,n_workers);
+% build jobExecutor initialization message used by each worker
+je_init_message = JobExecutor.build_worker_init(task_class_name,...
+    exit_worker_when_job_ends,keep_workers_running);
 
 
-    if obj.job_is_starting_
-        log_message_prefix = 'starting';
-    else
-        log_message_prefix = 'continuing';
-    end
-
-    % submit info to cluster and start job
-    cluster_wrp = cluster_wrp.start_job(je_init_message,taskInitMessages,log_message_prefix);
+% determine the way of splitting job among workers and construct the
+% messages to initialize each worker's job
+[task_ids,taskInitMessages] = obj.split_tasks(common_params,loop_params,return_results,n_workers);
 
 
-    % wait until the job finishes
-    waiting_time = obj.task_wait_time;
+if obj.job_is_starting_
+    log_message_prefix = 'starting';
+else
+    log_message_prefix = 'continuing';
+end
 
-    % Checks between prints
-    nWait = obj.task_check_time / waiting_time;
+% submit info to cluster and start job
+cluster_wrp = cluster_wrp.start_job(je_init_message,taskInitMessages,log_message_prefix);
 
+
+% wait until the job finishes
+waiting_time = obj.task_check_time;
+pause(waiting_time );
+
+[completed,cluster_wrp]=cluster_wrp.check_progress();
+cluster_wrp = cluster_wrp.display_progress();
+% regularly checking the task state
+while(~completed)
+    pause(waiting_time);
     [completed,cluster_wrp]=cluster_wrp.check_progress();
     cluster_wrp = cluster_wrp.display_progress();
-    % regularly checking the task state
-    t_since_print = 0;
-    while(~completed)
-        pause(waiting_time);
-        [completed,cluster_wrp]=cluster_wrp.check_progress();
-        if t_since_print >= nWait
-            cluster_wrp = cluster_wrp.display_progress();
-            t_since_print = 0;
-        end
-        t_since_print = t_since_print + 1;
-    end
-
-    % retrieve final results
-    [outputs,n_failed] =  cluster_wrp.retrieve_results();
-    % retrieve and reject all messages may left after the job was completed
-    %  (e.g. if some tasks of the job have failed);
-    obj.mess_framework.clear_messages();
-
 end
+% retrieve final results
+[outputs,n_failed] =  cluster_wrp.retrieve_results();
+% retrieve and reject all messages may left after the job was completed
+%  (e.g. if some tasks of the job have failed);
+obj.mess_framework.clear_messages();

--- a/herbert_core/utilities/general/bigtoc.m
+++ b/herbert_core/utilities/general/bigtoc.m
@@ -21,7 +21,6 @@ function t = bigtoc(varargin)
 %
 % Original author: T.G.Perring
 %
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
 
 display_time=false;
 % Parse arguments
@@ -65,7 +64,7 @@ end
 % Perform function
 t_tmp=bigtictoc('toc',n);
 if nargout==0
-    if ~isempty(mess); disp(mess); end;
+    if ~isempty(mess); disp(mess); end
     disp(['Elapsed time is ',num2str(t_tmp(1)),' seconds'])
     disp(['    CPU time is ',num2str(t_tmp(2)),' seconds'])
     if display_time

--- a/horace_core/sqw/@gen_sqw_files_job/private/rundata_write_to_sqw_.m
+++ b/horace_core/sqw/@gen_sqw_files_job/private/rundata_write_to_sqw_.m
@@ -91,7 +91,7 @@ run_id = zeros(1,nfiles);
 for i=1:nfiles
     if hor_log_level>-1 && write_banner
         fprintf('--------------------------------------------------------------------------------\n');
-        fprintf('*** Processing input file N:%d of %d:\n',i,nfiles);
+        fprintf('*** Processing input file N %d of %d:\n\n',i,nfiles);
     end
     %
     run_id(i) = run_files{i}.run_id;

--- a/horace_core/sqw/@gen_sqw_files_job/private/rundata_write_to_sqw_.m
+++ b/horace_core/sqw/@gen_sqw_files_job/private/rundata_write_to_sqw_.m
@@ -111,7 +111,7 @@ for i=1:nfiles
     % ----------------
     bigtic
     %save(w,sqw_file{i});
-    ldw = sqw_formats_factory.instance().get_pref_faccess(w);
+    ldw = sqw_formats_factory.instance().get_pref_access(w);
     if hor_log_level > 0
         fprintf('*** Writing to: %s...\n',sqw_file{i});
     end

--- a/horace_core/sqw/@gen_sqw_files_job/private/rundata_write_to_sqw_.m
+++ b/horace_core/sqw/@gen_sqw_files_job/private/rundata_write_to_sqw_.m
@@ -113,7 +113,7 @@ for i=1:nfiles
     %save(w,sqw_file{i});
     ldw = sqw_formats_factory.instance().get_pref_access(w);
     if hor_log_level > 0
-        fprintf('*** Writing to: %s...\n',sqw_file{i});
+        fprintf('Writing to: %s...\n',sqw_file{i});
     end
     ldw = ldw.init(w,sqw_file{i});
     ldw = ldw.put_sqw();

--- a/horace_core/sqw/@gen_sqw_files_job/private/rundata_write_to_sqw_.m
+++ b/horace_core/sqw/@gen_sqw_files_job/private/rundata_write_to_sqw_.m
@@ -90,9 +90,8 @@ end
 run_id = zeros(1,nfiles);
 for i=1:nfiles
     if hor_log_level>-1 && write_banner
-        disp('--------------------------------------------------------------------------------')
-        disp(['Processing spe file ',num2str(i),' of ',num2str(nfiles),':'])
-        disp(' ')
+        fprintf('--------------------------------------------------------------------------------\n');
+        fprintf('*** Processing input file N:%d of %d:\n',i,nfiles);
     end
     %
     run_id(i) = run_files{i}.run_id;
@@ -113,7 +112,7 @@ for i=1:nfiles
     bigtic
     %save(w,sqw_file{i});
     ldw = sqw_formats_factory.instance().get_pref_faccess(w);
-    if ll>0
+    if hor_log_level > 0
         fprintf('*** Writing to: %s...\n',sqw_file{i});
     end
     ldw = ldw.init(w,sqw_file{i});

--- a/horace_core/sqw/@gen_sqw_files_job/private/rundata_write_to_sqw_.m
+++ b/horace_core/sqw/@gen_sqw_files_job/private/rundata_write_to_sqw_.m
@@ -9,7 +9,7 @@ function [grid_size, data_range,update_runlabels] = rundata_write_to_sqw_(run_fi
 %   run_file        Cell array of initiated rundata objects
 %   sqw_file        Cell array of full file names of output sqw files
 %   grid_size_in    Scalar or row vector of grid dimensions.
-%   pix_db_range    Range of data image grid to rebin pixels on. If not given, 
+%   pix_db_range    Range of data image grid to rebin pixels on. If not given,
 %                   uses smallest hypercuboid that encloses the whole data range
 %                   for pixels in Crystal Cartesian coordinate system.
 %   instrument      Array of structures or objects containing instrument information
@@ -61,8 +61,8 @@ for ii=1:nfiles
         else
             maxrunid = max(maxrunid, runid);
         end
-	% as max(integer,NaN) is integer, the else would also work for the if
-	% but leaving this explicit to make the point
+        % as max(integer,NaN) is integer, the else would also work for the if
+        % but leaving this explicit to make the point
     else
         hasnans = true;
     end
@@ -108,12 +108,18 @@ for i=1:nfiles
             max([data_range_tmp(2,:);data_range(2,:)],[],1)];
     end
 
-
     % Write sqw object
     % ----------------
     bigtic
-    save(w,sqw_file{i});
-
+    %save(w,sqw_file{i});
+    ldw = sqw_formats_factory.instance().get_pref_faccess(w);
+    if ll>0
+        fprintf('*** Writing to: %s...\n',sqw_file{i});
+    end
+    ldw = ldw.init(w,sqw_file{i});
+    ldw = ldw.put_sqw();
+    ldw.delete();
+    % -----------------
     if running_mpi
         mpi_obj.do_logging(i,nfiles,[],[]);
     end

--- a/horace_core/sqw/PixelData/pix_data.m
+++ b/horace_core/sqw/PixelData/pix_data.m
@@ -8,8 +8,9 @@ classdef pix_data < serializable
     properties(Dependent)
         npix;   % Number of pixels, stored in the the pixels data block
         n_rows  % Number of rows in pixel data array
-        data;  % data array block
-        offset;
+        data;   % data array block
+        offset; % shift (in Bytes) from the beginning of the binary file
+        %  containing  the pixels to the first byte of pixels to access.
     end
 
     properties(Access=protected)

--- a/horace_core/sqw/file_io/@faccess_sqw_v4/put_num_pixels.m
+++ b/horace_core/sqw/file_io/@faccess_sqw_v4/put_num_pixels.m
@@ -1,5 +1,5 @@
 function obj = put_num_pixels(obj, num_pixels)
-%PUT_RAW_PIX  Store num_pixels in the appropriate position of the pixel data
+%PUT_NUM_PIXELS  Store num_pixels in the appropriate position of the pixel data
 %block.
 %
 % Inputs:

--- a/horace_core/sqw/file_io/@sqw_binfile_common/put_pix.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/put_pix.m
@@ -12,7 +12,11 @@ function   obj = put_pix(obj,varargin)
 %
 % If update options is selected, file header have to exist. This option keeps
 % existing file information untouched;
-[ok,mess,update,nopix,reserve,argi] = parse_char_options(varargin,{'-update','-nopix','-reserve'});
+%
+% hold_pix_place is here for compatibility with horace4 file format
+% interface. This option is ignored here.
+[ok,mess,update,nopix,reserve,hold_pix_place,argi] = ...
+    parse_char_options(varargin,{'-update','-nopix','-reserve','-hold_pix_place'});
 if ~ok
     error('SQW_FILE_IO:invalid_argument',...
         'SQW_BINFILE_COMMON::put_pix: %s',mess);

--- a/horace_core/sqw/file_io/@sqw_binfile_common/sqw_binfile_common.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/sqw_binfile_common.m
@@ -147,6 +147,19 @@ classdef sqw_binfile_common < binfile_v2_common & sqw_file_interface
         obj = put_det_info(obj,varargin);
         %
         obj = put_pix(obj,varargin);
+        %
+        function obj = put_num_pixels(obj,num_pixels)
+            % store/modify number of pixels.
+            % Horace-4 compartibility function. Should not be used in
+            % Horace-3
+            if ~isnumeric(obj.pix_pos_)
+                error('HORACE:sqw_binfile_common:runtime_error', ...
+                    'Using non-initialized file-accessor')
+            end
+            do_fseek(obj.file_id_,obj.pix_pos_,'bof');
+            fwrite(obj.file_id_,uint64(num_pixels),'uint64');
+            check_error_report_fail_(obj,'Error writing npix value');
+        end
         function obj = put_raw_pix(~,varargin)
             error('HORACE:sqw_binfile_common:not_implemented', ...
                 ['This is the method, available for sqw files version higher then 3 \n', ...

--- a/horace_core/sqw/file_io/@sqw_file_interface/sqw_file_interface.m
+++ b/horace_core/sqw/file_io/@sqw_file_interface/sqw_file_interface.m
@@ -161,6 +161,7 @@ classdef sqw_file_interface
         obj = put_pix(obj,varargin);
         obj = put_pix_metadata(obj,varargin);
         obj = put_raw_pix(obj,pix_data,pix_idx,varargin);
+        obj = put_num_pixels(obj, num_pixels)        
         obj = put_sqw(obj,varargin);
         % extended interface:
         obj = put_instruments(obj,varargin);

--- a/horace_core/sqw/file_io/@sqw_formats_factory/private/get_loader_.m
+++ b/horace_core/sqw/file_io/@sqw_formats_factory/private/get_loader_.m
@@ -1,0 +1,84 @@
+function  loader = get_loader_(obj,sqw_file_name,varargin)
+% Returns initiated loader which can load the data from the specified data file.
+%
+%Usage:
+%>>loader=loaders_factory.instance().get_loader(sqw_file_name);
+%>>loader=loaders_factory.instance().get_loader(sqw_file_name,'-update');
+%
+% where:
+%>>data_file_name  -- the name of the file, which is the source of the data
+%                     or the cellarray of such names.
+%                     If cellarray of the names provided, the method returns
+%                     cellarray of loaders.
+% Optional:
+% '-update'        -- if provided, open file for read/write/update
+%                     operations, unlike default opening file
+%                     for read access only
+%
+%
+% On error:      throws
+% HORACE:file_io:runtime_error exception with
+%                message, explaining the reason for error.
+%                The errors are usually caused by missing or
+%                not-recognized (non-sqw) input files.
+if iscell(sqw_file_name) % process range of files
+    loader = cellfun(@(x)(obj.get_loader(x)),sqw_file_name,...
+        'UniformOutput',false);
+    return;
+end
+if ~isnumeric(sqw_file_name)
+    [ok,mess,full_data_name] = check_file_exist(sqw_file_name,'*');
+else
+    error('HORACE:file_io:runtime_error', 'filename was not numeric');
+end
+if ~ok
+    mess = regexprep(mess,'[\\]','/');
+    error('HORACE:file_io:runtime_error','get_loader: %s',mess);
+end
+% read initial bytes of binary file and interpret them as Horace headers to identify file format.
+% Returns header block and open file handle not to open file again
+[head_struc,fh] = horace_binfile_interface.get_file_header(full_data_name,varargin{:});
+
+for i=1:numel(obj.supported_accessors_)
+    loader = obj.supported_accessors_{i};
+    % check if loader should load the file. Initiate loaders
+    % with open file handle if loader recognizes the file format
+    % as its own.
+    [ok,objinit] = loader.should_load_stream(head_struc,fh);
+    if ok
+        % if loader can load, initialize loader to be able
+        % to read the file.
+        try
+            loader=loader.init(objinit,varargin{:});
+            return
+        catch ME
+            if fh>0
+                try
+                    fclose(fh);
+                catch
+                end
+            end
+            err = MException('HORACE:file_io:runtime_error',...
+                ['get_loader: Error initializing selected loader: %s : %s\n',...
+                'invalid file format or damaged file?'],...
+                class(loader),ME.message);
+            err = addCause(ME,err);
+            rethrow(err);
+        end
+    end
+end
+% no appropriate loader found.
+fclose(fh);
+if strcmp(head_struc.name,'horace')
+    error('HORACE:file_io:runtime_error',...
+        ['get_loader: this Horace package does not support the sqw',...
+        ' file version %d found in file: %s\n',...
+        ' Update your Horace installation.'],...
+        head_struc.version,full_data_name);
+else
+    error('HORACE:file_io:runtime_error',...
+        ['get_loader: Existing readers can not understand format of file: %s\n',...
+        ' Is it a sqw file at all?'],...
+        full_data_name);
+end
+

--- a/horace_core/sqw/file_io/@sqw_formats_factory/private/get_pref_access_.m
+++ b/horace_core/sqw/file_io/@sqw_formats_factory/private/get_pref_access_.m
@@ -1,0 +1,42 @@
+function loader = get_pref_access_(obj,varargin)
+% Returns the version of the accessor recommended to use for writing sqw files
+% by default or accessor necessary for writing the particular class provided as
+% input.
+%
+%Usage:
+%>>loader = sqw_formats_factory.instance().get_pref_access();
+%           -- returns default accessor suitable for most files.
+%>>loader = sqw_formats_factory.instance().get_pref_access('dnd')
+% or
+%>>loader = sqw_formats_factory.instance().get_pref_access('sqw')
+%         -- returns preferred accessor for dnd or sqw object
+%            correspondingly
+%
+%>>loader = sqw_formats_factory.instance().get_pref_access(object)
+%         -- returns preferred accessor for the object of type
+%             provided, where allowed types are sqw,dnd,d0d,d1d,d2d,d3d,d4d.
+%
+%            Throws 'SQW_FILE_IO:invalid_argument' if the type
+%            is not among the types specified above.
+%
+if nargin <2
+    % When it is completed, return most functional accessor.
+    loader = obj.supported_accessors_{obj.preferred_accessor_num_};
+    return
+end
+if ischar(varargin{1})
+    the_type = varargin{1};
+else
+    [the_type,orig_type] = sqw_formats_factory.get_sqw_type(varargin{1});
+    if strcmp(the_type,'none') % assume sqw
+        the_type = orig_type;
+    end
+end
+if obj.types_map_.isKey(the_type)
+    ld_num = obj.types_map_(the_type);
+    loader = obj.supported_accessors_{ld_num};
+else
+    error('HORACE:file_io:invalid_argument',...
+        'get_pref_access: input class %s does not have registered accessor',...
+        the_type)
+end

--- a/horace_core/sqw/file_io/@sqw_formats_factory/private/get_sqw_type_.m
+++ b/horace_core/sqw/file_io/@sqw_formats_factory/private/get_sqw_type_.m
@@ -1,0 +1,34 @@
+function [in_type,orig_type] = get_sqw_type_(in_obj)
+% Determine the type of sqw object based on data in the header
+% return value options are:
+%      in_type == 'none' - the header is empty, there is no efix/emode
+%                          data to determine the type
+%      in_type == 'sqw2' - the header has emode==2 and
+%                          numel(efix)>1
+%      in_type == 'sqw'  - none of the above so using the
+%                          class of obj i.e. sqw
+orig_type = class(in_obj);
+if isa(in_obj,'sqw')
+    in_type = 'sqw';
+    header =in_obj.experiment_info;
+    if isa(header, 'Experiment')
+        if isempty(header.expdata)
+            in_type = 'none';
+            return;
+        else
+            header = header.expdata(1);
+        end
+    elseif isempty(header)
+        in_type = 'none';
+        return;
+    end
+    emode = header.emode;
+    if emode == 2
+        nefix = numel(header.efix);
+        if nefix>1
+            in_type = 'sqw2';
+        end
+    end
+else
+    in_type = orig_type;
+end

--- a/horace_core/sqw/file_io/@sqw_formats_factory/private/set_pref_accessor_.m
+++ b/horace_core/sqw/file_io/@sqw_formats_factory/private/set_pref_accessor_.m
@@ -1,0 +1,48 @@
+function set_pref_accessor_(obj,type,facc_name)
+% method allows manually set preferable accessor for specific
+% object type. New accessor will be used until sqw_formats_factory is
+% loaded in memory and have not been updated.
+% Inputs:
+% obj     --  Instance of sqw_formats_factory
+% type    --  name of the type, one wants to set accessor for.
+% facc_name
+%         -- name of file-accessor class to set as target for
+%            the type provided. The name have to be among the
+%            names of the registered accessors (classes present
+%            in obj.supported_accessors_ list.
+% Empty facc_name resets factory to default values.
+%
+% Returns:
+% Modified sqw_formats_factory singleton with new file accessor
+% set as default for input type.
+% get_pref_access method invoked without parameters would also
+% return the file accessor, specified as input of this method.
+
+if ~ischar(type)||isstring(type)
+    type = class(type);
+end
+if ~ischar(facc_name)||isstring(facc_name)
+    facc_name = class(facc_name);
+end
+if isempty(facc_name)
+    obj.types_map_ = containers.Map(obj.written_types_ ,...
+        obj.access_to_type_ind_);
+    obj.preferred_accessor_num_  = 1;
+    return;
+end
+
+type_at = ismember(obj.written_types_,type);
+if ~any(type_at)
+    error('HORACE:sqw_fromats_factory:invalid_argument', ...
+        'Type: %s is not among the types, factory know how to save',type)
+end
+
+known_types = cellfun(@class,obj.supported_accessors_,'UniformOutput',false);
+facc_at = ismember(known_types,facc_name);
+if ~any(facc_at)
+    error('HORACE:sqw_fromats_factory:invalid_argument', ...
+        'class: "%s" is not among the file accessors, registered with the factory',facc_name)
+end
+facc_idx = find(facc_at);
+obj.preferred_accessor_num_ = facc_idx;
+obj.types_map_(type) = facc_idx;

--- a/horace_core/sqw/file_io/@sqw_formats_factory/sqw_formats_factory.m
+++ b/horace_core/sqw/file_io/@sqw_formats_factory/sqw_formats_factory.m
@@ -128,68 +128,9 @@ classdef sqw_formats_factory < handle
             %                The errors are usually caused by missing or
             %                not-recognized (non-sqw) input files.
             %
-            if iscell(sqw_file_name) % process range of files
-                loader = cellfun(@(x)(obj.get_loader(x)),sqw_file_name,...
-                    'UniformOutput',false);
-                return;
-            end
-            if ~isnumeric(sqw_file_name)
-                [ok,mess,full_data_name] = check_file_exist(sqw_file_name,'*');
-            else
-                error('HORACE:file_io:runtime_error', 'filename was not numeric');
-            end
-            if ~ok
-                mess = regexprep(mess,'[\\]','/');
-                error('HORACE:file_io:runtime_error','get_loader: %s',mess);
-            end
-            % read initial bytes of binary file and interpret them as Horace headers to identify file format.
-            % Returns header block and open file handle not to open file again
-            [head_struc,fh] = horace_binfile_interface.get_file_header(full_data_name,varargin{:});
-
-            for i=1:numel(obj.supported_accessors_)
-                loader = obj.supported_accessors_{i};
-                % check if loader should load the file. Initiate loaders
-                % with open file handle if loader recognizes the file format
-                % as its own.
-                [ok,objinit] = loader.should_load_stream(head_struc,fh);
-                if ok
-                    % if loader can load, initialize loader to be able
-                    % to read the file.
-                    try
-                        loader=loader.init(objinit,varargin{:});
-                        return
-                    catch ME
-                        if fh>0
-                            try
-                                fclose(fh);
-                            catch
-                            end
-                        end
-                        err = MException('HORACE:file_io:runtime_error',...
-                            ['get_loader: Error initializing selected loader: %s : %s\n',...
-                            'invalid file format or damaged file?'],...
-                            class(loader),ME.message);
-                        err = addCause(ME,err);
-                        rethrow(err);
-                    end
-                end
-            end
-            % no appropriate loader found.
-            fclose(fh);
-            if strcmp(head_struc.name,'horace')
-                error('HORACE:file_io:runtime_error',...
-                    ['get_loader: this Horace package does not support the sqw',...
-                    ' file version %d found in file: %s\n',...
-                    ' Update your Horace installation.'],...
-                    head_struc.version,full_data_name);
-            else
-                error('HORACE:file_io:runtime_error',...
-                    ['get_loader: Existing readers can not understand format of file: %s\n',...
-                    ' Is it a sqw file at all?'],...
-                    full_data_name);
-            end
-
+            loader = get_loader_(obj,sqw_file_name,varargin{:});
         end
+        %
         function ver = last_version(obj)
             % return the version number of file accessor to use for new sqw
             % files.
@@ -217,27 +158,33 @@ classdef sqw_formats_factory < handle
             %            Throws 'SQW_FILE_IO:invalid_argument' if the type
             %            is not among the types specified above.
             %
-            if nargin <2
-                % When it is completed, return most functional accessor.
-                loader = obj.supported_accessors_{obj.preferred_accessor_num_};
-                return
-            end
-            if ischar(varargin{1})
-                the_type = varargin{1};
-            else
-                [the_type,orig_type] = sqw_formats_factory.get_sqw_type(varargin{1});
-                if strcmp(the_type,'none') % assume sqw
-                    the_type = orig_type;
-                end
-            end
-            if obj.types_map_.isKey(the_type)
-                ld_num = obj.types_map_(the_type);
-                loader = obj.supported_accessors_{ld_num};
-            else
-                error('HORACE:file_io:invalid_argument',...
-                    'get_pref_access: input class %s does not have registered accessor',...
-                    the_type)
-            end
+            loader = get_pref_access_(obj,varargin{:});
+        end
+
+        function set_pref_access(obj,type,facc_name)
+            % method allows manually set preferable accessor for specific
+            % object type. New accessor will be used until sqw_formats_factory is
+            % loaded in memory and have not been updated.
+            % Inputs:
+            % obj     --  Instance of sqw_formats_factory
+            % type    --  the class or the name of the class, one wants to
+            %             set accessor for.
+            %             The name of the class needs to be among the
+            %             classes factory know how to save
+            % facc_name
+            %         -- name of file-accessor class to set as saver for
+            %            the type provided or instance of this class.
+            %            The class name have to be among the
+            %            names of the registered accessors (classes present
+            %            in obj.supported_accessors_ list.)
+            % Empty facc_name string resets factory to its default values.
+            %
+            % Returns:
+            % Modified sqw_formats_factory singleton with new file accessor
+            % set as default for input type.
+            % get_pref_access method invoked without parameters would also
+            % return the file accessor, specified as input of this method.
+            set_pref_accessor_(obj,type,facc_name);
         end
         %
         function is_compartible = check_compatibility(~,obj1,obj2)
@@ -273,46 +220,22 @@ classdef sqw_formats_factory < handle
                 is_compartible = true;
             end
         end
-
         %
         function obj_list = get.supported_accessors(obj)
             obj_list = obj.supported_accessors_;
         end
     end
     methods(Static)
-        function [sqw_type,orig_type] = get_sqw_type(sqw_obj)
+        function [in_type,orig_type] = get_sqw_type(in_obj)
             % determine the type of sqw object based on data in the header
             % return value options are:
-            %      sqw_type == 'none' - the header is empty, there is no efix/emode
-            %                           data to determine the type
-            %      sqw_type == 'sqw2' - the header has emode==2 and
-            %                           numel(efix)>1
-            %      sqw_type == 'sqw'  - none of the above so using the
-            %                           class of obj i.e. sqw
-            orig_type = class(sqw_obj);
-            sqw_type = orig_type;
-            if strcmp(orig_type,'sqw')
-                header =sqw_obj.experiment_info;
-                if isa(header, 'Experiment')
-                    if isempty(header.expdata)
-                        sqw_type = 'none';
-                        return;
-                    else
-                        header = header.expdata(1);
-                    end
-                elseif isempty(header)
-                    sqw_type = 'none';
-                    return;
-                end
-                emode = header.emode;
-                if emode == 2
-                    nefix = numel(header.efix);
-                    if nefix>1
-                        sqw_type = 'sqw2';
-                    end
-                end
-            end
+            %      in_type == 'none' - the header is empty, there is no efix/emode
+            %                          data to determine the type
+            %      in_type == 'sqw2' - the header has emode==2 and
+            %                          numel(efix)>1
+            %      in_type == 'sqw'  - none of the above so using the
+            %                          class of obj i.e. sqw
+            [in_type,orig_type] = get_sqw_type_(in_obj);
         end
-
     end
 end

--- a/horace_core/sqw/file_io/class_helpers/@pix_data_block/private/put_bindata_in_file_.m
+++ b/horace_core/sqw/file_io/class_helpers/@pix_data_block/private/put_bindata_in_file_.m
@@ -24,7 +24,7 @@ obj.check_write_error(fid,'num_pixels');
 if isnumeric(obj_data.data)&&~isempty(obj_data.data)
     block_size = config_store.instance().get_value('hor_config','mem_chunk_size');
     % apparently faster then writing whole large array and does not crash
-    % some FS drivers.
+    % some Linux FS drivers.
     data  = obj_data.data;
     for istart=1:block_size:npix
         iend  = min(istart+block_size-1,npix);

--- a/horace_core/sqw/file_io/class_helpers/@pix_data_block/private/put_bindata_in_file_.m
+++ b/horace_core/sqw/file_io/class_helpers/@pix_data_block/private/put_bindata_in_file_.m
@@ -19,18 +19,22 @@ obj.check_write_error(fid,'num pix rows');
 npix  = uint64(obj_data.npix);
 fwrite(fid,npix,'uint64');
 obj.check_write_error(fid,'num_pixels');
-
 %
 if isnumeric(obj_data.data)&&~isempty(obj_data.data)
+    obj.move_to_position(fid,obj.pix_position);
+
     block_size = config_store.instance().get_value('hor_config','mem_chunk_size');
     % apparently faster then writing whole large array and does not crash
     % some Linux FS drivers.
+    n_blocks = npix/block_size;
     data  = obj_data.data;
     for istart=1:block_size:npix
         iend  = min(istart+block_size-1,npix);
         block = single(data(:,istart:iend));
-        fwrite(fid,block,'float32');
+        fwrite(fid,block(:),'float32');
+        obj.check_write_error(fid, ...
+            sprintf('writing pixel data block %d out of %g',istart,n_blocks));
     end
-    obj.check_write_error(fid,'pixel data');
+
 end
 %

--- a/horace_core/sqw/file_io/class_helpers/@pix_data_block/private/put_bindata_in_file_.m
+++ b/horace_core/sqw/file_io/class_helpers/@pix_data_block/private/put_bindata_in_file_.m
@@ -19,9 +19,17 @@ obj.check_write_error(fid,'num pix rows');
 npix  = uint64(obj_data.npix);
 fwrite(fid,npix,'uint64');
 obj.check_write_error(fid,'num_pixels');
+
 %
 if isnumeric(obj_data.data)&&~isempty(obj_data.data)
-    fwrite(fid,single(obj_data.data(:)),'single');
+    block_size = config_store.instance().get_value('hor_config','mem_chunk_size');
+    % apparently faster then writing whole large array and does not crash
+    % some FS drivers.
+    data  = obj_data.data;
+    for istart=1:block_size:npix
+        iend  = min(istart+block_size-1,npix);
+        fwrite(fid,single(data(:,istart:iend)),'float32');
+    end
     obj.check_write_error(fid,'pixel data');
 end
 %

--- a/horace_core/sqw/file_io/class_helpers/@pix_data_block/private/put_bindata_in_file_.m
+++ b/horace_core/sqw/file_io/class_helpers/@pix_data_block/private/put_bindata_in_file_.m
@@ -28,7 +28,8 @@ if isnumeric(obj_data.data)&&~isempty(obj_data.data)
     data  = obj_data.data;
     for istart=1:block_size:npix
         iend  = min(istart+block_size-1,npix);
-        fwrite(fid,single(data(:,istart:iend)),'float32');
+        block = single(data(:,istart:iend));
+        fwrite(fid,block,'float32');
     end
     obj.check_write_error(fid,'pixel data');
 end

--- a/horace_core/sqw/file_io/class_helpers/@pix_data_block/private/put_bindata_in_file_.m
+++ b/horace_core/sqw/file_io/class_helpers/@pix_data_block/private/put_bindata_in_file_.m
@@ -21,20 +21,14 @@ fwrite(fid,npix,'uint64');
 obj.check_write_error(fid,'num_pixels');
 %
 if isnumeric(obj_data.data)&&~isempty(obj_data.data)
-    obj.move_to_position(fid,obj.pix_position);
-
     block_size = config_store.instance().get_value('hor_config','mem_chunk_size');
-    % apparently faster then writing whole large array and does not crash
+    % apparently faster then writing whole large array and should not crash
     % some Linux FS drivers.
-    n_blocks = npix/block_size;
     data  = obj_data.data;
     for istart=1:block_size:npix
         iend  = min(istart+block_size-1,npix);
         block = single(data(:,istart:iend));
         fwrite(fid,block(:),'float32');
-        obj.check_write_error(fid, ...
-            sprintf('writing pixel data block %d out of %g',istart,n_blocks));
     end
-
+    obj.check_write_error(fid,'writing pixel data block');
 end
-%

--- a/horace_core/sqw/file_io/sqw_formats_factory.m
+++ b/horace_core/sqw/file_io/sqw_formats_factory.m
@@ -32,9 +32,6 @@ classdef sqw_formats_factory < handle
     %
     %
     properties(Access=private) %
-        % Number (in the registered accessors list) of file accessor
-        % to choose for new binary files
-        preferred_accessor_num_ = 1;
         % List of registered file accessors:
         % Add all new file readers which inherit from sqw_file_interface and horace_binfile_interface
         % to this list in the order of expected frequency of their appearance.
@@ -48,14 +45,21 @@ classdef sqw_formats_factory < handle
             faccess_dnd_v2(), ...
             faccess_sqw_v3_2(), ...
             faccess_sqw_prototype()};
-        %
+        %------------------------------------------------------------------
+        % Loader selection rules:
+        %------------------------------------------------------------------
+        % Number (in the registered accessors list) of file accessor
+        % to choose for new binary files by defaul, when no input object is
+        % provided
+        preferred_accessor_num_ = 1;
         % Rules for saving different classes, defines the preferred loader
-        % for saving the class from the list:
-        % sqw2 corresponds to sqw file in indirect mode with efixed being
-        % array
+        % for saving the class from the list. The same as above but when a
+        % object provided as input.
         written_types_ = {'DnDBase','sqw','sqw2','dnd','d0d','d1d','d2d','d3d','d4d'};
+        % sqw2 corresponds to sqw file in indirect mode with efixed being
+        % array.
         % number of loader in the list of loaders above to use for saving
-        % correspondent class.
+        % class, defined by written_types_ string.
         access_to_type_ind_ = {2,1,1,2,2,2,2,2,2};
         types_map_ ;
     end


### PR DESCRIPTION
This contains various debugging changes and modifications done in attempt to fix IDAAAS kernel crash when running gen_sqw job.
Though the reason for crash was the issue in kernel, here I put bunch of convenience changes and fixes made during debugging, namely:
1) logging while running parallel framework. Previous code was botching FUSE file system. In addition, it is exteamly inconvenient to see and look at dots. User wants to get estimate when his parallel job completes and he wants this estimate ASAP, not in half an hour.
2) presumably faster pix writer
3) log while gen_sqw bulds rundata files. Before it was sitting telling user nothing for long time when sqw is build from number of nxspe files. 
4) Possibility to modify `sqw_format_factory` to have different default file writer for specified objects. Previous file accessors do not work entirely correctly but may be used successfully in number of differen situations. 
5) bunch of small formatting and convenience changes. 