### PR TITLE
bug in alignment

### DIFF
--- a/_test/test_change_crystal/test_change_crystal_bragg_coarse.m
+++ b/_test/test_change_crystal/test_change_crystal_bragg_coarse.m
@@ -273,9 +273,7 @@ classdef test_change_crystal_bragg_coarse < TestCaseWithSave
         end
         %------------------------------------------------------------------
         %------------------------------------------------------------------
-        function test_revert_alignment_works_on_file_and_on_filebacked(obj)
-            corr  = crystal_alignment_info([5.0191 4.9903 5.0121], ...
-                [90.1793 90.9652 89.9250], [-0.0530 0.0519 0.0345]);
+        function test_revert_alignment_same_on_file_and_on_filebacked_object(obj)
             test_file_fb = build_tmp_file_name(obj.misaligned_sqw_file);
             copyfile(obj.misaligned_sqw_file, test_file_fb, 'f');
             test_file_file = fullfile(tmp_dir,'misaligned_file_to_check_reversion.sqw');
@@ -289,8 +287,9 @@ classdef test_change_crystal_bragg_coarse < TestCaseWithSave
             test_fb = test_fb.set_as_tmp_obj();
             assertTrue(test_fb.is_tmp_obj)
 
-
-            % TEST:
+            corr  = crystal_alignment_info([5.0191 4.9903 5.0121], ...
+                [90.1793 90.9652 89.9250], [-0.0530 0.0519 0.0345]);
+            % TEST:            
             % apply alignment on FB object
             test_fb_ref = change_crystal(test_fb, corr);
             % apply alignment on file directrly

--- a/_test/test_change_crystal/test_change_crystal_bragg_coarse.m
+++ b/_test/test_change_crystal/test_change_crystal_bragg_coarse.m
@@ -273,6 +273,46 @@ classdef test_change_crystal_bragg_coarse < TestCaseWithSave
         end
         %------------------------------------------------------------------
         %------------------------------------------------------------------
+        function test_revert_alignment_works_on_file_and_on_filebacked(obj)
+            corr  = crystal_alignment_info([5.0191 4.9903 5.0121], ...
+                [90.1793 90.9652 89.9250], [-0.0530 0.0519 0.0345]);
+            test_file_fb = build_tmp_file_name(obj.misaligned_sqw_file);
+            copyfile(obj.misaligned_sqw_file, test_file_fb, 'f');
+            test_file_file = fullfile(tmp_dir,'misaligned_file_to_check_reversion.sqw');
+            copyfile(obj.misaligned_sqw_file, test_file_file, 'f');
+            clOb = onCleanup(@()delete(test_file_file));
+
+
+            test_fb = sqw(test_file_fb,'file_backed',true);
+            assertTrue(test_fb.is_filebacked, ...
+                'This test validates filebacked operations but the object test_fb placed in memory')
+            test_fb = test_fb.set_as_tmp_obj();
+            assertTrue(test_fb.is_tmp_obj)
+
+
+            % TEST:
+            % apply alignment on FB object
+            test_fb_ref = change_crystal(test_fb, corr);
+            % apply alignment on file directrly
+            test_file = change_crystal(test_file_file, corr);
+
+            assertEqualToTol(test_fb_ref,sqw(test_file{1}),'ignore_str',true);
+
+            source_obj = sqw(obj.misaligned_sqw_file,'file_backed',true);
+            rev_corr_way1 = crystal_alignment_info(source_obj.data.alatt,source_obj.data.angdeg);
+            rev_corr_way1.rotmat = test_fb_ref.pix.alignment_matr';
+
+            rev_corr_way2 = crystal_alignment_info(source_obj.data.alatt,source_obj.data.angdeg);
+            rev_corr_way2.rotmat = corr.rotmat';
+
+            assertEqualToTol(rev_corr_way1,rev_corr_way2)
+
+            test_fb_rev = change_crystal(test_fb_ref, rev_corr_way1);
+            test_file_rev = change_crystal(test_file_file, rev_corr_way1);
+
+            assertEqualToTol(test_fb_rev,sqw(test_file_rev{1}),'ignore_str',true,'tol',[1.e-12,1.e-12]);
+        end
+
         function test_alignment_is_additive_on_file(obj)
             % Prepare test data
             corr  = crystal_alignment_info([5.0191 4.9903 5.0121], ...

--- a/horace_core/change_crystal.m
+++ b/horace_core/change_crystal.m
@@ -110,7 +110,7 @@ for i=1:numel(in_data)
             %
             if ~alignment_info.legacy_mode
                 pix_info = ld.get_pix_metadata();
-                pix_info.alignment_matr = alignment_info.rotmat;
+                pix_info.alignment_matr = pix_info.alignment_matr*alignment_info.rotmat;
                 ld = ld.put_pix_metadata(pix_info);
             end
         elseif sqw_only

--- a/horace_core/lattice_functions/bragg_positions.m
+++ b/horace_core/lattice_functions/bragg_positions.m
@@ -128,9 +128,9 @@ wcut=repmat(IX_dataset_1d,npeaks,3);
 wpeak=repmat(IX_dataset_1d,npeaks,3);
 
 % Get matrix to convert rlu to projection axes
-proj = img.proj;
-u1_rlu = proj.u;
-u2_rlu = proj.v;
+proj0 = img.proj;
+u1_rlu = proj0.u;
+u2_rlu = proj0.v;
 % Get the matrix to convert rlu to crystal Cartesian coordinates
 B = bmatrix (img.alatt, img.angdeg);
 
@@ -153,12 +153,6 @@ for i=1:size(rlu_expected,1)
     else
         v=u2_rlu;
     end
-    type='aaa';        % force unit length of projection axes to be 1 Ang^-1
-    proj = line_proj('u',u,'v',v,'type',type,'offset',offset, ...
-        'alatt',img.alatt,'angdeg',img.angdeg);
-
-    % if old file has been already aligned, ignore this alignment
-    proj.ignore_legacy_alignment = true;
 
     % radial_cut_length, radial_bin_width, radial_thickness,...
     % trans_cut_length, trans_bin_width, trans_thickness, energy_window)
