### PR TITLE
Fix SymopGeneral in cut_sym

### DIFF
--- a/_test/test_sym_op/test_cut_sym_cube.m
+++ b/_test/test_sym_op/test_cut_sym_cube.m
@@ -178,6 +178,30 @@ classdef test_cut_sym_cube < TestCase
 
         end
 
+        function test_cut_sym_general(obj)
+            data = sqw.generate_cube_sqw(10);
+
+            proj = line_proj([1 0 0], [0 1 0]);
+            ubin = {[0.5 1 4.5], [0.5 1 4.5], [-5 5], [-5 5]};
+
+            wtmp = symmetrise_sqw(data, SymopRotation([0 0 1], 90));
+            w1sym = cut(wtmp, proj, ubin{:}, '-nopix');
+
+            op = {};
+            for i = 1:3
+                op{i} = SymopGeneral(rot_mat_z(i*90));
+            end
+
+            w2sym = cut(data, proj, ubin{:}, op, '-nopix');
+
+            assertEqualToTol(w1sym, w2sym);
+        end
 
     end
+end
+
+function mat = rot_mat_z(x)
+    mat = [cosd(x) -sind(x) 0
+           sind(x)  cosd(x) 0
+             0        0     1];
 end

--- a/horace_core/sqw/@sqw/private/cut_accumulate_data_.m
+++ b/horace_core/sqw/@sqw/private/cut_accumulate_data_.m
@@ -195,7 +195,7 @@ if ll>=2
     t_proj_start = tic;
 end
 
-% multiple projections here can appear only from multiple symmetries, so 
+% multiple projections here can appear only from multiple symmetries, so
 % if only one projection is there, no symmetries will be used
 apply_symmetries = num_proj > 1;
 
@@ -226,8 +226,8 @@ for iter = 1:num_chunks
 
         % if there are symmetries, we need to transform pixels and tag used
         % pixels to avoid multiple usage of the same pixels.
-        if apply_symmetries 
-            candidate_pix = sym{i}.transform_pix(candidate_pix, {}, selected);
+        if apply_symmetries
+            candidate_pix = sym{i}.transform_pix(candidate_pix, {}, selected, true);
             candidate_pix = candidate_pix.tag(selected);
         end
 


### PR DESCRIPTION
Add extra option to `trust` the `selection` of atoms found by cut to be in the cut range and not check whether it also lies in the irreducible zone. 

Adds test for SymopGeneral cuts.

Fixes #1735