### PR TITLE
projection scales

### DIFF
--- a/_test/test_dnd_class/test_dnd_cut.m
+++ b/_test/test_dnd_class/test_dnd_cut.m
@@ -29,7 +29,7 @@ classdef test_dnd_cut< TestCaseWithSave
         function test_2D_to2D_cut_with_cylinder_proj(obj)
             clOb = set_temporary_warning('off','HORACE:runtime_error');
 
-            proj = cylinder_proj();
+            proj = cylinder_proj('type','aad');
             cut_range = obj.d2d_obj.targ_range(proj);
             w2 = cut(obj.d2d_obj,proj,[1,0.1,2], ...
                 [113,114],[cut_range(1,3),0.1,cut_range(2,3)],[-0.25,0.25]);
@@ -41,7 +41,7 @@ classdef test_dnd_cut< TestCaseWithSave
         function test_2D_to2D_cut_with_spher_proj(obj)
             clOb = set_temporary_warning('off','HORACE:runtime_error');
 
-            proj = sphere_proj();
+            proj = sphere_proj('type','add');
             cut_range = obj.d2d_obj.targ_range(proj);
             w2 = cut(obj.d2d_obj,proj,[1,0.1,2], ...
                 [113,114],[cut_range(1,3),0.1,cut_range(2,3)],[-0.25,0.25]);

--- a/_test/test_transformation/test_cylinder_proj.m
+++ b/_test/test_transformation/test_cylinder_proj.m
@@ -12,34 +12,29 @@ classdef test_cylinder_proj<TestCase
             this=this@TestCase(name);
         end
         %------------------------------------------------------------------
-        function test_scales_l(~)
-            proj = cylinder_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','ldd');
-            % length of c*
-            assertElementsAlmostEqual(proj.img_scales,[2/3,180/pi,180/pi]);
+        function test_scales_kl(~)
+            proj = cylinder_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','kld');
+            % length of b*,c*
+            assertElementsAlmostEqual(proj.img_scales,[1,2/3,180/pi]);
         end
-        function test_scales_k(~)
-            proj = cylinder_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','kdd');
-            % length of b*
-            assertElementsAlmostEqual(proj.img_scales,[1,180/pi,180/pi]);
-        end
-        function test_scales_h(~)
-            proj = cylinder_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','hdd');
-            % length of a*
-            assertElementsAlmostEqual(proj.img_scales,[2,180/pi,180/pi]);
+        function test_scales_hk(~)
+            proj = cylinder_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','hkd');
+            % length of a*,b
+            assertElementsAlmostEqual(proj.img_scales,[2,1,180/pi]);
         end
 
         function test_scales_r(~)
