### PR TITLE
horace install accepts spinW path

### DIFF
--- a/_test/test_admin/test_horace_install.m
+++ b/_test/test_admin/test_horace_install.m
@@ -133,7 +133,6 @@ classdef test_horace_install < TestCase
             clear clOb;
             assertTrue(contains(modified_hor_on_contents,spinw_foler));
         end
-
         %
         function test_files_in_folder_like_Jenkins_repo_clean(obj)
             % prepare fake Horace/Herbert code tree

--- a/_test/test_admin/test_horace_install.m
+++ b/_test/test_admin/test_horace_install.m
@@ -126,14 +126,14 @@ classdef test_horace_install < TestCase
             assertFalse(use_old_init_folder);
 
             assertEqual(new_install,install_folder);
-            %assertEqual(her_test_source,her_init_dir);
             assertEqual(hor_test_source,hor_init_dir);
 
             clear clob1;
             clear clob2;
             clear clOb;
+            assertTrue(contains(modified_hor_on_contents,spinw_foler));
         end
-        
+
         %
         function test_files_in_folder_like_Jenkins_repo_clean(obj)
             % prepare fake Horace/Herbert code tree
@@ -218,7 +218,7 @@ classdef test_horace_install < TestCase
             assertEqual(fileparts(which('horace_on')),install_folder);
             assertTrue(use_old_init_folder);
 
-            assertEqual(install_root,hor_admin);            
+            assertEqual(install_root,hor_admin);
             assertEqual(hor_test_source,hor_init_dir);
 
             clear clob1;
@@ -280,7 +280,6 @@ classdef test_horace_install < TestCase
                 copyfile(source,targ,'f');
             end
         end
-
     end
 
 end

--- a/_test/test_admin/test_horace_install.m
+++ b/_test/test_admin/test_horace_install.m
@@ -1,23 +1,14 @@
 classdef test_horace_install < TestCase
-    
+
     properties
         this_folder;
     end
-    
+
     methods
-        
+
         function obj=test_horace_install(~)
             obj = obj@TestCase('test_horace_install');
             obj.this_folder = fileparts(mfilename('fullpath'));
-        end
-        function copy_install_files(~,source_files,target_folder)
-            
-            for i=1:numel(source_files)
-                source = which(source_files{i});
-                [~,tn,te] = fileparts(source);
-                targ = fullfile(target_folder,[tn,te]);
-                copyfile(source,targ,'f');
-            end
         end
         function [hor_unpack,herbert_unpack]=find_hor_her_location(~)
             % Identify where actually Horace code is unpacked on the system
@@ -46,19 +37,19 @@ classdef test_horace_install < TestCase
             if strcmp(fullfile(new_init_path),fileparts(which('horace_on')))
                 new_init_path = fullfile(new_init_path,'TestISIS');
             end
-            
+
             [install_folder,hor_init_dir,use_old_init_path] = ...
                 horace_install('init_folder',new_init_path,'-test_mode');
-            
+
             [hor_unpack,herbert_unpack]=obj.find_hor_her_location();
-            
+
             assertEqual(install_folder,fullfile(tmp_dir(),'ISIS'));
-            assertEqual(hor_init_dir,fullfile(hor_unpack,'horace_core'));            
+            assertEqual(hor_init_dir,fullfile(hor_unpack,'horace_core'));
             assertEqual(hor_unpack,herbert_unpack);
 
             assertFalse(use_old_init_path);
         end
-        
+
         function test_init_folder_provided(obj)
             %
             new_init_path = tmp_dir();
@@ -67,12 +58,12 @@ classdef test_horace_install < TestCase
             if strcmp(fullfile(new_init_path,'ISIS'),fileparts(which('horace_on')))
                 new_init_path = fullfile(new_init_path,'TestISIS');
             end
-            
+
             [init_folder,hor_init_dir,use_old_init_path] = ...
                 horace_install('init_folder',new_init_path,'-test_mode');
-            
+
             [hor_unpack,herbert_unpack]=obj.find_hor_her_location();