@@ -170,7 +164,7 @@ for i=1:size(rlu_expected,1)
         bin_t=trans_bin_width;
         thick_t=trans_thickness;
     else
-        modQ=norm(proj.transform_hkl_to_pix(Qrlu(:)));   % length of Q vector in Ang^-1        
+        modQ=norm(proj0.transform_hkl_to_pix(Qrlu(:)));   % length of Q vector in Ang^-1        
         len_r=radial_cut_length*modQ;
         bin_r=radial_bin_width*modQ;
         thick_r=radial_thickness*modQ;
@@ -178,6 +172,14 @@ for i=1:size(rlu_expected,1)
         bin_t=(pi/180)*trans_bin_width*modQ;
         thick_t=(pi/180)*trans_thickness*modQ;
     end
+    % Build projection for using in cuts done in A^-1 Units
+    type='aaa';        % force unit length of projection axes to be 1 Ang^-1
+    proj = line_proj('u',u,'v',v,'type',type,'offset',offset, ...
+        'alatt',img.alatt,'angdeg',img.angdeg);
+
+    % if old file has been already aligned, ignore this alignment
+    proj.ignore_legacy_alignment = true;
+    
 
     % Make three orthogonal cuts through nominal Bragg peak positions
     disp('--------------------------------------------------------------------------------')

--- a/horace_core/lattice_functions/bragg_positions.m
+++ b/horace_core/lattice_functions/bragg_positions.m
@@ -56,13 +56,13 @@ function [rlu_actual,width,wcut,wpeak]=bragg_positions(w, rlu_expected,...
 %                  (radial cuts) and degrees (transverse cuts)
 %
 % Fitting:
-%   'outer'         Determine peak position from centre of peak half-height; find
+%   'outer'        Determine peak position from centre of peak half-height; find
 %                  peak width moving inwards from limits of data - useful if
 %                  there is known to be a single peak in the data as it is
 %                  more robust to too finely binned data.  [Default]
-%   'inner'         Determine peak position from centre of peak half height; find
+%   'inner'        Determine peak position from centre of peak half height; find
 %                  peak width moving outwards from peak maximum
-%   'gaussian'      Fit Gaussian on a linear background.
+%   'gaussian'     Fit Gaussian on a linear background.
 %
 %
 % Output:
@@ -139,7 +139,6 @@ peak_problem=false(size(rlu_expected));
 for i=1:size(rlu_expected,1)
     % Extract Q point through which to get three orthogonal cuts
     Qrlu = rlu_expected(i,:);
-    modQ=norm(proj.transform_hkl_to_pix(Qrlu(:)));   % length of Q vector in Ang^-1
 
     % Create proj for taking three orthogonal cuts
     %   - proj.u along Q, to get maximum resolution in d-spacing
@@ -171,6 +170,7 @@ for i=1:size(rlu_expected,1)
         bin_t=trans_bin_width;
         thick_t=trans_thickness;
     else
+        modQ=norm(proj.transform_hkl_to_pix(Qrlu(:)));   % length of Q vector in Ang^-1        
         len_r=radial_cut_length*modQ;
         bin_r=radial_bin_width*modQ;
         thick_r=radial_thickness*modQ;


### PR DESCRIPTION
While working with alignment code, I have identified another bug there.  There was a way to change pixels alignment directly in file, which has not been modified similarly to the changes for filebacker/memorybased `sqw` objects.
In other words, `change_crystal` filebacked operation with metadata was missing multiplication by new alignment matrix, added to operations with `sqw` objects earlier

This PR adds unit test demonstrating the bug and fixture for it.