### PR TITLE
Fix docify for R2024

### DIFF
--- a/_test/test_admin/test_help.m
+++ b/_test/test_admin/test_help.m
@@ -1,0 +1,27 @@
+classdef test_help< TestCase
+    % Verify if help which uses docify works regardless of Matlab version
+
+    properties
+    end
+    methods
+        %
+        function this=test_help(name)
+            if nargin<1
+                name = 'test_help';
+            end
+            this = this@TestCase(name);
+
+        end
+        function test_help_works(~)
+            ref_str = sprintf('%s\n%s\n%s',...
+                'Verify if help which uses docify works regardless of Matlab version',...
+                'Documentation for test_help',...
+                'doc test_help');
+            actual_help = disp2str(help('test_help'));
+
+            assertEqual(ref_str,actual_help)
+        end
+
+    end
+end
+

--- a/_test/test_admin/test_help.m
+++ b/_test/test_admin/test_help.m
@@ -13,9 +13,14 @@ classdef test_help< TestCase
 
         end
         function test_help_works(~)
+            if matlab_version_num() < 9.05
+                ref_str = 'Reference page in Doc Center';
+            else
+                ref_str = 'Documentation for test_help';
+            end
             ref_str = sprintf('%s\n%s\n%s',...
                 'Verify if help which uses docify works regardless of Matlab version',...
-                'Documentation for test_help',...
+                ref_str,...
                 'doc test_help');
             actual_help = disp2str(help('test_help'));
 

--- a/_test/test_admin/test_help.m
+++ b/_test/test_admin/test_help.m
@@ -13,7 +13,7 @@ classdef test_help< TestCase
 
         end
         function test_help_works(~)
-            if matlab_version_num() < 9.05
+            if matlab_version_num() < 9.06
                 ref_str = 'Reference page in Doc Center';
             else
                 ref_str = 'Documentation for test_help';

--- a/herbert_core/applications/docify/help.m
+++ b/herbert_core/applications/docify/help.m
@@ -1,76 +1,76 @@
 function [out, docTopic] = help(varargin)
-    % Customized overloaded help function
-    % 1. If the help topic has docify directives, run docify and use its result
-    % 2. Otherwise use the builtin help
-    % This function assumes that the input is a string, like the built-in function
-    %
-    % A limitation of this function is that it cannot be used to look up
-    % properties defined within the same file as a classdef
-    % E.g. `help mfclass/fun` will produce the docstring in the original
-    % mfclass.m file and *not* the docified version.
-    % However, docify does not support such substitution in any case.
-    %
-    % Another limitation is that inherited methods in separate files
-    % e.g. IX_data_1d/acosh which is inherited from IX_dataset
-    % are not processed (they are not resolved).
-    % E.g. `help IX_dataset/acosh` returns the docified version
-    % but  `help IX_data_1d/acosh` returns the raw docify code.
+% Customized overloaded help function
+% 1. If the help topic has docify directives, run docify and use its result
+% 2. Otherwise use the builtin help
+% This function assumes that the input is a string, like the built-in function
+%
+% A limitation of this function is that it cannot be used to look up
+% properties defined within the same file as a classdef
+% E.g. `help mfclass/fun` will produce the docstring in the original
+% mfclass.m file and *not* the docified version.
+% However, docify does not support such substitution in any case.
+%
+% Another limitation is that inherited methods in separate files
+% e.g. IX_data_1d/acosh which is inherited from IX_dataset
+% are not processed (they are not resolved).
+% E.g. `help IX_dataset/acosh` returns the docified version
+% but  `help IX_data_1d/acosh` returns the raw docify code.
 
-    % Create a handle to the original Matlab help function
-    persistent builtin_help;
-    if isempty(builtin_help)
-        builtin_help = get_shadowed_function_handle('help', mfilename('fullpath'));
+% Create a handle to the original Matlab help function
+persistent builtin_help;
+if isempty(builtin_help)
+    builtin_help = get_shadowed_function_handle('help', mfilename('fullpath'));
+end
+
+if nargin == 0 && isscalar(dbstack)
+    % Replicate Matlab behaviour where we get the help of the
+    % previous command entered if user just types `help` on the CLI
+    helpProcess = get_previous_help(nargout);
+elseif strcmpi(varargin{1}, 'help')
+    % Show docstring for builtin help
+    helpProcess = show_builtin_help(nargout);
+elseif nargin == 1
+    topic = check_docify(varargin{1});
+    if ~isempty(topic)
+        % Topic has docify strings, parse it
+        helpProcess = docify_help(varargin{1}, topic, nargout, nargin);
     end