-            
+
             assertEqual(init_folder,fullfile(tmp_dir(),'ISIS'));
             assertEqual(hor_unpack,herbert_unpack);
             assertEqual(hor_init_dir,fullfile(hor_unpack,'horace_core'));
@@ -81,7 +72,7 @@ classdef test_horace_install < TestCase
         %
         function test_warning_on_nonadmin_install(obj)
             %
-            % hide tested warnings from beeing displayed when the test runs
+            % hide tested warnings from being displayed when the test runs
             ws = struct('identifier',{'MATLAB:DELETE:Permission','HORACE:installation'},...
                 'state',{'off','off'});
             warning(ws)
@@ -90,16 +81,16 @@ classdef test_horace_install < TestCase
             % do not forget to recover the warnings when finished with
             % tests
             clob = onCleanup(@()warning(ws));
-            
+
             % throw DELETE warning and test
             warning('MATLAB:DELETE:Permission','test delete permission warning');
             [init_folder,hor_init_dir,use_old_init_folder] = horace_install('-test_mode');
             [~,id]=lastwarn();
             assertEqual(id,'HORACE:installation');
-            
-            
+
+
             [hor_unpack,herbert_unpack]=obj.find_hor_her_location();
-            
+
             % despite we are testing non-accessible warning, the
             % installation is actually into old init folder
             assertEqual(init_folder,fileparts(which('horace_on')));
@@ -107,29 +98,11 @@ classdef test_horace_install < TestCase
             assertEqual(hor_unpack,herbert_unpack);
             assertEqual(hor_init_dir,fullfile(hor_unpack,'horace_core'));
         end
-        %
-        function test_files_in_folder_like_Jenkins_repo_clean(obj)
-            % prepare fake Horace/Herbert code tree
-            test_install = fullfile(obj.this_folder,'folder4install_jenkins_repo');
-            mkdir(test_install);
-            test_admin = fullfile(test_install,'admin');
-            mkdir(test_admin);
-            clob = onCleanup(@()(rmdir(test_install,'s')));
-            
-            template_files = {'horace_install.m','horace_on.m.template',...
-                'worker_v4.m.template'};
-            obj.copy_install_files(template_files,test_admin);
-            hor_test_source = fullfile(test_install,'horace_core');
-            mkdir(hor_test_source);
-            init_files = {'horace_init.m'};
-            obj.copy_install_files(init_files ,hor_test_source);
-            
-            her_test_source = fullfile(test_install,'herbert_core');
-            mkdir(her_test_source);
-            init_files = {'herbert_init.m'};
-            obj.copy_install_files(init_files ,her_test_source);
+        function test_files_in_folder_like_cloned_repo_with_spinW(obj)
+            % prepare fake Horace/Herbert code installation tree
+            [clOb,hor_root,test_admin,hor_test_source] = ...
+                obj.prepare_install_package_structure('folder2install_repo_spinW','admin','horace_core','herbert_core');
 
-            
             path_list_recover = cell(1,1);
             n_path = 0;
             % clear path to existing Horace init files
@@ -142,44 +115,63 @@ classdef test_horace_install < TestCase
             end
             % do not forget to recover path to existing installation
             clob2 = onCleanup(@()addpath(path_list_recover{:}));
-            
+
             current_dir = pwd;
             cd(test_admin);
             clob1 = onCleanup(@()cd(current_dir));
-            
-            
-            [install_folder,hor_init_dir,use_old_init_folder] = horace_install('-test_mode');
-            new_install = fullfile(test_install,'ISIS');
+
+            spinw_foler = fullfile(hor_root,'spinw_folder');
+            [install_folder,hor_init_dir,use_old_init_folder,modified_hor_on_contents] = horace_install('-test_mode','spinW_folder',spinw_foler);
+            new_install = fullfile(hor_root,'ISIS');
             assertFalse(use_old_init_folder);
-            
+
             assertEqual(new_install,install_folder);
+            %assertEqual(her_test_source,her_init_dir);
             assertEqual(hor_test_source,hor_init_dir);
