### PR TITLE
removed old fit_sqw from horace demo

### DIFF
--- a/admin/horace_install.m
+++ b/admin/horace_install.m
@@ -19,11 +19,11 @@ function [init_folder,hor_init_dir,use_old_init_path,modified_hor_on_contents] =
 %                  to be installed. If missing,
 %                  <path to Horace code>/../ISIS folder is selected.
 %                  This folder will be added to Matlab search path.
-% spinW_folder --  key with value, which shows where spinw is located. 
-%                  Allows to initalize horace together with spin_w
+% spinW_folder --  key with value, which shows where spinW is located. 
+%                  Allows to initialize Horace together with spin_w
 %                  For this option to work, spinw_on.m.template file have
-%                  to be available in Horace and spinw package installedn and 
-%                  be avaiable on filesystem.
+%                  to be available in Horace and spinW package installed and 
+%                  be available on filesystem.
 %
 % test_mode   -- if true, do not install Horace but return installation
 %              folders, i.e. the folder where Horace and horace_on
@@ -33,7 +33,7 @@ function [init_folder,hor_init_dir,use_old_init_path,modified_hor_on_contents] =
 % Defaults (no arguments)
 %  the horace_install script is located either in the folder, where Horace
 %  and  Herbert folders are extracted to (installation archive) or in
-%  /Horace/admin folder (cloned from the Github directly)
+%  /Horace/admin folder (cloned from the GitHub directly)
 %
 % Output parameters:
 %  Expected to be used in test mode only.

--- a/demo/demo_FM_spinwaves.m
+++ b/demo/demo_FM_spinwaves.m
@@ -27,8 +27,9 @@ warning off
 js=pars(1); delta=pars(2);
 gam=pars(3); temp=pars(4); amp=pars(5);
 
-omega0 = delta + ...
-    (4*js)*((sin(pi.*qh)).^2 + (sin(pi.*qk)).^2 + (sin(pi.*ql)).^2);
+%omega0 = delta + ...
+%    (4*js)*((sin(pi.*qh)).^2 + (sin(pi.*qk)).^2 + (sin(pi.*ql)).^2);
+omega0 = delta + (8*js)*(1-cos(pi.*qh).*cos(pi.*qk).*cos(pi.*ql));
 
 Bose= en./ (1-exp(-11.602.*en./temp));%Bose factor from Tobyfit. 
 

--- a/demo/demo_FM_spinwaves.m
+++ b/demo/demo_FM_spinwaves.m
@@ -1,8 +1,6 @@
 function y=demo_FM_spinwaves(qh,qk,ql,en,pars)
-%
 % Calculate the spectral weight from a Heisenberg ferromagnet for a Q-E slice
 % with nearest-neighbour interactions only.
-% Same model as in sqw_broad in Tobyfit.
 %
 % syntax:
 %   >> wout= sqw_eval(win,@demo_FM_spinwaves,[pars],options)
@@ -27,13 +25,16 @@ warning off
 js=pars(1); delta=pars(2);
 gam=pars(3); temp=pars(4); amp=pars(5);
 
+% Same model as in sqw_broad in Tobyfit.
 %omega0 = delta + ...
 %    (4*js)*((sin(pi.*qh)).^2 + (sin(pi.*qk)).^2 + (sin(pi.*ql)).^2);
+% 
+% Iron nearest neighbours model
 omega0 = delta + (8*js)*(1-cos(pi.*qh).*cos(pi.*qk).*cos(pi.*ql));
 
 Bose= en./ (1-exp(-11.602.*en./temp));%Bose factor from Tobyfit. 
 
-%Use damped SHO model to give intensity:
+%Use damped SHO model to give intensity (peak broadening):
 y = amp.* (Bose .* (4.*gam.*omega0)./(pi.*((en-omega0).^2 + 4.*(gam.*en).^2)));
 
 

--- a/demo/horace_demo_script.m
+++ b/demo/horace_demo_script.m
@@ -133,7 +133,7 @@ keep_figure;
 %argument gives a verbose output during the fitting process
 J = 250;     % Exchange interaction in meV
 D = 0;      % Single-ion anisotropy in meV