-    
-    if nargin == 0 && isscalar(dbstack)
-        % Replicate Matlab behaviour where we get the help of the 
-        % previous command entered if user just types `help` on the CLI
-        helpProcess = get_previous_help(nargout);
-    elseif strcmpi(varargin{1}, 'help')
-        % Show docstring for builtin help
-        helpProcess = show_builtin_help(nargout);
-    elseif nargin == 1
-        topic = check_docify(varargin{1});
-        if ~isempty(topic)
-            % Topic has docify strings, parse it
-            helpProcess = docify_help(varargin{1}, topic, nargout, nargin);
-        end
-    end
-    if ~exist('helpProcess', 'var') || isempty(helpProcess)
-        % Calls the builtin help function
-        if nargout == 0
-            builtin_help(varargin{:});
-        else
-            [out, docTopic] = builtin_help(varargin{:});
-        end
+end
+if ~exist('helpProcess', 'var') || isempty(helpProcess)
+    % Calls the builtin help function
+    if nargout == 0
+        builtin_help(varargin{:});
     else
-        helpProcess.prepareHelpForDisplay;
-        if nargout > 0
-            out = helpProcess.helpStr;
-            if nargout > 1
-                docTopic = helpProcess.docLinks.referencePage;
-                if isempty(docTopic)
-                    docTopic = helpProcess.docLinks.productName;
-                end
+        [out, docTopic] = builtin_help(varargin{:});
+    end
+else
+    helpProcess.prepareHelpForDisplay;
+    if nargout > 0
+        out = helpProcess.helpStr;
+        if nargout > 1
+            docTopic = helpProcess.docLinks.referencePage;
+            if isempty(docTopic)
+                docTopic = helpProcess.docLinks.productName;
             end
         end
     end
 end
+end
 
 function process = get_previous_help(n_out)
-    process = helpUtils.helpProcess(n_out, 0, {});
-    process.isAtCommandLine = true;
-    process.getHelpText;
+process = helpUtils.helpProcess(n_out, 0, {});
+process.isAtCommandLine = true;
+process.getHelpText;
 end
 
 function process = show_builtin_help(n_out)
-    list = which('help', '-all');
-    f = strncmp(list, matlabroot, numel(matlabroot));
-    if any(f)
-        topic = list{find(f, 1, 'first')};
-    else
-        topic = 'help';
-    end
-    process = helpUtils.helpProcess(n_out, 1, {topic});
-    process.getHelpText;
+list = which('help', '-all');
+f = strncmp(list, matlabroot, numel(matlabroot));
+if any(f)
+    topic = list{find(f, 1, 'first')};
+else
+    topic = 'help';
+end
+process = helpUtils.helpProcess(n_out, 1, {topic});
+process.getHelpText;
 end

--- a/herbert_core/applications/docify/private/check_docify.m
+++ b/herbert_core/applications/docify/private/check_docify.m
@@ -1,12 +1,19 @@
 function out = check_docify(topic)
+    persistent isR2023
+    if isempty(isR2023)
+        isR2023 = isMATLABReleaseOlderThan('R2024a');
+    end
+    if isR2023
+        resolveName = @(topic) matlab.internal.language.introspective.resolveName(topic, '', false, [], false);
+    else
+        resolveName = @matlab.lang.internal.introspective.resolveName;
+    end
     % Checks if a topic contains docify directives and returns mfile name
     out = [];
     % Uses internal Matlab functions to resolve the topic to a file
-    resolver = matlab.internal.language.introspective.resolveName( ...
-        topic, '', false, [], false);
+    resolver = resolveName(topic);
     if isempty(resolver.nameLocation)
-        resolver = matlab.internal.language.introspective.resolveName( ...
-            regexprep(topic, '\.', '/'), '', false, [], false);
+        resolver = resolveName(regexprep(topic, '\.', '/'));
         if isempty(resolver.nameLocation) || ~exist(resolver.nameLocation, 'file')
             return
         end

--- a/herbert_core/applications/docify/private/check_docify.m
+++ b/herbert_core/applications/docify/private/check_docify.m
@@ -1,7 +1,12 @@
 function out = check_docify(topic)
     persistent isR2023
     if isempty(isR2023)
-        isR2023 = isMATLABReleaseOlderThan('R2024a');
+        try
+            matlab.internal.language.introspective.resolveName('');
+            isR2023 = true;
+        catch
+            isR2023 = false;
+        end
     end
     if isR2023
         resolveName = @(topic) matlab.internal.language.introspective.resolveName(topic, '', false, [], false);


### PR DESCRIPTION
Fixes Horace overloaded `help` command using "docify" for R2024a and newer (where the Matlab internal language function `resolveName` changed package and syntax.

Fixes #1780