-            
+
+            clear clob1;
+            clear clob2;
+            clear clOb;
+        end
+        
+        %
+        function test_files_in_folder_like_Jenkins_repo_clean(obj)
+            % prepare fake Horace/Herbert code tree
+            [clOb,hor_root,test_admin,test_hor_init] = obj.prepare_install_package_structure('folder2install_jenkins_repo','admin','horace_core','herbert_core');
+
+            path_list_recover = cell(1,1);
+            n_path = 0;
+            % clear path to existing Horace init files
+            old_hor_path = fileparts(which('horace_on.m'));
+            while ~isempty(old_hor_path)
+                rmpath(old_hor_path);
+                n_path = n_path+1;
+                path_list_recover{n_path} = old_hor_path;
+                old_hor_path = fileparts(which('horace_on.m'));
+            end
+            % do not forget to recover path to existing installation
+            clob2 = onCleanup(@()addpath(path_list_recover{:}));
+
+            current_dir = pwd;
+            cd(test_admin);
+            clob1 = onCleanup(@()cd(current_dir));
+
+
+            [install_folder,hor_init_dir,use_old_init_folder] = horace_install('-test_mode');
+            new_install = fullfile(hor_root,'ISIS');
+            assertFalse(use_old_init_folder);
+
+            assertEqual(new_install,install_folder);
+            assertEqual(test_hor_init,hor_init_dir);
+
             clear clob1;
             clear clob2;
         end
         %
         function test_files_in_folder_like_cloned_repo_clean(obj)
-            % prepare fake Horace/Herbert code tree
-            test_install = fullfile(obj.this_folder,'folder4install_repo');
-            mkdir(test_install);
-            test_admin = fullfile(test_install,'Horace','admin');
-            mkdir(test_admin);
-            clob = onCleanup(@()(rmdir(test_install,'s')));
-            
-            template_files = {'horace_install.m','horace_on.m.template',...
-                'worker_v4.m.template'};
-            obj.copy_install_files(template_files,test_admin);
-            hor_test_source = fullfile(test_install,'Horace','horace_core');
-            mkdir(hor_test_source);
-            init_files = {'horace_init.m'};
-            obj.copy_install_files(init_files ,hor_test_source);
-            
-            her_test_source= fullfile(test_install,'Horace','herbert_core');
-            mkdir(her_test_source);
-            init_files = {'herbert_init.m'};
-            obj.copy_install_files(init_files ,her_test_source);
-            
+            % prepare fake Horace/Herbert code installation tree
+            [clOb,hor_root,test_admin,hor_test_source] = obj.prepare_install_package_structure('folder2install_repo','admin','horace_core','herbert_core');
+
             path_list_recover = cell(1,1);
             n_path = 0;
             % clear path to existing Horace init files
@@ -192,61 +184,52 @@ classdef test_horace_install < TestCase
             end
             % do not forget to recover path to existing installation
             clob2 = onCleanup(@()addpath(path_list_recover{:}));
-            
+
             current_dir = pwd;
             cd(test_admin);
             clob1 = onCleanup(@()cd(current_dir));
-            
-            
+
+
             [install_folder,hor_init_dir,use_old_init_folder] = horace_install('-test_mode');
-            new_install = fullfile(test_install,'ISIS');
+            new_install = fullfile(hor_root,'ISIS');
             assertFalse(use_old_init_folder);
-            
+
             assertEqual(new_install,install_folder);
             %assertEqual(her_test_source,her_init_dir);
             assertEqual(hor_test_source,hor_init_dir);
-            
+
             clear clob1;
             clear clob2;
+            clear clOb;
         end
-        
+
         function test_files_in_folder_like_installation_dir(obj)
-            % prepare fake horace installation
-            test_install = fullfile(obj.this_folder,'folder_for_install_tests');
-            mkdir(test_install);
-            clob = onCleanup(@()(rmdir(test_install,'s')));
-            
-            template_files = {'horace_install.m','horace_on.m.template',...
-                'worker_v4.m.template'};
-            obj.copy_install_files(template_files,test_install);
-            hor_test_source = fullfile(test_install,'Horace');
-            mkdir(hor_test_source);
-            init_files = {'horace_init.m'};
-            obj.copy_install_files(init_files ,hor_test_source);
-            
-            init_files = {'herbert_init.m'};
-            obj.copy_install_files(init_files ,hor_test_source);
+            % prepare fake horace installation package
+            [clOb,install_root,hor_admin,hor_test_source] = obj.prepare_install_package_structure( ...
+                'folder_to_install_from_package','','Horace','Horace');
             % move to install folder and test installation