-gam = 2.4;   % Intrinsic linewidth in meV (inversely proportional to excitation lifetime)
+gam = 0.5;   % Intrinsic linewidth in meV (inversely proportional to excitation lifetime)
 temp = 10;  % Sample measurement temperature in Kelvin
 amp = 5;  % Magnitude of the intensity of the excitation (arbitrary units)
 
@@ -150,8 +150,8 @@ kk = kk.set_bpin (0.05);   % initial background constant
 kk = kk.set_bfree (1);    % fix the background
 kk = kk.set_options('fit_control_parameters',[0.001 30 0.001]);
 sh = kk.simulate();
-[wfit fitdata]=kk.fit();
-plot(wfit)
+[wfit_hor fitdata_hor]=kk.fit();
+plot(wfit_hor)
 keep_figure
 try
     %Use spinW to calculate the S(Q,w) instead. First setup the spinW model.
@@ -185,7 +185,7 @@ try
     kk = kk.set_bfree (1);    % fix the background
     kk = kk.set_options('fit_control_parameters',[0.001 30 0.001]);    
     ssw = kk.simulate();
-    [wfit fitdata_sw]=kk.fit();
+    [wfit_sw fitdata_sw]=kk.fit();
 
 catch ME
     warning(ME.identifier,'Problem with spinw: %s',ME.message);

--- a/demo/horace_demo_script.m
+++ b/demo/horace_demo_script.m
@@ -20,7 +20,8 @@ par_file=fullfile(indir,'4to1_124.par'); % detector parameters (positions) file.
 %                                       % stored in nxspe files.
 sqw_file=fullfile(indir,'fe_demo.sqw'); % let's place output sqw file into
 %                                       % init directory.
-% after generation, sqw file becomes the source of further analysis
+% after generation, sqw file becomes the source of further analysis.
+% When script completed successfully, file will be deleted.
 data_source =sqw_file;
 
 
@@ -30,7 +31,8 @@ data_source =sqw_file;
 %Run the command below to obtain the data we will use for the demo. This
 %process can take a few minutes - be patient! Provide sqw file name as
 %additional parameter, to ensure that if sqw is already there, you do not 
-%need to generated source files again.
+%need to generated source files again. Generation of sqw file will not be
+%demonstrated as the result. Will demonstrate only operations with sqw.
 file_list=setup_demo_data(sqw_file);
 
 %At the end of this you should have a set of files called
@@ -40,7 +42,6 @@ file_list=setup_demo_data(sqw_file);
 %combines the data from several runs (23 in this case) into one single data
 %source, data from which can then be cut and sliced along any direction in
 %4-dimensional reciprocal space:
-
 
 % Set incident energy, lattice parameters etc.
 efix=787;
@@ -73,15 +74,15 @@ if ~isfile(sqw_file)
         u, v, psi, omega, dpsi, gl, gs);
 end
 
-%====================================
-%% Make plots etc
-%====================================
+%============================================
+%% Analyze dava visually. Make cuts and plots
+%============================================
 
 %Viewing axes to look at the data. These can be any orthogonal set you like
 proj.u=[1,0,0]; proj.v=[0,1,0]; proj.type='rrr';
 
 %3D slice - view using sliceomatic
-cc3=cut_sqw(sqw_file,proj,[-3,0.05,3],[-3,0.05,3],[-0.1,0.1],[0,16,700]); %,'-nopix');
+cc3=cut_sqw(sqw_file,proj,[-3,0.05,3],[-3,0.05,3],[-0.1,0.1],[0,16,700],'-nopix');
 save(cc3,'cut3D_sqw.sqw');
 plot(cc3);
 %notice the '-nopix' option - we chose not to retain in memory the
@@ -145,11 +146,11 @@ w_sqw=sqw_eval(cc2a,@demo_FM_spinwaves,[250 0 2.4 10 5]);
 %fixed (2nd vector is list of free parameters). We will
 %also have a backgound function (specified separately). The (optional) list
 %argument gives a verbose output during the fitting process
