### PR TITLE
Fix issue with 4.0.0 spaghetti plot

### DIFF
--- a/documentation/user_docs/docs/user_guide/Horace3_to_4.rst
+++ b/documentation/user_docs/docs/user_guide/Horace3_to_4.rst
@@ -69,6 +69,13 @@ Passing a pair of vectors will still be accepted and be internally
 transformed into the correct ``Symop``, however, it is still best to
 switch.
 
+Spaghetti Plot
+--------------
+
+``qwidth`` in ``spaghetti_plot`` arguments now correctly refers to a full-width of the perpendicular
+bins. This means that to achieve the same results in Horace 4 as Horace 3, a user-specified
+``qwidth`` should be twice as large. Default ``qwidths`` have been updated to reflect this change.
+
 Crystal Alignment
 -----------------
 

--- a/horace_core/spaghetti_plot.m
+++ b/horace_core/spaghetti_plot.m
@@ -21,10 +21,10 @@ function varargout = spaghetti_plot(varargin)
 %   >> [wdisp,cuts] = spaghetti_plot(...)                    % generates a set of 1D cuts
 %   >> [wdisp, cuts] = spaghetti_plot(...,'withpix')         % return cuts as sqw rather than d1ds
 %   >> [wdisp,cuts,fig,axes,plots] = spaghetti_plot(...)     % in addition
-%                                    to  1D cuts retun references to the
+%                                    to 1D cuts return references to the
 %                                    plot objects i.e. figure handle, axes
-%                                    handle and array of hanles to each
-%                                    line plots displayed by spaghetti plot
+%                                    handle and array of handles to each
+%                                    line plot displayed by spaghetti plot
 % Input:
 % ------
 %   rlp             Array of r.l.p. e.g. [0,0,0; 0,0,1; 1,0,1; 1,0,0];