-            
+
             current_dir = pwd;
-            cd(test_install);
+            cd(install_root);
             clob1 = onCleanup(@()cd(current_dir));
-            
+
             [install_folder,hor_init_dir,use_old_init_folder] = horace_install('-test_mode');
             % init folder remains the folder for tested installation
             assertEqual(fileparts(which('horace_on')),install_folder);
             assertTrue(use_old_init_folder);
-            
+
+            assertEqual(install_root,hor_admin);            
             assertEqual(hor_test_source,hor_init_dir);
-            
+
             clear clob1;
+            clear clOb;
         end
-        
+
         function test_folder_provided_old_install_exist(~)
             horace_code = fileparts(fileparts(which('horace_init')));
             %disp('*********** horace code:')
             %disp(horace_code)
-            
+
             [install_folder,hor_init_dir,use_old_init_path] = horace_install(...
                 'horace_root',horace_code,'-test_mode');
             assertEqual(fileparts(which('horace_on')),install_folder);
@@ -254,7 +237,50 @@ classdef test_horace_install < TestCase
             assertEqual(fullfile(horace_code,'horace_core'),hor_init_dir);
             assertTrue(use_old_init_path);
         end
-        
+
     end
-    
+    methods(Access=protected)
+        function [clOb,fake_install_root,admin_folder,hor_test_init] = ...
+                prepare_install_package_structure(obj,source_folder,admin_folder,hor_folder,her_folder)
+            % function builds fake directory tree and key files, which represents
+            % structure of Horace package obtained from different sources,
+            % e.g. GitHub, package or old directory tree and used for
+            % running horace_install script on this tree.
+            %
+            fake_install_root = fullfile(obj.this_folder,source_folder);
+            admin_folder      = fullfile(fake_install_root,admin_folder);
+            mkdir(admin_folder);
+            clOb = onCleanup(@()(rmdir(fake_install_root,'s')));
+
+            template_files = {'horace_install.m','horace_on.m.template',...
+                'worker_v4.m.template'};
+            obj.copy_install_files(template_files,admin_folder);
+            hor_test_init = fullfile(obj.this_folder,source_folder,hor_folder);
+            mkdir(hor_test_init);
+            init_files = {'horace_init.m'};
+            obj.copy_install_files(init_files ,hor_test_init);
+
+            init_files = {'herbert_init.m'};
+            if isempty(her_folder) || strcmp(her_folder,hor_folder)
+                her_test_source = hor_test_init;
+            else
+                her_test_source = fullfile(obj.this_folder,source_folder,her_folder);
+                mkdir(her_test_source);
+            end
+
+            obj.copy_install_files(init_files ,her_test_source);
+        end
+        %
+        function copy_install_files(~,source_files,target_folder)
+
+            for i=1:numel(source_files)
+                source = which(source_files{i});
+                [~,tn,te] = fileparts(source);
+                targ = fullfile(target_folder,[tn,te]);
+                copyfile(source,targ,'f');
+            end
+        end
+
+    end
+
 end

--- a/_test/test_admin/test_pc_spec_config.m
+++ b/_test/test_admin/test_pc_spec_config.m
@@ -85,6 +85,7 @@ classdef test_pc_spec_config < TestCase
             hc.log_level= ll+1;
             assertEqual(hc.log_level,ll+1);
 
+            clWarn = set_temporary_warning('off', 'HERBERT:parallel_config:parallel_threads');
             cm.load_configuration('-set_config');
 
             % the previous number of threads have been restored

--- a/admin/horace_install.m
+++ b/admin/horace_install.m
@@ -7,6 +7,7 @@ function [init_folder,hor_init_dir,use_old_init_path] = ...
 %  >>horace_install()
 %  >>horace_install('horace_root',/path/to/Horace)
 %  >>horace_install(__,'init_folder',/path/to/place/where/init_files/to_be_installed)