-J = 300;     % Exchange interaction in meV
+J = 250;     % Exchange interaction in meV
 D = 0;       % Single-ion anisotropy in meV
-gam  = 2;   % Intrinsic linewidth in meV (inversely proportional to excitation lifetime)
-temp = 10;  % Sample measurement temperature in Kelvin
-amp  = 2;  % Magnitude of the intensity of the excitation (arbitrary units)
+gam  = 2.5;   % Intrinsic linewidth in meV (inversely proportional to excitation lifetime)
+temp = 10; % Sample measurement temperature in Kelvin
+amp  = 1;  % Magnitude of the intensity of the excitation (arbitrary units)
 
 kk = multifit_sqw (cc2a);
 kk = kk.set_fun (@demo_FM_spinwaves);

--- a/demo/horace_demo_script.m
+++ b/demo/horace_demo_script.m
@@ -20,6 +20,7 @@ par_file=fullfile(indir,'4to1_124.par'); % detector parameters (positions) file.
 %                                       % stored in nxspe files.
 sqw_file=fullfile(indir,'fe_demo.sqw'); % let's place output sqw file into
 %                                       % init directory.
+% after generation, sqw file becomes the source of further analysis
 data_source =sqw_file;
 
 
@@ -130,24 +131,25 @@ plot(wdiff);
 %==================================
 
 cc2a=cut_sqw(sqw_file,proj,[-3,0.05,3],[-3,0.05,3],[-0.1,0.1],[180,220]);
+plot(cc2a)
+keep_figure;
 
 % Simulate a model for S(Q,w):
 % (This is an example where the user can provide the spectral weight as a
 % function of (vector) Q and energy)
 w_sqw=sqw_eval(cc2a,@demo_FM_spinwaves,[250 0 2.4 10 5]);
-plot(w_sqw)
-keep_figure;
 %Looks vaguely like the data.
 
+% Simulation parameters are 300 0 2 10 2 and we try to recover it
 %Do a fit. We'll fit parameters 1, 3 and 5 in our model, but leave 2 and 4
 %fixed (2nd vector is list of free parameters). We will
 %also have a backgound function (specified separately). The (optional) list
 %argument gives a verbose output during the fitting process
-J = 250;     % Exchange interaction in meV
+J = 300;     % Exchange interaction in meV
 D = 0;       % Single-ion anisotropy in meV
-gam = 0.5;   % Intrinsic linewidth in meV (inversely proportional to excitation lifetime)
+gam  = 2;   % Intrinsic linewidth in meV (inversely proportional to excitation lifetime)
 temp = 10;  % Sample measurement temperature in Kelvin
-amp = 5;  % Magnitude of the intensity of the excitation (arbitrary units)
+amp  = 2;  % Magnitude of the intensity of the excitation (arbitrary units)
 
 kk = multifit_sqw (cc2a);
 kk = kk.set_fun (@demo_FM_spinwaves);
@@ -172,17 +174,17 @@ try
     fefm.genlattice('lat_const',[2.87 2.87 2.87],'angled',[90 90 90],'sym','I m -3 m');
     fefm.addatom('r',[0 0 0],'S',2.5,'label', 'MFe3');
     fefm.gencoupling();
-    fefm.addmatrix('label','J','value',1);
+    fefm.addmatrix('label','J','value',-1);
     fefm.addcoupling('mat','J','bond',1);
 
     fefm.addmatrix('value',diag([0 0 -1]),'label','D');
     fefm.addaniso('D');
     fefm.genmagstr('mode','direct','S',[0,0; 0,0;1,1]);
 
-    cpars = {'mat', {'J', 'D(3,3)'}, 'hermit', false, 'optmem', 1, 'useFast', true, 'resfun', 'sho', 'formfact', true};
+    cpars = {'mat', {'J', 'D(3,3)'}, 'hermit', false, 'optmem', 1, 'useFast', true, 'resfun', 'sho', 'formfact', false};
 
     kk = multifit_sqw (cc2a);
