### PR TITLE
remove persistiong output in sliceomatic

### DIFF
--- a/herbert_core/graphics/sliceomatic/private/textbox_axis.m
+++ b/herbert_core/graphics/sliceomatic/private/textbox_axis.m
@@ -56,7 +56,7 @@ switch textb
 % *** with:
         if ~isempty(val)
             if val < d.clim(1,2)
-                sliceomatic('ISONew1',[val,d.clim(1,2)])
+                sliceomatic('ISONew1',[val,d.clim(1,2)]);
             else
                 disp('Error in input - must be less than current maximum intensity setting')
                 set(h,'String',d.clim(1,1));

--- a/herbert_core/graphics/sliceomatic/sliceomatic.m
+++ b/herbert_core/graphics/sliceomatic/sliceomatic.m
@@ -1,4 +1,4 @@
-function d=sliceomatic(U1,U2,U3,S,xlabel,ylabel,zlabel,xaxis,yaxis,zaxis,clim,isoflag,name)
+function varargout=sliceomatic(U1,U2,U3,S,xlabel,ylabel,zlabel,xaxis,yaxis,zaxis,clim,isoflag,name)
 % SLICEOMATIC - Slice and isosurface volume exploration GUI
 %
 % Using the GUI:
@@ -99,7 +99,7 @@ function d=sliceomatic(U1,U2,U3,S,xlabel,ylabel,zlabel,xaxis,yaxis,zaxis,clim,is
 %   clim    Intensity limits
 %   isoflag TRUE if isonormals are to be plotted later on. FALSE (or simply
 %           omitted) if not. Isonormals take longer to calculate.
-%   name    if provided, the name of the figure to contain sliseomatic. If absent, 
+%   name    if provided, the name of the figure to contain sliseomatic. If absent,
 %           the name will be Sliceomatic
 
 
@@ -107,6 +107,9 @@ colordef white  % to avoid screw-up that earlier 'colordef none' produces
 
 if nargin==0
     help sliceomatic
+    if nargout>0
+        varargout{1} = [];
+    end
     return
 end
 if nargin < 13
@@ -182,7 +185,7 @@ else
                     'xdata',d.clim,'ydata',[0 5],...
                     'alphadata',1.0, ...
                     'hittest','off');
-                sliceomatic('isodeleteall')
+                sliceomatic('isodeleteall');
 
             case 'ISONew2'
                 %           I=U2;
@@ -196,7 +199,7 @@ else
                     'xdata',d.clim,'ydata',[0 5],...
                     'alphadata',1.0, ...
                     'hittest','off');
-                sliceomatic('isodeleteall')
+                sliceomatic('isodeleteall');
                 %--------------------------Modification started on 12th  may 2003 by srikanth---------------
             case 'XnewText'
                 X=U2;
@@ -883,6 +886,10 @@ end
 % Will reset just before exiting this function
 set(0, 'DefaultFigureRendererMode', mode);
 set(0,'DefaultFigureRenderer',rend );
+if nargout>0
+    varargout{1} = d;
+end
+
 %-------------------------------------------------------------------------------------------------
 
 
@@ -1183,6 +1190,9 @@ if ~isempty(X)
         [xdata, ydata, zdata]=meshgrid(newX,d.ylim(1):ydivision:d.ylim(2),d.zlim(1):zdivision:d.zlim(2));
         st = 'X';
     else
+        if nargout>0
+            varargout{1} = d;
+        end
         return
     end
 elseif ~isempty(Y)
@@ -1193,6 +1203,10 @@ elseif ~isempty(Y)
         [xdata, ydata, zdata]=meshgrid(d.xlim(1):xdivision:d.xlim(2),newY,d.zlim(1):zdivision:d.zlim(2));
         st = 'Y';
     else
+        if nargout>0
+            varargout{1} = d;
+        end
+
         return
     end
 elseif ~isempty(Z)
@@ -1203,6 +1217,9 @@ elseif ~isempty(Z)
         [xdata, ydata, zdata]=meshgrid(d.xlim(1):xdivision:d.xlim(2),d.ylim(1):ydivision:d.ylim(2),newZ);
         st = 'Z';
     else
+        if nargout>0
+            varargout{1} = d;
+        end
         return
     end
 else
@@ -1264,6 +1281,10 @@ contour = getappdata(s,'contour');
 if ~isempty(contour)
     localcontour(s, contour);
 end
+if nargout>0
+    varargout{1} = d;
+end
+
 
 
 function textureizeslice(slice,onoff)

--- a/herbert_core/utilities/classes/@IX_dataset_3d/IX_dataset_3d.m
+++ b/herbert_core/utilities/classes/@IX_dataset_3d/IX_dataset_3d.m
@@ -55,7 +55,8 @@ classdef IX_dataset_3d < IX_data_3d & data_plot_interface
         % actual plotting interface:
         %------------------------------------------------------------------
         % PLOT:
-        [figureHandle, axesHandle, plotHandle] = sliceomatic(w, varargin);
+        %[figureHandle, axesHandle, plotHandle] = sliceomatic(w, varargin);
+        varargout = sliceomatic(w, varargin);
     end
 
 end

--- a/horace_core/sqw/@d3d/d3d.m
+++ b/horace_core/sqw/@d3d/d3d.m
@@ -46,8 +46,10 @@ classdef d3d < DnDBase
         % actual plotting interface:
         %------------------------------------------------------------------
         % PLOT:
-        [figureHandle, axesHandle, plotHandle] = sliceomatic(w, varargin);
-        [figureHandle, axesHandle, plotHandle] = sliceomatic_overview(w,varargin);
+        %[figureHandle, axesHandle, plotHandle] = sliceomatic(w, varargin);
+        varargout = sliceomatic(w, varargin);
+        %[figureHandle, axesHandle, plotHandle] = sliceomatic_overview(w,varargin);
+        varargout = sliceomatic_overview(w,varargin);
 
     end
 end


### PR DESCRIPTION
Should fix  Re #1732 

Instantiate Horace\_test\test_dnd_class\test_plot_dnd.m  put breakpoint at row 97 and when code stops at it run:
`plot(d3d_obj)`

sliceomatic appears but each time you move or add view pannel, output is displayed on Matlab screen.

after applying this change, the output disappears