+%  >>horace_install(__,'spinW_folder',/path/to/spinW)
 %
 % Optional arguments:
 % ------------------
@@ -33,6 +34,7 @@ function [init_folder,hor_init_dir,use_old_init_path] = ...
 %  Expected to be used in test mode only.
 %
 HORACE_ON_PLACEHOLDER = '${Horace_CORE}';
+SPINW_PLACEHOLDER     = '${spinW_folder}';
 
 % presumably the code root is where this file is located
 code_root = fileparts(mfilename('fullpath'));
@@ -126,11 +128,19 @@ if opt.test_mode
     return;
 end
 % Install horace_on
+if isempty(opt.spinW_folder)
+    placeholders = {HORACE_ON_PLACEHOLDER};
+    replacement_str = {hor_init_dir};
+else
+    placeholders = {HORACE_ON_PLACEHOLDER,SPINW_PLACEHOLDER};
+    replacement_str = {hor_init_dir,opt.spinW_folder};
+end
 install_file( ...
     horace_on_path, ...
     fullfile(init_folder, 'horace_on.m'), ...
-    {HORACE_ON_PLACEHOLDER}, {hor_init_dir} ...
+    placeholders,replacement_str ...
     );
+
 % Install worker_v4 script (required by parallel routines) to user-path
 install_file(worker_path, fullfile(init_folder, 'worker_v4.m'));
 
@@ -216,6 +226,12 @@ function opts = parse_args(code_root,init_folder_default,...
         @(x) validate_path(x, 'init_folder') ...
                        );
 
+    parser.addParameter( ...
+        'spinW_folder', ...
+        '', ...
+        @(x) validate_path(x, 'spinW_folder') ...
+                       );
+    
     parser.parse(argi{:});
 
     opts = parser.Results;

--- a/admin/horace_install.m
+++ b/admin/horace_install.m
@@ -43,7 +43,7 @@ code_root = fileparts(mfilename('fullpath'));
 
 % is there an old installation present? Use old Horace init directory not
 % to create mess
-old_horace_on = which('horace_on');
+old_horace_on   = which('horace_on');
 old_init_folder = fileparts(old_horace_on);
 %
 % Are some path or parameters provided as input? If not, use defaults