-    kk = kk.set_fun (@fefm.horace_sqw, {[300 0 2 10 2], cpars{:}});
+    kk = kk.set_fun (@fefm.horace_sqw, {[50 0 2 10 0.1], cpars{:}});
 
     %kk = kk.set_pin ({[250 0 2.4 10 5],fefm}); %input parameters
     kk = kk.set_free ([1 0 1 0 1]); %fitting parameters 1,3 and 5

--- a/demo/horace_spinW_comparison.m
+++ b/demo/horace_spinW_comparison.m
@@ -1,0 +1,155 @@
+% This script is based on horace_dempo_script. It illustrates comparison
+% between Horace and spinW parameters. 
+%
+% After some efforts to achieve equivalence and explaining differecne, it
+% should be converted into integration script.
+%
+% Define working directories, used by this script
+%First of all ensure that the current directory of Matlab is the directory
+%in which this script file is located (otherwise the following line will
+%not work).
+demo_dir = fileparts(mfilename('fullpath'));
+indir=demo_dir; % source directory of spe (or nxspe) files
+%               % We will generate demo source files  in this directory,
+%               % but usually this  folder is the folder with data
+%               % reduction results
+par_file=fullfile(indir,'4to1_124.par'); % detector parameters (positions) file.
+%                                       % Old spe files need this but modern
+%                                       % reduction script puts this data into
+%                                       % each nxspe file, so par-file may
+%                                       % be lef empty. If it is not emptpy, it
+%                                       % contents will override the contents
+%                                       % stored in nxspe files.
+sqw_file=fullfile(indir,'fe_demo.sqw'); % let's place output sqw file into
+%                                       % init directory.
+% after generation, sqw file becomes the source of further analysis
+data_source =sqw_file;
+
+
+%====================================
+%% Generate Horace data files
+%====================================
+%Run the command below to obtain the data we will use for the demo. This
+%process can take a few minutes - be patient! Provide sqw file name as
+%additional parameter, to ensure that if sqw is already there, you do not
+%need to generated source files again.
+file_list=setup_demo_data(sqw_file);
+
+%At the end of this you should have a set of files called
+%HoraceDemoDataFileN.spe, where N is 1 to 23.
+
+%We will now generate the SQW file that lies at the heart of Horace. It
+%combines the data from several runs (23 in this case) into one single data
+%source, data from which can then be cut and sliced along any direction in
+%4-dimensional reciprocal space:
+
+
+% Set incident energy, lattice parameters etc.
+efix=787;
+emode=1;
+alatt=[2.87,2.87,2.87];
+angdeg=[90,90,90];
+u=[1,0,0];
+v=[0,1,0];
+omega=0;dpsi=0;gl=0;gs=0;
+
+% Create the list of file names and orientation angles
+psi=0:4:90;%the angle of the sample w.r.t. the incident beam for each run.
+%psi=0 is defined when u is parallel to the incident beam (in this case
+%u=[1,0,0] - see above).
+
+nfiles=numel(psi);
+if exist('file_list','var')
+    spe_file = file_list;
+else
+    spe_file=cell(1,nfiles);
+    for i=1:length(psi)
+        spe_file{i}=fullfile(indir,['HoraceDemoDataFile',num2str(i),'.nxspe']);
+        if ~exist(spe_file{i},'file')
+            spe_file{i}=fullfile(indir,['HoraceDemoDataFile',num2str(i),'.spe']);
+        end
+    end
+end
+if ~isfile(sqw_file)
+    gen_sqw (spe_file, par_file, sqw_file, efix, emode, alatt, angdeg,...
+        u, v, psi, omega, dpsi, gl, gs);
+end
+
+%====================================
+%% Make plots etc
+%====================================
+
+%Viewing axes to look at the data. These can be any orthogonal set you like
+proj.u=[1,0,0]; proj.v=[0,1,0]; proj.type='rrr';
+
+cc2a=cut_sqw(sqw_file,proj,[-3,0.05,3],[-3,0.05,3],[-0.1,0.1],[80,100]);
+plot(cc2a)
+
+
+% Simulation parameters are 300 0 2 10 2 and we try to recover it
+%Do a fit. We'll fit parameters 1, 3 and 5 in our model, but leave 2 and 4
+%fixed (2nd vector is list of free parameters). We will
+%also have a backgound function (specified separately). The (optional) list
+%argument gives a verbose output during the fitting process
+J = 300;     % Exchange interaction in meV
+D = 0;       % Single-ion anisotropy in meV
+gam  = 2;   % Intrinsic linewidth in meV (inversely proportional to excitation lifetime)
+temp = 10;  % Sample measurement temperature in Kelvin
+amp  = 2;  % Magnitude of the intensity of the excitation (arbitrary units)
+
+% Simulate a model for S(Q,w):
+% (This is an example where the user can provide the spectral weight as a
+% function of (vector) Q and energy)
+w_sqw=sqw_eval(cc2a,@demo_FM_spinwaves,[J D gam temp amp]);
+w_sqw.pix.variance  = 1;
+w_sqw.data.e = 1;
+
+
+kk = multifit_sqw (w_sqw);
+kk = kk.set_fun (@demo_FM_spinwaves);
+
+kk = kk.set_pin ([J D gam temp amp]); %input parameters
+kk = kk.set_free ([1 0 1 0 1]); %fitting parameters 1, 3 and 5
+
+kk = kk.set_bfun (@constant_background); % set_bfun sets the background functions
+kk = kk.set_bpin (0.05);   % initial background constant
+kk = kk.set_bfree (1);    % fix the background
+kk = kk.set_options('fit_control_parameters',[0.001 30 0.001],'listing',2);
+sh = kk.simulate();
+plot(sh)
+keep_figure;
+[wfit_hor fitdata_hor]=kk.fit();
+plot(wfit_hor)
+keep_figure
+
+%Use spinW to calculate the S(Q,w) instead. First setup the spinW model.
+
+fefm = spinw;
+
+fefm.genlattice('lat_const',[2.87 2.87 2.87],'angled',[90 90 90],'sym','I m -3 m');
+fefm.addatom('r',[0 0 0],'S',2.5,'label', 'MFe3');
+fefm.gencoupling();
+fefm.addmatrix('label','J','value',-1);
+fefm.addcoupling('mat','J','bond',1);
+
+fefm.addmatrix('value',diag([0 0 -1]),'label','D');
+fefm.addaniso('D');
+fefm.genmagstr('mode','direct','S',[0,0; 0,0;1,1]);
+
+cpars = {'mat', {'J', 'D(3,3)'}, 'hermit', false, 'optmem', 1, 'useFast', true, 'resfun', 'sho', 'formfact', false};
+
+kk = multifit_sqw (w_sqw);
+kk = kk.set_fun (@fefm.horace_sqw, {[50 D gam temp amp], cpars{:}});
+
+kk = kk.set_free ([1 0 1 0 1]); %fitting parameters 1,3 and 5
+
+kk = kk.set_bfun (@constant_background); % set_bfun sets the background functions
+kk = kk.set_bpin (0.05);   % initial background constant
+kk = kk.set_bfree (1);    % fix the background
+kk = kk.set_options('fit_control_parameters',[0.001 30 0.001],'listing',2);
+ssw = kk.simulate();
+plot(ssw);
+keep_figure;
+[wfit_sw fitdata_sw]=kk.fit();
+plot(wfit_sw);
+

