### PR TITLE
Fix getFF_calculator for Horace4

### DIFF
--- a/horace_core/utilities/@MagneticIons/getFF_calculator.m
+++ b/horace_core/utilities/@MagneticIons/getFF_calculator.m
@@ -44,13 +44,24 @@ function  fint = getFF_calculator(self,win)
 %
 
 if isa(win,'sqw')
-    self.hkl_to_Qmat_ = win.data.proj.bmatrix();
+    self.proj_ = win.data.proj;
 elseif isnumeric(win) || all(size(win) == [3,3])
-    self.hkl_to_Qmat_= win;
+    proj = line_proj([1,0,0], [0,1,0]);
+    % Uses the identity:
+    % inv(B^T * B) = [aa ab.cos(gamma) ac.cos(beta);
+    %                 ab.cos(gamma) bb bc.cos(alpha);
+    %                 ac.cos(beta) bc.cos(alpha) cc];
+    bb = inv(win' * win);
+    alatt = sqrt(diag(bb));
+    angdeg(1) = acos(bb(2,3) / prod(alatt(2:3)));
+    angdeg(2) = acos(bb(1,3) / prod(alatt([1 3])));
+    angdeg(3) = acos(bb(1,2) / prod(alatt(1:2)));
+    proj.alatt = 2*pi * alatt;
+    proj.angdeg = angdeg * 180 / pi;
+    self.proj_ = proj;
 else
-    self.hkl_to_Qmat_ = win.proj.bmatrix();
+    self.proj_ = win.proj;
 end
-
 
 fint = @(h,k,l,en,argi)form_factor(self,h,k,l,en,argi);
 


### PR DESCRIPTION
Fixes `getFF_calculator` which broke due to changes in Horace 4.

To test run the examples in the [resolution convolution doc](https://pace-neutrons.github.io/Horace/unstable/user_guide/Resolution_convolution.html#a-worked-example).

Or check the output of:

```
proj = line_proj([1,1,0], [-1,1,0], 'type', 'rrr');
w1 = cut('fe_cut.sqw', proj, 0.05, [-1.05,-0.95], [-0.1,0.1], [80, 100]);
ff_fun = MagneticIons('Fe0').getFF_calculator(w1);
```

between Horace 3 and Horace 4.

`fe_cut.sqw` can be [downloaded here](https://github.com/pace-neutrons/pace-python-demo/blob/main/datafiles/fe_cut.sqw).