@@ -127,7 +127,7 @@ worker_path = find_file( ...
 
 % Install horace_on
 if isempty(opt.spinW_folder)
-    placeholders = {HORACE_ON_PLACEHOLDER};
+    placeholders    = {HORACE_ON_PLACEHOLDER};
     replacement_str = {hor_init_dir};
 else
     placeholders = {HORACE_ON_PLACEHOLDER,SPINW_PLACEHOLDER};

--- a/admin/horace_install.m
+++ b/admin/horace_install.m
@@ -141,13 +141,14 @@ modified_hor_on_contents = install_file( ...
     );
 
 % Install worker_v4 script (required by parallel routines) to user-path
-install_file(worker_path, fullfile(init_folder, 'worker_v4.m'),opt.test_mode);
+install_file(worker_path, fullfile(init_folder, 'worker_v4.m'),'','',opt.test_mode);
 
-% Validate the installation
-validate_function(@horace_on, @horace_off);
-
-disp('Horace successfully installed.')
-disp('Call ''horace_on'' to start using Horace.')
+if ~opt.test_mode
+    % Validate the installation
+    validate_function(@horace_on, @horace_off);
+    disp('Horace successfully installed.')
+    disp('Call ''horace_on'' to start using Horace.')
+end
 
 end
 % -----------------------------------------------------------------------------
@@ -258,7 +259,7 @@ function file_contents = install_file(source, dest, placeholders, replace_strs,t
 % in placeholders with the string at the corresponding index in
 % replace_strs.
 %
-if exist('placeholders', 'var')
+if exist('placeholders', 'var') && ~isempty(placeholders)
     file_contents = fileread(source);
     for i = 1:numel(placeholders)
         file_contents = replace(file_contents, placeholders{i}, replace_strs{i});
@@ -268,12 +269,15 @@ if exist('placeholders', 'var')
     end
     write_file(dest, file_contents);
 else
-    if test_mode && nargout>0
-        file_contents = fileread(source);
+    if test_mode
+        if nargout>0
+            file_contents = fileread(source);
+            return;
+        end
     else
         copy_file(source, dest);
-        file_contents = [];
     end
+    file_contents = [];
 end
 end
 

--- a/admin/horace_on.m.template
+++ b/admin/horace_on.m.template
@@ -9,11 +9,11 @@ default_horace_path  = '${Horace_CORE}';
 % To use spinW together with Horace, modify the row below pointing to correct
 % spinW location. Also need to modify spinw_on template and place it together
 % with horace_on.m script.
-default_spinw_path = '${spinW_folder}';
+spinw_installation_path = '${spinW_folder}';
 
 %
-warn_state=warning('off','all');    % turn off warnings 
-% (so don't get errors if removing non-existent paths 
+warn_state=warning('off','all');    % turn off warnings
+% (so don't get errors if removing non-existent paths
 % -- if no package have been initialized before, this is normal situation)
 try
     % get old code version if any available. Will throw if no Horace
@@ -60,17 +60,18 @@ sw_start = which('spinw_on.m');
 ws = warning('off','MATLAB:rmpath:DirNotFound');
 if isempty(sw_start)
     % check if spinW already on a path, though "on" script is not on the path
-    sw_stargt = which('spinw_init');    
+    sw_stargt = which('spinw_init');
     if ~isempty(sw_stargt)
         spinw_init;
-    %else == no spinW, no point to warn users about it, probably they do not
-    %        care
+        %else == no spinW, no point to warn users about it, probably they do not
+        %        care
     end
 else
-    if spinw_installation_path(1)=='$' % spinW was installed through its own installation script
-       spinw_on();                     % Horace installation does not know about it.
+    if spinw_installation_path(1)=='$' || isempty(spinw_installation_path)
+        %             spinW was installed through its own installation script
+        spinw_on(); % Horace installation does not know about it.
     else   % spinw was installed through horace_install
-       spinw_on(spinw_installation_path);
+        spinw_on(spinw_installation_path);
     end
 end
 warning(ws);
@@ -79,7 +80,7 @@ if ~isempty(old_version) && new_version ~= old_version
     clearvars -global;
     clearvars config_store MPI_State ;
     evalin('base','clearvars')
-    clearvars -except horace_path;    
+    clearvars -except horace_path;
 end
 
 

--- a/admin/horace_on.m.template
+++ b/admin/horace_on.m.template
@@ -9,7 +9,7 @@ default_horace_path  = '${Horace_CORE}';
 % To use spinW together with Horace, modify the row below pointing to correct
 % spinW location. Also need to modify spinw_on template and place it together
 % with horace_on.m script.
-default_spinw_path = '/usr/local/mprogs/spinW';
+default_spinw_path = '${spinW_folder}';
 
 %
 warn_state=warning('off','all');    % turn off warnings 

--- a/admin/horace_on.m.template
+++ b/admin/horace_on.m.template
@@ -58,8 +58,20 @@ new_version = this_horace_version(root_path);
 % if spinW start up file exist, try to initialize it
 sw_start = which('spinw_on.m');
 ws = warning('off','MATLAB:rmpath:DirNotFound');
-if ~isempty(sw_start)
-    spinw_on(default_spinw_path);
+if isempty(sw_start)
+    % check if spinW already on a path, though "on" script is not on the path
+    sw_stargt = which('spinw_init');    
+    if ~isempty(sw_stargt)
+        spinw_init;
+    %else == no spinW, no point to warn users about it, probably they do not
+    %        care
+    end
+else
+    if spinw_installation_path(1)=='$' % spinW was installed through its own installation script
+       spinw_on();                     % Horace installation does not know about it.
+    else   % spinw was installed through horace_install
+       spinw_on(spinw_installation_path);
+    end
 end
 warning(ws);
 


### PR DESCRIPTION
fixes Re #1758 

`horace_install` accepts path to `spinW` package and if such  option is available, modifies `horace_on` to include path to spinW.

Modified unit tests for `horace_install` to remove common code and test new option.