--- a/demo/setup_demo_data.m
+++ b/demo/setup_demo_data.m
@@ -6,7 +6,7 @@ function file_list=setup_demo_data()
 
 demo_dir=pwd;
 
-en=[-80:8:760];
+en=-80:8:760;
 par_file=[demo_dir,filesep,'4to1_124.par'];
 sqw_file_single=[demo_dir,filesep,'single.sqw'];
 efix=800;
@@ -29,19 +29,18 @@ disp('Getting data for Horace demo... Please wait a few minutes');
 try
     for i=1:numel(psi)
         if i<=nxspe_limit
-            file_list{i} = [demo_dir,filesep,'HoraceDemoDataFile',num2str(i),'.nxspe'];            
+            file_list{i} = fullfile(demo_dir,['HoraceDemoDataFile',num2str(i),'.nxspe']);
         else
-            file_list{i} = [demo_dir,filesep,'HoraceDemoDataFile',num2str(i),'.spe'];            
+            file_list{i} = fullfile(demo_dir,['HoraceDemoDataFile',num2str(i),'.spe']);
         end
         if exist(file_list{i},'file')
             continue;
         end
-        dummy_sqw(en, par_file, sqw_file_single, efix, emode, alatt, angdeg,...
-                         u, v, psi(i), omega, dpsi, gl, gs);
+        w = dummy_sqw(en, par_file, sqw_file_single, efix, emode, alatt, angdeg,...
+            u, v, psi(i), omega, dpsi, gl, gs);
 