@@ -123,7 +123,7 @@ function varargout = spaghetti_plot(varargin)
 % Set defaults
 % ------------
 arglist = struct('qbin', 0.05, ...
-    'qwidth', 0.1, ...
+    'qwidth', 0.2, ...
     'ebin', [], ...
     'labels', '', ...
     'noplot', false, ...
@@ -139,15 +139,18 @@ flags = {'noplot', 'logscale', 'withpix'};
 % --------------------
 [args, opt, present] = parse_arguments(varargin, arglist, flags);
 
+return_plots = nargout > 0;
+return_cuts = nargout > 1;
+
 if numel(args) == 1 && (isa(args{1}(1), 'd2d') || isa(args{1}(1), 'IX_dataset_2d'))
     out = plot_dispersion(args{1}, opt,nargout);
-    if nargout>0
+    if return_plots
         varargout = data_plot_interface.set_argout(nargout,out{:});
     end
     return
 elseif numel(args) > 1 && isa(args{2}(1), 'd2d')
     out = plot_dispersion(args{2}, opt,nargout);
-    if nargout>0
+    if return_plots
         varargout = data_plot_interface.set_argout(nargout,out{:});
     end
     return
@@ -273,73 +276,51 @@ end
 xrlp = 0;
 wdisp = repmat(d2d, 1, nseg);
 
-bz_norm = sqw_proj.transform_hkl_to_pix([0;0;1]);
-bz_norm = bz_norm ./ norm(bz_norm);
+cstar_cart = sqw_proj.transform_hkl_to_pix([0;0;1]);
+cstar_cart = cstar_cart ./ norm(cstar_cart);
 
-bx_norm = sqw_proj.transform_hkl_to_pix([1;0;0]);
-bx_norm = bx_norm ./ norm(bx_norm);
-if nargout>1
+astar_cart = sqw_proj.transform_hkl_to_pix([1;0;0]);
+astar_cart = astar_cart ./ norm(astar_cart);
+
+if return_cuts
     out_1d_cuts = cell(1,nseg);
 end
 
 for i = 1:nseg
+    % Choose u1 along the user desired q-direction
     q_dir_rlu = rlp(i+1, :) - rlp(i, :);
 
-    q_dir_abs = sqw_proj.transform_hkl_to_pix(q_dir_rlu')';
-    q_dir_abs = q_dir_abs ./ norm(q_dir_abs);
-
-    q_start_abs = sqw_proj.transform_hkl_to_pix(rlp(i, :)')';
-    q_end_abs = sqw_proj.transform_hkl_to_pix(rlp(i+1, :)')';
-
-
+    q_dir_cart = sqw_proj.transform_hkl_to_pix(q_dir_rlu')';
+    % Choose u2 to be either perpendicular to the plane of all the rlp (previous determined)
+    %   or the plane defined by u1 and c* or, if u1||c*, the plane defined by u1 and a*.
     if isempty(plane_normal)
-        dqv_abs = cross(q_dir_abs, bz_norm);
-        if sum(abs(dqv_abs)) < min(opt.qbin) / 100
-            dqv_abs = cross(q_dir_abs, bx_norm);
+        v_cart = cross(q_dir_cart, cstar_cart);
+        if sum(abs(v_cart)) < min(opt.qbin) / 100
+            v_cart = cross(q_dir_cart, astar_cart);
         end
     else
-        dqv_abs = ortho_vec(q_dir_abs);
+        v_cart = ortho_vec(q_dir_cart);
     end
+    v_rlu = sqw_proj.transform_pix_to_hkl(v_cart')';
 
-    dqv_abs = dqv_abs ./ norm(dqv_abs);
-    dqw_abs = cross(q_dir_abs, dqv_abs);
-    q_dir_frac = sqw_proj.transform_pix_to_hkl(q_dir_abs')';
-    dqv_frac = sqw_proj.transform_pix_to_hkl(dqv_abs')';
-    dqw_frac = sqw_proj.transform_pix_to_hkl(dqw_abs')';
+    proj = line_proj(q_dir_rlu, ...
+                     v_rlu, ...
+                     'offset', rlp(i, :), ...
+                     'type', 'aaa');
 
-    ulen = 1 ./ vecnorm(inv(ubmatrix(q_dir_frac, dqv_frac, sqw_proj.bmatrix)));
 
-    q_dir_rs = q_dir_frac .* ulen(1);
-    dqv_rs = dqv_frac .* ulen(2);
-    dqw_rs = dqw_frac .* ulen(2);
-
-    proj = line_proj(q_dir_rs, ...
-        dqv_rs, ...
-        dqw_rs, ...
-        'type', 'rrr');
-
-    % determines the bin size in the desired q-direction in r.l.u.
-    u1bin = qbin / ulen(1);
-
-    % determines the integration range over the perpendicular q-directions in r.l.u.
-    u2bin = qwidth(1, i) / ulen(2);
-    u3bin = qwidth(2, i) / ulen(3);
-
-    u20 = dot(q_start_abs, dqv_abs) / ulen(2);
-    u30 = dot(q_start_abs, dqw_abs) / ulen(3);
-    u1 = [dot(q_start_abs, q_dir_abs) / ulen(1), ...
-        u1bin, ...
-        dot(q_end_abs, q_dir_abs) / ulen(1)];
+    u1 = [0, qbin, norm(q_dir_cart)];
+    u2 = [-qwidth(1, i), qwidth(1, i)] ./ 2;
+    u3 = [-qwidth(2, i), qwidth(2, i)] ./ 2;
 
     % Radu Coldea on 19/12/2018: adjust qbin size to have an exact
     % integer number of bins between the start and end points
     u1(2) = (u1(3) - u1(1)) / floor((u1(3) - u1(1)) / u1(2));
-    u2 = [u20 - u2bin, u20 + u2bin];
-    u3 = [u30 - u3bin, u30 + u3bin];
 
     % Make cut, and save to array of d2d
     wdisp_sqw = cut(sqw_in, proj, u1, u2, u3, ebin);
-    if nargout > 1
+
+    if return_cuts
         u1v = u1(1):u1(2):u1(3);
 
         if wdisp_sqw.has_pixels()
@@ -357,7 +338,7 @@ for i = 1:nseg
     end
 
     wdisp(i) = d2d(wdisp_sqw);
-    if ~opt.withpix && nargout > 1
+    if ~opt.withpix && return_cuts
         out_1d_cuts{i} = arrayfun(@d1d, out_1d_cuts{i});
     end
 
@@ -383,20 +364,26 @@ for i = 1:nseg
     end
 end
 
-if nargout > 0
-    varargout{1}=wdisp;
+if return_plots
+    varargout{1} = wdisp;
+else
+    varargout{1} = [];
 end
-if nargout>1
-    varargout{2}  = out_1d_cuts;
+
+if return_cuts
+    varargout{2} = out_1d_cuts;
+else
+    varargout{2} = [];
 end
 
 % Plot dispersion
 %----------------
 if nargout == 0 || ~opt.noplot
-    out = plot_dispersion(arrayfun(@d2d,wdisp), opt,nargout);
+    out = plot_dispersion(arrayfun(@d2d,wdisp), opt, nargout);
+
     out{1} = varargout{1};
     out{2} = varargout{2};
-    if nargout>0
+    if return_plots
         varargout = data_plot_interface.set_argout(nargout,out{:});
     end
 else
@@ -404,6 +391,7 @@ else
         varargout{i} = [];
     end
 end
+
 end
 
 %========================================================================================================


### PR DESCRIPTION
Issue was with which space vectors were computed in. 

- Fixed and simplified spaghetti plot using Horace 4 features. 
- One notable difference is that `qwidth` now specifies a full-width rather than a half-width confirmed by Duc to be the original intent, however, this means that `spaghetti_plot` `qwidths` in new Horace are half those of Horace 4. **N.B.** Can back this change out.

Fixes #1710 
Fixes #1709 