-            proj = cylinder_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','rdd');
+            proj = cylinder_proj([1,1,1],[-1,1,0],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','rrd');
             % length of max|u*[e_h,e_k,e_l]| == 1
-            assertElementsAlmostEqual(proj.img_scales,[2,180/pi,180/pi]);
+            assertElementsAlmostEqual(proj.img_scales,[2,1,180/pi]);
         end
         function test_scales_p(~)
-            proj = cylinder_proj([1,1,0],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','pdd');
+            proj = cylinder_proj([1,1,0],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','ppd');
             % length of |u| == 1
-            assertElementsAlmostEqual(proj.img_scales,[sqrt(2^2+1),180/pi,180/pi]);
+            assertElementsAlmostEqual(proj.img_scales,[sqrt(2^2+1),1,180/pi]);
         end
         function test_scales_a(~)
-            proj = cylinder_proj([1,1,0],'angdeg',90,'type','arr');
+            proj = cylinder_proj([1,1,0],'angdeg',90,'type','aar');
             % length of |u| == 1
             assertElementsAlmostEqual(proj.img_scales,[1,1,1]);
         end        

--- a/_test/test_transformation/test_cylinder_proj.m
+++ b/_test/test_transformation/test_cylinder_proj.m
@@ -161,7 +161,7 @@ classdef test_cylinder_proj<TestCase
         end
         %
         function test_set_direction_110_cub(~)
-            proj = cylinder_proj([1,-1,0],[1,1,0],'alatt',2*pi,'angdeg',90);
+            proj = cylinder_proj([1,-1,0],[1,1,0],'alatt',2*pi,'angdeg',90,'type','aad');
             assertEqual(proj.u,[1,-1,0])
             assertEqual(proj.v,[1, 1,0])
             ref_vec = [...
@@ -177,7 +177,7 @@ classdef test_cylinder_proj<TestCase
         end
         %
         function test_set_direction_010(~)
-            proj = cylinder_proj([0,1,0],[1,0,0]);
+            proj = cylinder_proj([0,1,0],[1,0,0],'type','aad');
             assertEqual(proj.u,[0,1,0])
             assertEqual(proj.v,[1,0,0])
             ref_vec = [...
@@ -191,7 +191,7 @@ classdef test_cylinder_proj<TestCase
         end
         %
         function test_set_direction_001(~)
-            proj = cylinder_proj([0,0,1],[1,0,0]);
+            proj = cylinder_proj([0,0,1],[1,0,0],'type','aad');
             assertEqual(proj.u,[0,0,1])
             assertEqual(proj.v,[1,0,0])
             ref_vec = [...
@@ -205,7 +205,7 @@ classdef test_cylinder_proj<TestCase
         end
 
         function test_empty_constructor(~)
-            proj = cylinder_proj();
+            proj = cylinder_proj('type','aad');
             assertEqual(proj.u,[1,0,0]);
             assertEqual(proj.v,[0,1,0])
 

--- a/_test/test_transformation/test_cylinder_proj.m
+++ b/_test/test_transformation/test_cylinder_proj.m
@@ -11,7 +11,38 @@ classdef test_cylinder_proj<TestCase
             end
             this=this@TestCase(name);
         end
+        %------------------------------------------------------------------
+        function test_scales_l(~)
+            proj = cylinder_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','ldd');
+            % length of c*
+            assertElementsAlmostEqual(proj.img_scales,[2/3,180/pi,180/pi]);
+        end
+        function test_scales_k(~)
+            proj = cylinder_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','kdd');
+            % length of b*
+            assertElementsAlmostEqual(proj.img_scales,[1,180/pi,180/pi]);
+        end
+        function test_scales_h(~)
+            proj = cylinder_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','hdd');
+            % length of a*
+            assertElementsAlmostEqual(proj.img_scales,[2,180/pi,180/pi]);
+        end
 
+        function test_scales_r(~)
+            proj = cylinder_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','rdd');
+            % length of max|u*[e_h,e_k,e_l]| == 1
+            assertElementsAlmostEqual(proj.img_scales,[2,180/pi,180/pi]);
+        end
+        function test_scales_p(~)
+            proj = cylinder_proj([1,1,0],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','pdd');
+            % length of |u| == 1
+            assertElementsAlmostEqual(proj.img_scales,[sqrt(2^2+1),180/pi,180/pi]);
+        end
+        function test_scales_a(~)
+            proj = cylinder_proj([1,1,0],'angdeg',90,'type','arr');
+            % length of |u| == 1
+            assertElementsAlmostEqual(proj.img_scales,[1,1,1]);
+        end        
         %------------------------------------------------------------------
         function test_coord_transf_PixData_plus_offset(~)
             proj = cylinder_proj('alatt',2*pi,'angdeg',90);

--- a/_test/test_transformation/test_proj_captions.m
+++ b/_test/test_transformation/test_proj_captions.m
@@ -46,7 +46,7 @@ classdef test_proj_captions<TestCase
             assertEqual(title_pax{2},'\phi (rad)');
 
             assertEqual(numel(title_iax),2);
-            assertEqual(title_iax{1},['0 \leq Q_{tr} \leq 8 in ',char(197),'^{-1}']);
+            assertEqual(title_iax{1},['0 \leq Q_{\perp} \leq 8 in ',char(197),'^{-1}']);
             assertEqual(title_iax{2},'-5 \leq En \leq 20 in meV');
 
             assertEqual(numel(display_pax),2);
@@ -54,7 +54,7 @@ classdef test_proj_captions<TestCase
             assertEqual(display_pax{2}, '\phi = -3.06:0.16:3.06 in rad');
 
             assertEqual(numel(display_iax),2);
-            assertEqual(display_iax{1},['0 =< Q_{tr} =< 8 in ',char(197),'^{-1}']);
+            assertEqual(display_iax{1},['0 =< Q_{\perp} =< 8 in ',char(197),'^{-1}']);
             assertEqual(display_iax{2}, '-5 =< En =< 20 in meV');
 
             assertEqual(energy_axis,4);
@@ -78,7 +78,7 @@ classdef test_proj_captions<TestCase
             assertTrue(isempty(title_main{1}));
 
             assertEqual(numel(title_pax),2);
-            assertEqual(title_pax{1},['Q_{tr} (',char(197),'^{-1})']);
+            assertEqual(title_pax{1},['Q_{\perp} (',char(197),'^{-1})']);
             assertEqual(title_pax{2},'En (meV)');
 
             assertEqual(numel(title_iax),2);
@@ -86,7 +86,7 @@ classdef test_proj_captions<TestCase
             assertEqual(title_iax{2},'-3.14 \leq \phi \leq 3.14 in rad');
 
             assertEqual(numel(display_pax),2);
-            assertEqual(display_pax{1},['Q_{tr} = 0.08:0.16:7.92 in ',char(197)','^{-1}']);
+            assertEqual(display_pax{1},['Q_{\perp} = 0.08:0.16:7.92 in ',char(197)','^{-1}']);
             assertEqual(display_pax{2},'En = -9.5:1:29.5 in meV');
 
             assertEqual(numel(display_iax),2);
@@ -117,7 +117,7 @@ classdef test_proj_captions<TestCase
             assertEqual(title_pax{2},'\phi^{o}');
 
             assertEqual(numel(title_iax),2);
-            assertEqual(title_iax{1},['0 \leq Q_{tr} \leq 8 in ',char(197),'^{-1}']);
+            assertEqual(title_iax{1},['0 \leq Q_{\perp} \leq 8 in ',char(197),'^{-1}']);
             assertEqual(title_iax{2},'-5 \leq En \leq 20 in meV');
 
             assertEqual(numel(display_pax),2);
@@ -125,7 +125,7 @@ classdef test_proj_captions<TestCase
             assertEqual(display_pax{2}, '\phi = -176:9:176 in ^{o}');
 
             assertEqual(numel(display_iax),2);
-            assertEqual(display_iax{1},['0 =< Q_{tr} =< 8 in ',char(197),'^{-1}']);
+            assertEqual(display_iax{1},['0 =< Q_{\perp} =< 8 in ',char(197),'^{-1}']);
             assertEqual(display_iax{2}, '-5 =< En =< 20 in meV');
 
             assertEqual(energy_axis,4);
@@ -148,7 +148,7 @@ classdef test_proj_captions<TestCase
             assertTrue(isempty(title_main{1}));
 
             assertEqual(numel(title_pax),2);
-            assertEqual(title_pax{1},['Q_{tr} (',char(197),'^{-1})']);
+            assertEqual(title_pax{1},['Q_{\perp} (',char(197),'^{-1})']);
             assertEqual(title_pax{2},'En (meV)');
 
             assertEqual(numel(title_iax),2);
@@ -156,7 +156,7 @@ classdef test_proj_captions<TestCase
             assertEqual(title_iax{2},'-180 \leq \phi \leq 180 in ^{o}');
 
             assertEqual(numel(display_pax),2);
-            assertEqual(display_pax{1},['Q_{tr} = 0.08:0.16:7.92 in ',char(197),'^{-1}']);
+            assertEqual(display_pax{1},['Q_{\perp} = 0.08:0.16:7.92 in ',char(197),'^{-1}']);
             assertEqual(display_pax{2},'En = -9.5:1:29.5 in meV');
 
             assertEqual(numel(display_iax),2);

--- a/_test/test_transformation/test_proj_captions.m
+++ b/_test/test_transformation/test_proj_captions.m
@@ -30,7 +30,7 @@ classdef test_proj_captions<TestCase
             range = [0,0,-pi,-5;8,pi/2,pi,20];
             dat.do_check_combo_arg = false;
             dat.axes = cylinder_axes('img_range',range,'nbins_all_dims',[1,50,40,1],'axes_units','aar');
-            dat.proj = cylinder_proj();
+            dat.proj = cylinder_proj('type','aad');
             dat.do_check_combo_arg = true;
             dat = dat.check_combo_arg();
 
@@ -66,7 +66,7 @@ classdef test_proj_captions<TestCase
             dat.do_check_combo_arg = false;
             dat.axes = cylinder_axes('img_range',range,'nbins_all_dims',[50,1,1,40], ...
                 'axes_units','aar');
-            dat.proj = cylinder_proj();
+            dat.proj = cylinder_proj('type','aar');
             dat.do_check_combo_arg = true;
             dat = dat.check_combo_arg();
 
@@ -101,7 +101,7 @@ classdef test_proj_captions<TestCase
             range = [0,0,-180,-5;8,90,180,20];
             dat.do_check_combo_arg = false;
             dat.axes = cylinder_axes('img_range',range,'nbins_all_dims',[1,50,40,1]);
-            dat.proj = cylinder_proj();
+            dat.proj = cylinder_proj('type','aad');
             dat.do_check_combo_arg = true;
             dat = dat.check_combo_arg();
 
@@ -136,7 +136,7 @@ classdef test_proj_captions<TestCase
             range = [0,0,-180,-10;8,90,180,30];
             dat.do_check_combo_arg = false;
             dat.axes = cylinder_axes('img_range',range,'nbins_all_dims',[50,1,1,40]);
-            dat.proj = cylinder_proj();
+            dat.proj = cylinder_proj('type','aar');
             dat.do_check_combo_arg = true;
             dat = dat.check_combo_arg();
 
@@ -210,7 +210,7 @@ classdef test_proj_captions<TestCase
             dat.do_check_combo_arg = false;
             dat.axes = sphere_axes('img_range',range,'nbins_all_dims',[50,1,1,40], ...
                 'axes_units','arr');
-            dat.proj = sphere_proj();
+            dat.proj = sphere_proj('type','add');
             dat.do_check_combo_arg = true;
             dat = dat.check_combo_arg();
 
@@ -245,7 +245,7 @@ classdef test_proj_captions<TestCase
             range = [0,0,-180,-5;8,90,180,20];
             dat.do_check_combo_arg = false;
             dat.axes = sphere_axes('img_range',range,'nbins_all_dims',[1,50,40,1]);
-            dat.proj = sphere_proj();
+            dat.proj = sphere_proj('type','add');
             dat.do_check_combo_arg = true;
             dat = dat.check_combo_arg();
 
@@ -280,7 +280,7 @@ classdef test_proj_captions<TestCase
             range = [0,0,-180,-10;8,90,180,30];
             dat.do_check_combo_arg = false;
             dat.axes = sphere_axes('img_range',range,'nbins_all_dims',[50,1,1,40]);
-            dat.proj = sphere_proj();
+            dat.proj = sphere_proj('type','add');
             dat.do_check_combo_arg = true;
             dat = dat.check_combo_arg();
 

--- a/_test/test_transformation/test_sphere_proj.m
+++ b/_test/test_transformation/test_sphere_proj.m
@@ -11,7 +11,38 @@ classdef test_sphere_proj<TestCase
             end
             this=this@TestCase(name);
         end
-
+        %------------------------------------------------------------------
+        function test_scales_l(~)
+            proj = sphere_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','ldd');
+            % length of c*
+            assertElementsAlmostEqual(proj.img_scales,[2/3,180/pi,180/pi]);
+        end                     
+        function test_scales_k(~)
+            proj = sphere_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','kdd');
+            % length of b*
+            assertElementsAlmostEqual(proj.img_scales,[1,180/pi,180/pi]);
+        end             
+        function test_scales_h(~)
+            proj = sphere_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','hdd');
+            % length of a*
+            assertElementsAlmostEqual(proj.img_scales,[2,180/pi,180/pi]);
+        end     
+        
+        function test_scales_r(~)
+            proj = sphere_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','rdd');
+            % length of max|u*[e_h,e_k,e_l]| == 1
+            assertElementsAlmostEqual(proj.img_scales,[2,180/pi,180/pi]);
+        end        
+        function test_scales_p(~)
+            proj = sphere_proj([1,1,0],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','pdd');
+            % length of |u| == 1
+            assertElementsAlmostEqual(proj.img_scales,[sqrt(2^2+1),180/pi,180/pi]);
+        end
+        function test_scales_a(~)
+            proj = sphere_proj([1,1,0],'angdeg',90,'type','arr');
+            % length of |u| == 1
+            assertElementsAlmostEqual(proj.img_scales,[1,1,1]);
+        end        
         %------------------------------------------------------------------
         function test_coord_transf_PixData_plus_offset(~)
             proj = sphere_proj('alatt',2*pi,'angdeg',90);

--- a/_test/test_transformation/test_sphere_proj.m
+++ b/_test/test_transformation/test_sphere_proj.m
@@ -167,7 +167,7 @@ classdef test_sphere_proj<TestCase
         end
 
         function test_set_direction_110_cub(~)
-            proj = sphere_proj([1,-1,0],[1,1,0],'alatt',2*pi,'angdeg',90);
+            proj = sphere_proj([1,-1,0],[1,1,0],'alatt',2*pi,'angdeg',90,'type','add');
             assertEqual(proj.u,[1,-1,0])
             assertEqual(proj.v,[1, 1,0])
             ref_vec = [...
@@ -185,7 +185,7 @@ classdef test_sphere_proj<TestCase
 
 
         function test_set_direction_010(~)
-            proj = sphere_proj([0,1,0],[1,0,0]);
+            proj = sphere_proj([0,1,0],[1,0,0],'type','add');
             assertEqual(proj.u,[0,1,0])
             assertEqual(proj.v,[1,0,0])
             ref_vec = [...
@@ -200,7 +200,7 @@ classdef test_sphere_proj<TestCase
 
 
         function test_set_direction_001(~)
-            proj = sphere_proj([0,0,1],[1,0,0]);
+            proj = sphere_proj([0,0,1],[1,0,0],'type','add');
             assertEqual(proj.u,[0,0,1])
             assertEqual(proj.v,[1,0,0])
             ref_vec = [...
@@ -214,7 +214,7 @@ classdef test_sphere_proj<TestCase
         end
 
         function test_empty_constructor(~)
-            proj = sphere_proj();
+            proj = sphere_proj('type','add');
             assertEqual(proj.u,[1,0,0]);
             assertEqual(proj.v,[0,1,0])
 

--- a/_test/test_transformation/test_sphere_proj.m
+++ b/_test/test_transformation/test_sphere_proj.m
@@ -16,23 +16,23 @@ classdef test_sphere_proj<TestCase
             proj = sphere_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','ldd');
             % length of c*
             assertElementsAlmostEqual(proj.img_scales,[2/3,180/pi,180/pi]);
-        end                     
+        end
         function test_scales_k(~)
             proj = sphere_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','kdd');
             % length of b*
             assertElementsAlmostEqual(proj.img_scales,[1,180/pi,180/pi]);
-        end             
+        end
         function test_scales_h(~)
             proj = sphere_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','hdd');
             % length of a*
             assertElementsAlmostEqual(proj.img_scales,[2,180/pi,180/pi]);
-        end     
-        
+        end
+
         function test_scales_r(~)
             proj = sphere_proj([1,1,1],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','rdd');
             % length of max|u*[e_h,e_k,e_l]| == 1
             assertElementsAlmostEqual(proj.img_scales,[2,180/pi,180/pi]);
-        end        
+        end
         function test_scales_p(~)
             proj = sphere_proj([1,1,0],'alatt',[pi,2*pi,3*pi],'angdeg',90,'type','pdd');
             % length of |u| == 1
@@ -42,7 +42,7 @@ classdef test_sphere_proj<TestCase
             proj = sphere_proj([1,1,0],'angdeg',90,'type','arr');
             % length of |u| == 1
             assertElementsAlmostEqual(proj.img_scales,[1,1,1]);
-        end        
+        end
         %------------------------------------------------------------------
         function test_coord_transf_PixData_plus_offset(~)
             proj = sphere_proj('alatt',2*pi,'angdeg',90);

--- a/_test/test_transformation/test_targ_ranges.m
+++ b/_test/test_transformation/test_targ_ranges.m
@@ -31,7 +31,7 @@ classdef test_targ_ranges < TestCase
             clOb = set_temporary_warning('off','HORACE:targ_range','HORACE:push_warning');
 
             img_block = sqw_samp.data;
-            targ_proj = cylinder_proj();
+            targ_proj = cylinder_proj('type','aad');
             warning('HORACE:push_warning','issue warning which pushes ')
             targ_range = img_block.targ_range(targ_proj);
             [~,wid] = lastwarn();
@@ -53,7 +53,7 @@ classdef test_targ_ranges < TestCase
             clOb = set_temporary_warning('off','HORACE:targ_range','HORACE:push_warning');
 
             img_block = sqw_samp.data;
-            targ_proj = sphere_proj();
+            targ_proj = sphere_proj('type','add');
             warning('HORACE:push_warning','issue warning which pushes ')
             targ_range = img_block.targ_range(targ_proj);
             [~,wid] = lastwarn();
@@ -170,7 +170,7 @@ classdef test_targ_ranges < TestCase
 
             dnd_obj = DnDBase.dnd(ax,proj);
 
-            targ_proj = cylinder_proj([1,1,0],[1,-1,0],'offset',[1,0,0]);
+            targ_proj = cylinder_proj([1,1,0],[1,-1,0],'offset',[1,0,0],'type','aad');
 
             range = dnd_obj.targ_range(targ_proj);
             ref_range = [...

--- a/horace_core/sqw/@SQWDnDBase/private/cut_parse_inputs_.m
+++ b/horace_core/sqw/@SQWDnDBase/private/cut_parse_inputs_.m
@@ -229,13 +229,12 @@ if opt.proj_given
     % There are currently no situations where we want to define lattice in
     % projection. so always take lattice from the source object
     source_proj = obj.proj;
-    %if ~proj.alatt_defined
     proj.do_check_combo_arg = false;
+
     proj.alatt = source_proj.alatt;
-    %end
-    %if ~proj.angdeg_defined
     proj.angdeg = source_proj.angdeg;
-    proj.do_check_combo_arg = true;    
+
+    proj.do_check_combo_arg = true;
     proj = proj.check_combo_arg();
     %end
 
@@ -393,7 +392,7 @@ elseif numel(pbin_given) == 1
         new_axis = paxis;
     else
         n_steps = floor((paxis(end)-paxis(1))/pbin_given);
-        paxis_end = paxis(1)+pbin_given*n_steps;        
+        paxis_end = paxis(1)+pbin_given*n_steps;
         if paxis(end)-paxis_end  > 4*eps('single')
             n_steps = n_steps+1;
         end

--- a/horace_core/sqw/axes_blocks/@cylinder_axes/cylinder_axes.m
+++ b/horace_core/sqw/axes_blocks/@cylinder_axes/cylinder_axes.m
@@ -88,7 +88,7 @@ classdef cylinder_axes < AxesBlockBase
             % empty spherical range:
             obj.img_range_ = obj.default_img_range_;
 
-            obj.label = {'Q_{tr}','Q_{||}','\phi','En'};
+            obj.label = {'Q_{\perp}','Q_{||}','\phi','En'};
             obj.type_ = 'aade';
             obj.changes_aspect_ratio_ = false;
             if nargin == 0

--- a/horace_core/sqw/axes_blocks/@cylinder_axes/cylinder_axes.m
+++ b/horace_core/sqw/axes_blocks/@cylinder_axes/cylinder_axes.m
@@ -32,14 +32,16 @@ classdef cylinder_axes < AxesBlockBase
         % expressed in Anstrom, radian, degree, meV. The key is the type
         % letter present in cylinder_projection and the value is the unit
         % caption.
-        capt_units = containers.Map({'a','r','d','e'}, ...
-            {[char(197),'^{-1}'],'rad','^{o}','meV'})
+        capt_units = containers.Map({'a','p','r','h','k','l','r','d','e'},{...
+            [char(197),'^{-1}'],[char(197),'^{-1}'],[char(197),'^{-1}'], ...
+            [char(197),'^{-1}'],[char(197),'^{-1}'],[char(197),'^{-1}'], ...
+            'rad','^{o}','meV'})
         default_img_range_ =[ ...
             0,-1,-180,-1;...  % the range, a object defined with dimensions
             1  1, 180, 1];    % only would have
         % what symbols axes_units can have
-        types_available_ = {'a','a',{'d','r'},'e'};
-
+        types_available_ = {{'a','p','r','h','k','l'},{'a','p','r','h','k','l'},...
+            {'d','r'},'e'};
     end
     properties(Dependent)
         % if angular dimensions of the axes are expressed in radians or degrees

--- a/horace_core/sqw/axes_blocks/@cylinder_axes/private/data_plot_titles_.m
+++ b/horace_core/sqw/axes_blocks/@cylinder_axes/private/data_plot_titles_.m
@@ -77,12 +77,15 @@ for j=1:4
     ax_type = type(j);
     angular_unit = (j == 3);
     scale_present =  (abs(img_scales(j)-1) > small);
-    
-    in_totvector{j} =  ['in ',obj.capt_units(ax_type)];
+    if scale_present && ~angular_unit
+        in_totvector{j} = sprintf('in %.3g %s',img_scales(j),obj.capt_units(ax_type));            
+    else
+        in_totvector{j} =  ['in ',obj.capt_units(ax_type)];        
+    end
     if ismember(j,pax) % pax
         ipax = find(j==pax(dax));
         if scale_present && ~angular_unit
-            title_pax{ipax} = sprintf('%s in %.3g %s',label{j},img_scales(j),obj.capt_units(ax_type));            
+            title_pax{ipax} = sprintf('%s %s',label{j},in_totvector{j});            
         else
             if ax_type == 'd'
                 title_pax{ipax} = sprintf('%s%s',label{j},obj.capt_units(ax_type));

--- a/horace_core/sqw/axes_blocks/@cylinder_axes/private/data_plot_titles_.m
+++ b/horace_core/sqw/axes_blocks/@cylinder_axes/private/data_plot_titles_.m
@@ -75,10 +75,13 @@ in_totvector=cell(1,4);
 % Create titling
 for j=1:4
     ax_type = type(j);
+    angular_unit = (j == 3);
+    scale_present =  (abs(img_scales(j)-1) > small);
+    
     in_totvector{j} =  ['in ',obj.capt_units(ax_type)];
     if ismember(j,pax) % pax
         ipax = find(j==pax(dax));
-        if abs(img_scales(j)-1) > small && j~=3
+        if scale_present && ~angular_unit
             title_pax{ipax} = sprintf('%s in %.3g %s',label{j},img_scales(j),obj.capt_units(ax_type));            
         else
             if ax_type == 'd'

--- a/horace_core/sqw/axes_blocks/@sphere_axes/private/data_plot_titles_.m
+++ b/horace_core/sqw/axes_blocks/@sphere_axes/private/data_plot_titles_.m
@@ -75,17 +75,23 @@ in_totvector=cell(1,4);
 % Create titling
 for j=1:4
     ax_type = type(j);
-    in_totvector{j} =  sprintf('in %s',obj.capt_units(ax_type));
+    angular_unit = (j == 2 || j == 3);
+    scale_present =  (abs(img_scales(j)-1) > small);
+    if scale_present && ~angular_unit
+        in_totvector{j} =  sprintf('in %.3g %s',img_scales(j),obj.capt_units(ax_type));
+    else
+        in_totvector{j} =  sprintf('in %s',obj.capt_units(ax_type));
+    end
     if ismember(j,pax) % pax
         ipax = find(j==pax(dax));
-        if j == 2 || j == 3
+        if angular_unit 
             if ax_type == 'd'
                 title_pax{ipax} = sprintf('%s%s',label{j},obj.capt_units(ax_type));
             else
                 title_pax{ipax} = sprintf('%s (%s)',label{j},obj.capt_units(ax_type));
             end
         else
-            if abs(img_scales(j)-1) > small
+            if scale_present
                 title_pax{ipax} = sprintf('%s in %.3g %s',label{j},img_scales(j),obj.capt_units(ax_type));
             else
                 title_pax{ipax} = sprintf('%s (%s)',label{j},obj.capt_units(ax_type));

--- a/horace_core/sqw/axes_blocks/@sphere_axes/sphere_axes.m
+++ b/horace_core/sqw/axes_blocks/@sphere_axes/sphere_axes.m
@@ -32,13 +32,15 @@ classdef sphere_axes < AxesBlockBase
         % expressed in Anstrom, radian, degree, meV. The key is the type
         % letter present in sphere_projection and the value is the unit
         % caption.
-        capt_units = containers.Map({'a','r','d','e'}, ...
-            {[char(197),'^{-1}'],'rad','^{o}','meV'})
+        capt_units = containers.Map({'a','p','r','h','k','l','r','d','e'},{...
+            [char(197),'^{-1}'],[char(197),'^{-1}'],[char(197),'^{-1}'], ...
+            [char(197),'^{-1}'],[char(197),'^{-1}'],[char(197),'^{-1}'], ...
+            'rad','^{o}','meV'})
         default_img_range_ =[ ...
             0,   0, -180, -1;...  % the range, a object defined with dimensions
             1 ,180,  180,  1];    % only would have
         % what symbols axes_units can have
-        types_available_ = {'a',{'d','r'},{'d','r'},'e'};
+        types_available_ = {{'a','p','r','h','k','l'},{'d','r'},{'d','r'},'e'};
 
     end
     properties(Dependent)

--- a/horace_core/sqw/coord_transform/@CurveProjBase/private/check_combo_arg_.m
+++ b/horace_core/sqw/coord_transform/@CurveProjBase/private/check_combo_arg_.m
@@ -34,9 +34,11 @@ e3 = e3/ne3; % should be 1 anyway, just in case to reduce round-off errors
 e2 = cross(e3,uv_norm(:,1));
 
 transf_mat = [[uv_norm(:,1);0],[e2/norm(e2);0],[e3;0],[0;0;0;1]];
-%TODO:  #954 scientific validation needed
+%
 obj.pix_to_matlab_transf_ = obj.hor2matlab_transf_*transf_mat';
 
 obj.img_scales_cache_ = [];
-[~,obj] = get_img_scales(obj);
+if obj.alatt_defined && obj.angdeg_defined
+    [~,obj] = get_img_scales(obj);
+end
 

--- a/horace_core/sqw/coord_transform/@aProjectionBase/aProjectionBase.m
+++ b/horace_core/sqw/coord_transform/@aProjectionBase/aProjectionBase.m
@@ -32,8 +32,8 @@ classdef aProjectionBase < serializable
         %
         offset;     % Offset of origin of the projection in r.l.u.
         %           % and energy i.e. [h; k; l; en] [row vector]
-        type;   % Character string length 3 defining normalisation, specific
-        %         to a projection type
+        type;      % Character string length 3 defining normalisation, specific
+        %           to a projection type
         %---------------------------------
         label % the method which allows user to change labels present on a
         %      cut
@@ -277,7 +277,7 @@ classdef aProjectionBase < serializable
             obj = check_and_set_type(obj,type);
         end
         
-        function bm = bmatrix(obj,ndim)
+        function [bm,arlu,angrlu] = bmatrix(obj,ndim)
             % Return b-matrix defined on this projection lattice.
             %
             % B-matrix is the Busing-Levy matrix which relates a vector,
@@ -296,7 +296,7 @@ classdef aProjectionBase < serializable
                     mat2str(obj.alatt_),mat2str(obj.angdeg_))
             end
 
-            bm = bmatrix(obj.alatt,obj.angdeg);
+            [bm,arlu,angrlu] = bmatrix(obj.alatt,obj.angdeg);
             if nargin == 2 && ndim == 4
                 bm4 = eye(4);
                 bm4(1:3,1:3) = bm;

--- a/horace_core/sqw/coord_transform/@cylinder_proj/cylinder_proj.m
+++ b/horace_core/sqw/coord_transform/@cylinder_proj/cylinder_proj.m
@@ -46,7 +46,7 @@ classdef cylinder_proj<CurveProjBase
             %
             obj = obj@CurveProjBase();
             % Default projection type: A^{-1}, A^{-1}, degree
-            obj.type_ = 'aad';
+            obj.type_ = 'ppd';
             obj.pix_to_matlab_transf_ = obj.hor2matlab_transf_;
             obj.label = {'Q_{\perp}','Q_{||}','\phi','En'};
             obj.curve_proj_types_ = obj.types_available_;

--- a/horace_core/sqw/coord_transform/@cylinder_proj/cylinder_proj.m
+++ b/horace_core/sqw/coord_transform/@cylinder_proj/cylinder_proj.m
@@ -23,10 +23,11 @@ classdef cylinder_proj<CurveProjBase
     % each direction:
     % for |Q|:
     % 'a' -- Angstrom,
-    % 'r' -- max(\vec{u}*\vec{e_h,e_k,e_l}) = 1 -- projection of u to
+    % 'r' -- max(\vec{u}*\vec{e_h,e_k,e_l}) = 1 -- projection of u or v to
     %                                       unit vectors in hkl directions
-    % 'p' -- |u| = 1
-    % 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
+    % 'p' -- scale == length of vector u or v
+    %  (depending on settings type(1)== 'p' or type(2)=='p')
+    % 'h','k' or 'l' -- scale in selected direction (1 or 2) == (a*,b* or c*);
     % for angular units theta, phi:
     % 'd' - degree, 'r' -- radians
     % For energy transfer:
@@ -47,7 +48,7 @@ classdef cylinder_proj<CurveProjBase
             % Default projection type: A^{-1}, A^{-1}, degree
             obj.type_ = 'aad';
             obj.pix_to_matlab_transf_ = obj.hor2matlab_transf_;
-            obj.label = {'Q_{tr}','Q_{||}','\phi','En'};
+            obj.label = {'Q_{\perp}','Q_{||}','\phi','En'};
             obj.curve_proj_types_ = obj.types_available_;
             if nargin>0
                 obj = obj.init(varargin{:});
@@ -90,17 +91,16 @@ classdef cylinder_proj<CurveProjBase
             % img_scales  -- 1x3 elements array, containing scaling factors
             %                for every scaled direction, namely:
             % for |Q|:
-            % 'a' -- Angstrom,
-            % 'r' -- max(\vec{u}*\vec{e_h,e_k,e_l}) = 1 -- projection of u to
-            %                                         unit vectors in hkl directions
-            % 'p' -- |u| = 1
-            % 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
-            % for angular units theta, phi:
+            % 'r' -- max(\vec{u}*\vec{e_h,e_k,e_l}) = 1 -- projection of u or v to
+            %                                       unit vectors in hkl directions
+            % 'p' -- scale == length of vector u or v
+            %  (depending on settings type(1)== 'p' or type(2)=='p')
+            % 'h','k' or 'l' -- scale in selected direction (1 or 2) == (a*,b* or c*);
             % 'd' - degree, 'r' -- radians
             % For energy transfer:
             % 'e'-energy transfer in meV (no other scaling so may be missing)
 
-            [img_scales,obj] = get_img_scales_(obj);            
+            [img_scales,obj] = get_img_scales_(obj);
         end
     end
     %=====================================================================

--- a/horace_core/sqw/coord_transform/@cylinder_proj/cylinder_proj.m
+++ b/horace_core/sqw/coord_transform/@cylinder_proj/cylinder_proj.m
@@ -3,7 +3,7 @@ classdef cylinder_proj<CurveProjBase
     % to make cylindical cuts.
     %
     % Default angular coordinates names and meanings are chosen as follows:
-    % Q_tr    -- coordinate 1  is the module of the component of the momentum
+    % Q_{\perp}    -- coordinate 1  is the module of the component of the momentum
     %            transfer orthogonal to the direction, selected by property
     %            e_z  of this class. e_z property is expressed in hkl and
     %            defines direction of e_z axis of cylindrical coordinate

--- a/horace_core/sqw/coord_transform/@cylinder_proj/cylinder_proj.m
+++ b/horace_core/sqw/coord_transform/@cylinder_proj/cylinder_proj.m
@@ -19,12 +19,23 @@ classdef cylinder_proj<CurveProjBase
     %            system
     % dE      -- coordinate 4 the energy transfer direction
     %
+    % parent's class "type" property describes which scales are avaliable for
+    % each direction:
+    % for |Q|:
+    % 'a' -- Angstrom,
+    % 'r' -- max(\vec{u}*\vec{e_h,e_k,e_l}) = 1 -- projection of u to
+    %                                       unit vectors in hkl directions
+    % 'p' -- |u| = 1
+    % 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
+    % for angular units theta, phi:
+    % 'd' - degree, 'r' -- radians
+    % For energy transfer:
+    % 'e'-energy transfer in meV (no other scaling so may be missing)
     %
     properties(Constant,Access = private)
         % cellarray describing what letters are available to assign for
-        % type properties.
-        % 'a' -- Angstrom, 'd' - degree, 'r' -- radians, e-energy transfer in meV;
-        types_available_ = {'a','a',{'d','r'}};
+        % projection type property.
+        types_available_ = {{'a','p','r','h','k','l'},{'a','p','r','h','k','l'},{'d','r'}};
     end
 
     methods
@@ -70,17 +81,26 @@ classdef cylinder_proj<CurveProjBase
     end
     methods(Access=protected)
         function [img_scales,obj] = get_img_scales(obj)
-            if isempty(obj.img_scales_cache_)
-                img_scales = ones(1,3);
-                if obj.type_(3) == 'r'
-                    img_scales(3) = 1;
-                else             % phi_to_ang
-                    img_scales(3) = 180/pi;
-                end
-                obj.img_scales_cache_ = img_scales;
-            else
-                img_scales = obj.img_scales_cache_;
-            end
+            % Calculate image scales using projection type
+            % input:
+            % obj -- initialized sphere_proj object with defined lattice
+            %        and "type" - property containing acceptable 3-letter
+            %        type code.
+            % Returns:
+            % img_scales  -- 1x3 elements array, containing scaling factors
+            %                for every scaled direction, namely:
+            % for |Q|:
+            % 'a' -- Angstrom,
+            % 'r' -- max(\vec{u}*\vec{e_h,e_k,e_l}) = 1 -- projection of u to
+            %                                         unit vectors in hkl directions
+            % 'p' -- |u| = 1
+            % 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
+            % for angular units theta, phi:
+            % 'd' - degree, 'r' -- radians
+            % For energy transfer:
+            % 'e'-energy transfer in meV (no other scaling so may be missing)
+
+            [img_scales,obj] = get_img_scales_(obj);            
         end
     end
     %=====================================================================

--- a/horace_core/sqw/coord_transform/@cylinder_proj/private/get_img_scales_.m
+++ b/horace_core/sqw/coord_transform/@cylinder_proj/private/get_img_scales_.m
@@ -9,10 +9,11 @@ function [img_scales,obj] = get_img_scales_(obj)
 % img_scales  -- 1x3 elements array, containing scaling factors
 %                for every scaled direction, namely:
 % for |Q|:
-% 'a' -- Angstrom,
-% 'r' -- max(\vec{u}*\vec{h,k,l}) = 1
-% 'p' -- |u| = 1
-% 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
+% 'r' -- max(\vec{u}*\vec{e_h,e_k,e_l}) = 1 -- projection of u or v to
+%                                       unit vectors in hkl directions
+% 'p' -- scale == length of vector u or v
+%  (depending on settings type(1)== 'p' or type(2)=='p')
+% 'h','k' or 'l' -- scale in selected direction (1 or 2) == (a*,b* or c*);
 % for angular units theta, phi:
 % 'd' - degree, 'r' -- radians
 % For energy transfer:
@@ -38,13 +39,13 @@ if type == 'a'
     scale  = 1;
 elseif type == 'p'
     bm = obj.bmatrix(3);
-    u_cc = bm*vec; % vec in Crystal Cartesian
-    scale = norm(u_cc);
+    v_cc = bm*vec; % vec in Crystal Cartesian
+    scale = norm(v_cc);
 elseif type == 'r'
     [bm,arlu] = obj.bmatrix(3);
     hkl_cc    = bm*eye(3)./arlu(:); % unit vectors in hkl direction
-    u_cc      = bm*vec; % vec in Crystal Cartesian
-    proj2hkl  = hkl_cc*u_cc; % projection u_cc to unit vectors in hkl directions
+    v_cc      = bm*vec; % vec in Crystal Cartesian
+    proj2hkl  = hkl_cc*v_cc; % projection u_cc to unit vectors in hkl directions
     scale = max(proj2hkl);
 elseif type == 'h'
     [~,arlu] = obj.bmatrix(3);

--- a/horace_core/sqw/coord_transform/@cylinder_proj/private/get_img_scales_.m
+++ b/horace_core/sqw/coord_transform/@cylinder_proj/private/get_img_scales_.m
@@ -1,0 +1,58 @@
+function [img_scales,obj] = get_img_scales_(obj)
+%GET_IMG_SCALES:  Calculate image scales using projection type
+%
+% Input:
+% obj -- initialized sphere_proj object with defined lattice
+%        and "type" - property containing acceptable 3-letter
+%        type code.
+% Returns:
+% img_scales  -- 1x3 elements array, containing scaling factors
+%                for every scaled direction, namely:
+% for |Q|:
+% 'a' -- Angstrom,
+% 'r' -- max(\vec{u}*\vec{h,k,l}) = 1
+% 'p' -- |u| = 1
+% 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
+% for angular units theta, phi:
+% 'd' - degree, 'r' -- radians
+% For energy transfer:
+% 'e'-energy transfer in meV (no other scaling so may be missing)
+
+if isempty(obj.img_scales_cache_)
+    img_scales = ones(1,3);
+    img_scales(1) = calc_scales_(obj,obj.u(:),obj.type(1));
+    img_scales(2) = calc_scales_(obj,obj.v(:),obj.type(2));
+    if obj.type_(3) == 'r'
+        img_scales(3) = 1;
+    else                  % phi_to_ang
+        img_scales(3) = 180/pi;
+    end
+    obj.img_scales_cache_ = img_scales;
+else
+    img_scales = obj.img_scales_cache_;
+end
+
+function scale = calc_scales_(obj,vec,type)
+
+if type == 'a'
+    scale  = 1;
+elseif type == 'p'
+    bm = obj.bmatrix(3);
+    u_cc = bm*vec; % vec in Crystal Cartesian
+    scale = norm(u_cc);
+elseif type == 'r'
+    [bm,arlu] = obj.bmatrix(3);
+    hkl_cc    = bm*eye(3)./arlu(:); % unit vectors in hkl direction
+    u_cc      = bm*vec; % vec in Crystal Cartesian
+    proj2hkl  = hkl_cc*u_cc; % projection u_cc to unit vectors in hkl directions
+    scale = max(proj2hkl);
+elseif type == 'h'
+    [~,arlu] = obj.bmatrix(3);
+    scale = arlu(1);
+elseif type == 'k'
+    [~,arlu] = obj.bmatrix(3);
+    scale = arlu(2);
+elseif type == 'l'
+    [~,arlu] = obj.bmatrix(3);
+    scale = arlu(3);
+end

--- a/horace_core/sqw/coord_transform/@cylinder_proj/private/transform_cylinder_to_pix_.m
+++ b/horace_core/sqw/coord_transform/@cylinder_proj/private/transform_cylinder_to_pix_.m
@@ -14,9 +14,9 @@ ndim = size(pix_data,1);
 
 %Original arrangement :  
 % [phi,rho,z] = cart2pol(pix_transf(1,:),pix_transf(2,:),pix_transf(3,:))
-% pix_transf = [cales(1)*rho; scales(2)*z; scales(3)*phi]
+% pix_transf = [rho/cales(1); z/scales(2); scales(3)*phi]
 %Requested arrangement:  [x,y,z] = pol2cart(phi,rho,z);
-[x,y,z] = pol2cart(pix_data(3,:)/scales(3),pix_data(1,:)/scales(1),pix_data(2,:)/scales(2));
+[x,y,z] = pol2cart(pix_data(3,:)/scales(3),pix_data(1,:)*scales(1),pix_data(2,:)*scales(2));
 
 %
 if ndim == 3

--- a/horace_core/sqw/coord_transform/@cylinder_proj/private/transform_pix_to_cylinder_.m
+++ b/horace_core/sqw/coord_transform/@cylinder_proj/private/transform_pix_to_cylinder_.m
@@ -40,9 +40,9 @@ end
 [phi,rho,z] = cart2pol(pix_transf(1,:),pix_transf(2,:),pix_transf(3,:));
 
 if ndim == 4
-    pix_transf = [scales(1)*rho; scales(2)*z; scales(3)*phi;  pix_transf(4,:)];
+    pix_transf = [rho/scales(1); z/scales(2); scales(3)*phi;  pix_transf(4,:)];
 else
-    pix_transf = [scales(1)*rho; scales(2)*z; scales(3)*phi];
+    pix_transf = [rho/scales(1); z/scales(2); scales(3)*phi];
 end
 if input_is_obj
     if shift_ei

--- a/horace_core/sqw/coord_transform/@sphere_proj/private/get_img_scales_.m
+++ b/horace_core/sqw/coord_transform/@sphere_proj/private/get_img_scales_.m
@@ -24,13 +24,14 @@ if isempty(obj.img_scales_cache_)
         img_scales(1) = 1;
     elseif obj.type(1) == 'p'
         bm = obj.bmatrix(3);
-        proj = bm*eye(3);
-        norm_angstom = arrayfun(@(nd)norm(proj(:,nd)),1:3);
-        img_scales(1) = max(norm_angstom);
+        u_cc = bm*obj.u(:); % u in Crystal Cartesian
+        img_scales(1) = norm(u_cc);        
     elseif obj.type(1) == 'r'
-        bm = obj.bmatrix(3);
-        u_angstrom = bm*obj.u(:);
-        img_scales(1) = norm(u_angstrom);
+        [bm,arlu] = obj.bmatrix(3);
+        hkl_cc    = bm*eye(3)./arlu(:); % unit vectors in hkl direction
+        u_cc      = bm*obj.u(:); % u in Crystal Cartesian
+        proj2hkl  = hkl_cc*u_cc; % projection u_cc to unit vectors in hkl directions
+        img_scales(1) = max(proj2hkl);        
     elseif obj.type(1) == 'h'
         [~,arlu] = obj.bmatrix(3);
         img_scales(1) = arlu(1);

--- a/horace_core/sqw/coord_transform/@sphere_proj/private/get_img_scales_.m
+++ b/horace_core/sqw/coord_transform/@sphere_proj/private/get_img_scales_.m
@@ -1,0 +1,57 @@
+function [img_scales,obj] = get_img_scales_(obj)
+%GET_IMG_SCALES:  Calculate image scales using projection type
+%
+% Input:
+% obj -- initialized sphere_proj object with defined lattice
+%        and "type" - property containing acceptable 3-letter
+%        type code.
+% Returns:
+% img_scales  -- 1x3 elements array, containing scaling factors
+%                for every scaled direction, namely:
+% for |Q|:
+% 'a' -- Angstrom,
+% 'r' -- max(\vec{u}*\vec{h,k,l}) = 1
+% 'p' -- |u| = 1
+% 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
+% for angular units theta, phi:
+% 'd' - degree, 'r' -- radians
+% For energy transfer:
+% 'e'-energy transfer in meV (no other scaling so may be missing)
+
+if isempty(obj.img_scales_cache_)
+    img_scales = ones(1,3);
+    if obj.type(1) == 'a'
+        img_scales(1) = 1;
+    elseif obj.type(1) == 'p'
+        bm = obj.bmatrix(3);
+        proj = bm*eye(3);
+        norm_angstom = arrayfun(@(nd)norm(proj(:,nd)),1:3);
+        img_scales(1) = max(norm_angstom);
+    elseif obj.type(1) == 'r'
+        bm = obj.bmatrix(3);
+        u_angstrom = bm*obj.u(:);
+        img_scales(1) = norm(u_angstrom);
+    elseif obj.type(1) == 'h'
+        [~,arlu] = obj.bmatrix(3);
+        img_scales(1) = arlu(1);
+    elseif obj.type(1) == 'k'
+        [~,arlu] = obj.bmatrix(3);
+        img_scales(1) = arlu(2);
+    elseif obj.type(1) == 'l'
+        [~,arlu] = obj.bmatrix(3);
+        img_scales(1) = arlu(3);
+    end
+    if obj.type_(2) == 'r'
+        img_scales(2) = 1;
+    else                  % theta_to_ang
+        img_scales(2) = 180/pi;
+    end
+    if obj.type_(3) == 'r'
+        img_scales(3) = 1;
+    else                  % phi_to_ang
+        img_scales(3) = 180/pi;
+    end
+    obj.img_scales_cache_ = img_scales;
+else
+    img_scales = obj.img_scales_cache_;
+end

--- a/horace_core/sqw/coord_transform/@sphere_proj/private/get_img_scales_.m
+++ b/horace_core/sqw/coord_transform/@sphere_proj/private/get_img_scales_.m
@@ -13,7 +13,7 @@ function [img_scales,obj] = get_img_scales_(obj)
 % 'r' -- scale = max(\vec{u}*\vec{e_h,e_k,e_l}) -- projection of u to
 %                                       unit vectors in hkl directions
 % 'p' -- |u| = 1 -- i.e. scale = |u| (in Crystal Cartesizan)
-% 'h','k' or 'l' -- i.e. scale = (a*,b* or c*);
+% 'h', 'k' or 'l' -- i.e. scale = (a*, b* or c*);
 % for angular units theta, phi:
 % 'd' - degree, 'r' -- radians
 % For energy transfer:

--- a/horace_core/sqw/coord_transform/@sphere_proj/private/get_img_scales_.m
+++ b/horace_core/sqw/coord_transform/@sphere_proj/private/get_img_scales_.m
@@ -10,9 +10,10 @@ function [img_scales,obj] = get_img_scales_(obj)
 %                for every scaled direction, namely:
 % for |Q|:
 % 'a' -- Angstrom,
-% 'r' -- max(\vec{u}*\vec{h,k,l}) = 1
-% 'p' -- |u| = 1
-% 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
+% 'r' -- scale = max(\vec{u}*\vec{e_h,e_k,e_l}) -- projection of u to
+%                                       unit vectors in hkl directions
+% 'p' -- |u| = 1 -- i.e. scale = |u| (in Crystal Cartesizan)
+% 'h','k' or 'l' -- i.e. scale = (a*,b* or c*);
 % for angular units theta, phi:
 % 'd' - degree, 'r' -- radians
 % For energy transfer:
@@ -25,13 +26,13 @@ if isempty(obj.img_scales_cache_)
     elseif obj.type(1) == 'p'
         bm = obj.bmatrix(3);
         u_cc = bm*obj.u(:); % u in Crystal Cartesian
-        img_scales(1) = norm(u_cc);        
+        img_scales(1) = norm(u_cc);
     elseif obj.type(1) == 'r'
         [bm,arlu] = obj.bmatrix(3);
         hkl_cc    = bm*eye(3)./arlu(:); % unit vectors in hkl direction
         u_cc      = bm*obj.u(:); % u in Crystal Cartesian
         proj2hkl  = hkl_cc*u_cc; % projection u_cc to unit vectors in hkl directions
-        img_scales(1) = max(proj2hkl);        
+        img_scales(1) = max(proj2hkl);
     elseif obj.type(1) == 'h'
         [~,arlu] = obj.bmatrix(3);
         img_scales(1) = arlu(1);

--- a/horace_core/sqw/coord_transform/@sphere_proj/private/transform_pix_to_spher_.m
+++ b/horace_core/sqw/coord_transform/@sphere_proj/private/transform_pix_to_spher_.m
@@ -40,9 +40,9 @@ end
 [azimuth,elevation,r] = cart2sph(pix_transf(1,:),pix_transf(2,:),pix_transf(3,:));
 
 if ndim == 4
-    pix_transf = [r*scales(1); scales(2)*(pi/2-elevation); azimuth*scales(3); pix_transf(4,:)];
+    pix_transf = [r/scales(1); scales(2)*(pi/2-elevation); azimuth*scales(3); pix_transf(4,:)];
 else
-    pix_transf = [r*scales(1); scales(2)*(pi/2-elevation); azimuth*scales(3)];
+    pix_transf = [r/scales(1); scales(2)*(pi/2-elevation); azimuth*scales(3)];
 end
 if input_is_obj
     if shift_ei

--- a/horace_core/sqw/coord_transform/@sphere_proj/private/transform_spher_to_pix_.m
+++ b/horace_core/sqw/coord_transform/@sphere_proj/private/transform_spher_to_pix_.m
@@ -14,7 +14,7 @@ ndim = size(pix_data,1);
 
 %Original arrangement :  pix_transf = [r; pi/2-elevation; azimuth];
 %Requested arrangement:  [x,y,z] = sph2cart(azimuth,elevation,r);
-[x,y,z] = sph2cart(pix_data(3,:)/scales(3),pi/2-pix_data(2,:)/scales(2),pix_data(1,:)/scales(1));
+[x,y,z] = sph2cart(pix_data(3,:)/scales(3),pi/2-pix_data(2,:)/scales(2),pix_data(1,:)*scales(1));
 
 %
 if ndim == 3

--- a/horace_core/sqw/coord_transform/@sphere_proj/sphere_proj.m
+++ b/horace_core/sqw/coord_transform/@sphere_proj/sphere_proj.m
@@ -12,14 +12,14 @@ classdef sphere_proj<CurveProjBase
     %            to k_i) and the crystal rotation plane.
     % dE      -- coordinate 4 the energy transfer direction
     %
-    % paten class "type" property describes which scales are avaliable for
+    % parent's class "type" property describes which scales are avaliable for
     % each direction:
     % for |Q|:
     % 'a' -- Angstrom,
-    % 'r' -- max(\vec{u}*\vec{e_h,e_k,e_l}) = 1 -- projection of u to
+    % 'r' -- scale = max(\vec{u}*\vec{e_h,e_k,e_l}) -- projection of u to
     %                                       unit vectors in hkl directions
-    % 'p' -- |u| = 1
-    % 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
+    % 'p' -- |u| = 1 -- i.e. scale = |u|
+    % 'h','k' or 'l' -- i.e. scale = (a*,b* or c*);
     % for angular units theta, phi:
     % 'd' - degree, 'r' -- radians
     % For energy transfer:
@@ -27,7 +27,7 @@ classdef sphere_proj<CurveProjBase
     %
     properties(Constant,Access = private)
         % cellarray describing what letters are available to assign for
-        % type properties.
+        % projection type property.
         types_available_ = {{'a','p','r','h','k','l'},{'d','r'},{'d','r'}};
     end
 
@@ -84,10 +84,10 @@ classdef sphere_proj<CurveProjBase
             %                for every scaled direction, namely:
             % for |Q|:
             % 'a' -- Angstrom,
-            % 'r' -- max(\vec{u}*\vec{e_h,e_k,e_l}) = 1 -- projection of u to
-            %                                         unit vectors in hkl directions
-            % 'p' -- |u| = 1
-            % 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
+            % 'r' -- scale = max(\vec{u}*\vec{e_h,e_k,e_l}) -- projection of u to
+            %                                       unit vectors in hkl directions
+            % 'p' -- |u| = 1 -- i.e. scale = |u|
+            % 'h','k' or 'l' -- i.e. scale = (a*,b* or c*);
             % for angular units theta, phi:
             % 'd' - degree, 'r' -- radians
             % For energy transfer:

--- a/horace_core/sqw/coord_transform/@sphere_proj/sphere_proj.m
+++ b/horace_core/sqw/coord_transform/@sphere_proj/sphere_proj.m
@@ -40,7 +40,7 @@ classdef sphere_proj<CurveProjBase
             obj.pix_to_matlab_transf_ = obj.hor2matlab_transf_;
             obj.label = {'|Q|','\theta','\phi','En'};
             obj.curve_proj_types_ = obj.types_available_;
-            obj.type_ = 'add';
+            obj.type_ = 'pdd';
             if nargin>0
                 obj = obj.init(varargin{:});
             end

--- a/horace_core/sqw/coord_transform/@sphere_proj/sphere_proj.m
+++ b/horace_core/sqw/coord_transform/@sphere_proj/sphere_proj.m
@@ -2,7 +2,6 @@ classdef sphere_proj<CurveProjBase
     % Class defines spherical coordinate projection, used by cut_sqw
     % to make spherical cuts.
     %
-    % TODO: #954 NEEDS verification:
     % Default angular coordinates names and meanings are chosen according
     % to the conventions of inelastic spectrometry, i.e.:
     % |Q|     -- coordinate 1 is the module of the scattering momentum,
@@ -13,12 +12,22 @@ classdef sphere_proj<CurveProjBase
     %            to k_i) and the crystal rotation plane.
     % dE      -- coordinate 4 the energy transfer direction
     %
+    % paten class "type" property describes which scales are avaliable for
+    % each direction:
+    % for |Q|:
+    % 'a' -- Angstrom,
+    % 'r' -- max(\vec{u}*\vec{h,k,l}) = 1
+    % 'p' -- |u| = 1
+    % 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
+    % for angular units theta, phi:
+    % 'd' - degree, 'r' -- radians
+    % For energy transfer:
+    % 'e'-energy transfer in meV (no other scaling so may be missing)
     %
     properties(Constant,Access = private)
         % cellarray describing what letters are available to assign for
         % type properties.
-        % 'a' -- Angstrom, 'd' - degree, 'r' -- radians, e-energy transfer in meV;
-        types_available_ = {'a',{'d','r'},{'d','r'}};
+        types_available_ = {{'a','p','h','k','l'},{'d','r'},{'d','r'}};
     end
 
     methods
@@ -65,22 +74,24 @@ classdef sphere_proj<CurveProjBase
     methods(Access=protected)
         function [img_scales,obj] = get_img_scales(obj)
             % Calculate image scales using projection type
-            if isempty(obj.img_scales_cache_)
-                img_scales = ones(1,3);
-                if obj.type_(2) == 'r' 
-                    img_scales(2) = 1;
-                else                  % theta_to_ang
-                    img_scales(2) = 180/pi;
-                end
-                if obj.type_(3) == 'r'
-                    img_scales(3) = 1;
-                else                  % phi_to_ang
-                    img_scales(3) = 180/pi;
-                end
-                obj.img_scales_cache_ = img_scales;
-            else
-                img_scales = obj.img_scales_cache_;
-            end
+            % input:
+            % obj -- initialized sphere_proj object with defined lattice
+            %        and "type" - property containing acceptable 3-letter
+            %        type code.
+            % Returns:
+            % img_scales  -- 1x3 elements array, containing scaling factors
+            %                for every scaled direction, namely:
+            % for |Q|:
+            % 'a' -- Angstrom,
+            % 'r' -- max(\vec{u}*\vec{h,k,l}) = 1
+            % 'p' -- |u| = 1
+            % 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
+            % for angular units theta, phi:
+            % 'd' - degree, 'r' -- radians
+            % For energy transfer:
+            % 'e'-energy transfer in meV (no other scaling so may be missing)
+
+            [img_scales,obj] = get_img_scales_(obj);
         end
     end
     %=====================================================================

--- a/horace_core/sqw/coord_transform/@sphere_proj/sphere_proj.m
+++ b/horace_core/sqw/coord_transform/@sphere_proj/sphere_proj.m
@@ -16,7 +16,8 @@ classdef sphere_proj<CurveProjBase
     % each direction:
     % for |Q|:
     % 'a' -- Angstrom,
-    % 'r' -- max(\vec{u}*\vec{h,k,l}) = 1
+    % 'r' -- max(\vec{u}*\vec{e_h,e_k,e_l}) = 1 -- projection of u to
+    %                                       unit vectors in hkl directions
     % 'p' -- |u| = 1
     % 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
     % for angular units theta, phi:
@@ -27,7 +28,7 @@ classdef sphere_proj<CurveProjBase
     properties(Constant,Access = private)
         % cellarray describing what letters are available to assign for
         % type properties.
-        types_available_ = {{'a','p','h','k','l'},{'d','r'},{'d','r'}};
+        types_available_ = {{'a','p','r','h','k','l'},{'d','r'},{'d','r'}};
     end
 
     methods
@@ -83,7 +84,8 @@ classdef sphere_proj<CurveProjBase
             %                for every scaled direction, namely:
             % for |Q|:
             % 'a' -- Angstrom,
-            % 'r' -- max(\vec{u}*\vec{h,k,l}) = 1
+            % 'r' -- max(\vec{u}*\vec{e_h,e_k,e_l}) = 1 -- projection of u to
+            %                                         unit vectors in hkl directions
             % 'p' -- |u| = 1
             % 'h','k' or 'l' -- \vec{Q}/(a*,b* or c*) = 1;
             % for angular units theta, phi:


### PR DESCRIPTION
fixes Re #1670. 
Added bunch of scaling options to spherical and cylindrical projections. 

Looks correct, testing used physical meaning would be beneficial.