-        w=read_sqw(sqw_file_single);
         %Make the fake data:
-        w=sqw_eval(w,@demo_FM_spinwaves,[300 0 2 10 2]);%simulate spinwave cross-section 
+        w=sqw_eval(w,@demo_FM_spinwaves,[300 0 2 10 2]);%simulate spinwave cross-section
         w=noisify(w,1);%add some noise to simulate real data
         if i<=nxspe_limit
             d = rundatah(w+0.74);
@@ -64,5 +63,3 @@ end
 if exist(sqw_file_single,'file')
     delete(sqw_file_single);
 end
-
-    

--- a/demo/setup_demo_data.m
+++ b/demo/setup_demo_data.m
@@ -2,13 +2,14 @@ function file_list=setup_demo_data(sqw_ready)
 %
 % Internal routine for demo - generates some spe files that can then be
 % used in the Horace demo suite.
+% 
 %
 
 demo_dir=pwd;
 
 en=-80:8:760;
-par_file=[demo_dir,filesep,'4to1_124.par'];
-sqw_file_single=[demo_dir,filesep,'single.sqw'];
+par_file=fullfile(demo_dir,'4to1_124.par');
+sqw_file_single=fullfile(demo_dir,'single.sqw');
 efix=800;
 emode=1;
 alatt=[2.87,2.87,2.87];

--- a/demo/setup_demo_data.m
+++ b/demo/setup_demo_data.m
@@ -1,4 +1,4 @@
-function file_list=setup_demo_data()
+function file_list=setup_demo_data(sqw_ready)
 %
 % Internal routine for demo - generates some spe files that can then be
 % used in the Horace demo suite.
@@ -24,6 +24,7 @@ file_list = cell(1,numel(psi));
 hil=get(hor_config,'log_level');
 set(hor_config,'log_level',-Inf);
 clob = onCleanup(@()set(hor_config,'log_level',hil));
+resulting_sqw_present = isfile(sqw_ready);
 %
 disp('Getting data for Horace demo... Please wait a few minutes');
 try
@@ -33,7 +34,7 @@ try
         else
             file_list{i} = fullfile(demo_dir,['HoraceDemoDataFile',num2str(i),'.spe']);
         end
-        if exist(file_list{i},'file')
+        if exist(file_list{i},'file') || resulting_sqw_present
             continue;
         end
         w = dummy_sqw(en, par_file, sqw_file_single, efix, emode, alatt, angdeg,...

--- a/herbert_core/applications/multifit/@mfclass/set_options.m
+++ b/herbert_core/applications/multifit/@mfclass/set_options.m
@@ -49,8 +49,6 @@ function obj = set_options (obj, varargin)
 
 
 % Original author: T.G.Perring
-%
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
 
 
 %--------------------------------------------------------------------------


### PR DESCRIPTION
fixes Re #1762. 
Old `fit_sqw` interface have been removed from Horace, but left in demo sctipt and now fails. This PR fixes this issue (noticed by user).

There is the question why not to support old `fit_sqw` interface -- it is ugly but works in old scripts. 

There is the question about spinW-Horace comparison as current spinW does not reproduce result obtained from Horace, but formaly demo script is fixed and spinW-Horace comparison is the question for another ticket.
The comparison question redirected to spinW:
 https://github.com/SpinW/spinw/issues/207
