### PR TITLE
fix fetch of glc

### DIFF
--- a/_test/test_unique_objects_container/test_unique_references.m
+++ b/_test/test_unique_objects_container/test_unique_references.m
@@ -28,7 +28,81 @@ classdef test_unique_references < TestCase
             unique_references_container.global_container( ...
                 'CLEAR','GLOBAL_NAME_SAMPLES_CONTAINER')
         end
+        %------------------------------------------------------------------
+        function test_save_restore_global_state_two_urcs(~)
+            clWa = set_temporary_warning('off','HERBERT:unique_references_container:debug_only_argument');
+            function urc_clearer()
+                unique_references_container.global_container('CLEAR','multifit_issue')
+            end
+            clSt  = onCleanup(@urc_clearer);
 
+            urc1 = unique_references_container('multifit_issue','char');
+            urc1(1) = 'aaa';
+            urc1(2) = 'aaa';
+            urc1(3) = 'aaa';
+            urc1(4) = 'bbb';
+            urc2 = unique_references_container('multifit_issue','char');
+            urc2(1) = 'ccc';
+            urc2(2) = 'ccc';
+            urc2(3) = 'ccc';
+            urc2(4) = 'bbb';
+
+
+            glc = unique_references_container.global_container( ...
+                'value','multifit_issue');
+
+            savestr1_or = urc1.to_struct();
+            savestr2_or = urc2.to_struct();            
+            unique_references_container.global_container( ...
+                'CLEAR','multifit_issue');
+
+
+            urr1 = serializable.from_struct(savestr1_or);
+            urr2 = serializable.from_struct(savestr2_or);            
+            glr = unique_references_container.global_container( ...
+                'value','multifit_issue');
+
+            savestr_copy1 = urr1.to_struct();
+            savestr_copy2 = urr2.to_struct();            
+
+            assertEqual(savestr1_or,savestr_copy1);
+            assertEqual(savestr2_or,savestr_copy2);            
+            clear clSt;
+        end
+        
+        function test_save_restore_global_state(~)
+            clWa = set_temporary_warning('off','HERBERT:unique_references_container:debug_only_argument');
+            function urc_clearer()
+                unique_references_container.global_container('CLEAR','multifit_issue')
+            end
+            clSt  = onCleanup(@urc_clearer);
+
+            urc = unique_references_container('multifit_issue','char');
+            urc(1) = 'aaa';
+            urc(2) = 'aaa';
+            urc(3) = 'aaa';
+            urc(4) = 'bbb';
+
+            glc = unique_references_container.global_container( ...
+                'value','multifit_issue');
+
+            savestr = urc.to_struct();
+            unique_references_container.global_container( ...
+                'CLEAR','multifit_issue');
+
+
+            urr = serializable.from_struct(savestr);
+            glr = unique_references_container.global_container( ...
+                'value','multifit_issue');
+
+            savestr_cp = urr.to_struct();
+
+            assertEqual(savestr,savestr_cp);
+            clear clSt;
+        end
+
+
+        %------------------------------------------------------------------
         function test_unique_reference_non_pollute_ws(obj)
             clOb = set_temporary_warning('off','HERBERT:unique_references_container:debug_only_argument');
             unique_references_container.global_container( ...

--- a/_test/test_unique_objects_container/test_unique_references.m
+++ b/_test/test_unique_objects_container/test_unique_references.m
@@ -30,6 +30,10 @@ classdef test_unique_references < TestCase
         end
         %------------------------------------------------------------------
         function test_save_restore_global_state_with_replacement(~)
+            % Tests that instances in the GLC are still stored in mem and only cleared on 
+            % unique_references_container's save/load. This expands on the
+            % basic test below by overwriting elements after initialisation
+            
             clWa = set_temporary_warning('off','HERBERT:unique_references_container:debug_only_argument');
             function urc_clearer()
                 unique_references_container.global_container('CLEAR','multifit_issue')
@@ -37,49 +41,66 @@ classdef test_unique_references < TestCase
             clSt  = onCleanup(@urc_clearer);
 
             urc = unique_references_container('multifit_issue','char');
+            % initialize urc with 3 duplicate 'aaa' values
             urc(1) = 'aaa';
             urc(2) = 'aaa';
             urc(3) = 'aaa';
+            % overwrite these elements with 'bbb' values
             urc(1) = 'bbb';
             urc(2) = 'bbb';
             urc(3) = 'bbb';
 
+            % extract implementing unique-objects for testing
             glc = unique_references_container.global_container( ...
                 'value','multifit_issue');
-            % despite we do not refer to 'aaa' any more, glc remembers.
+            % although urc no longer has 'aaa' values, they are retained in
+            % glc as there is no garbage collection. We expect the
+            % following tests to fail when garbage collection is
+            % implemented.
             assertTrue(isa(glc,'unique_objects_container'))
             assertEqual(glc.n_objects,2)
             assertEqual(glc.n_unique,2)
             assertEqual(glc.unique_objects,{'aaa','bbb'})
 
+            % we store urc in a struct, clear glc of all content and then
+            % reload urc from the structure as urr
             savestr = urc.to_struct();
             unique_references_container.global_container( ...
                 'CLEAR','multifit_issue');
-
-
             urr = serializable.from_struct(savestr);
+            
+            % glr the reconstructed unique-objects is refreshed and no
+            % longer contains the values which might be garbag-collected
             glr = unique_references_container.global_container( ...
                 'value','multifit_issue');
-            % forgets after reloading new state
+            % there are no longer any 'aaa' values in the global container
             assertTrue(isa(glr,'unique_objects_container'))
             assertEqual(glr.n_objects,1)
             assertEqual(glr.n_unique,1)
             assertEqual(glr.unique_objects,{'bbb'})
 
+            % check that the to_struct values for old and new urc and urr 
+            % are the same ie retained values are equal and values for
+            % garbage collection are not referred to by either urc and urr
             savestr_cp = urr.to_struct();
-            % need to compare structures as initial urc is broken after
-            % clear
             assertEqual(savestr,savestr_cp);
             clear clSt;
         end
 
         function test_save_restore_global_state_two_urcs(~)
+            % Test that 2 unique containers have the required contributions
+            % to the common global container and that is preserved when the
+            % global container is cleared and reconstituted
             clWa = set_temporary_warning('off','HERBERT:unique_references_container:debug_only_argument');
+ 
+            % prepare for final cleanup
             function urc_clearer()
                 unique_references_container.global_container('CLEAR','multifit_issue')
             end
             clSt  = onCleanup(@urc_clearer);
 
+            % initialise two unique containers with some unique and some
+            % shared objects
             urc1 = unique_references_container('multifit_issue','char');
             urc1(1) = 'aaa';
             urc1(2) = 'aaa';
@@ -91,7 +112,8 @@ classdef test_unique_references < TestCase
             urc2(3) = 'ccc';
             urc2(4) = 'bbb';
 
-
+            % extract the common global container and check correctness of
+            % its contents
             glc = unique_references_container.global_container( ...
                 'value','multifit_issue');
             assertTrue(isa(glc,'unique_objects_container'))
@@ -99,16 +121,18 @@ classdef test_unique_references < TestCase
             assertEqual(glc.n_unique,3)
             assertEqual(glc.unique_objects,{'aaa','bbb','ccc'})
 
-
+            % convert both containers to structs, clear the global
+            % container, and reconstruct the 2 contaners (and hence the 
+            % global container) from the structs
             savestr1_or = urc1.to_struct();
             savestr2_or = urc2.to_struct();
             unique_references_container.global_container( ...
                 'CLEAR','multifit_issue');
-
-
             urr1 = serializable.from_struct(savestr1_or);
             urr2 = serializable.from_struct(savestr2_or);
 
+            % extract again the global container and check it still has the
+            % right contents
             glr = unique_references_container.global_container( ...
                 'value','multifit_issue');
             assertTrue(isa(glr,'unique_objects_container'))
@@ -116,30 +140,35 @@ classdef test_unique_references < TestCase
             assertEqual(glr.n_unique,3)
             assertEqual(glr.unique_objects,{'aaa','bbb','ccc'})
 
-
+            % assert that the struct versions of the containers are the
+            % same before and after the global cleaar
             savestr_copy1 = urr1.to_struct();
             savestr_copy2 = urr2.to_struct();
-
-            % need to compare structures as initial urc is broken after
-            % clear
             assertEqual(savestr1_or,savestr_copy1);
             assertEqual(savestr2_or,savestr_copy2);
             clear clSt;
         end
 
         function test_save_restore_global_state(~)
+            % test unique container has the correct behaviour for its
+            % global storage - basic test. the test above also tests
+            % correctness of all this when overwriting elements.
             clWa = set_temporary_warning('off','HERBERT:unique_references_container:debug_only_argument');
             function urc_clearer()
                 unique_references_container.global_container('CLEAR','multifit_issue')
             end
             clSt  = onCleanup(@urc_clearer);
 
+            % initialise container with some unique and some duplicate
+            % items
             urc = unique_references_container('multifit_issue','char');
             urc(1) = 'aaa';
             urc(2) = 'aaa';
             urc(3) = 'aaa';
             urc(4) = 'bbb';
 
+            % extract the global container and check that its contents are
+            % correct
             glc = unique_references_container.global_container( ...
                 'value','multifit_issue');
             assertTrue(isa(glc,'unique_objects_container'))
@@ -147,12 +176,15 @@ classdef test_unique_references < TestCase
             assertEqual(glc.n_unique,2)
             assertEqual(glc.unique_objects,{'aaa','bbb'})
 
+            % store the container as a struct, clear the global container
+            % and restore a copy of the original container
             savestr = urc.to_struct();
             unique_references_container.global_container( ...
                 'CLEAR','multifit_issue');
-
-
             urr = serializable.from_struct(savestr);
+            
+            % extract the global container again and make sure it still has
+            % the required contents
             glr = unique_references_container.global_container( ...
                 'value','multifit_issue');
             assertTrue(isa(glr,'unique_objects_container'))
@@ -160,9 +192,9 @@ classdef test_unique_references < TestCase
             assertEqual(glr.n_unique,2)
             assertEqual(glr.unique_objects,{'aaa','bbb'})
 
+            % check the old and new containers are identical by comparison
+            % of struct conversios
             savestr_cp = urr.to_struct();
-            % need to compare structures as initial urc is broken after
-            % clear
             assertEqual(savestr,savestr_cp);
             clear clSt;
         end

--- a/herbert_core/utilities/classes/@unique_references_container/unique_references_container.m
+++ b/herbert_core/utilities/classes/@unique_references_container/unique_references_container.m
@@ -271,7 +271,7 @@ classdef unique_references_container < serializable
             end
 
             % get global container
-            glc = self.global_container('value',self.global_name);
+
             % reinitialise the indices of this container as empty
             % to purge this container of existing contents
             self.idx_ = zeros(1,0);
@@ -280,6 +280,9 @@ classdef unique_references_container < serializable
             for ii = 1:val.n_objects
                 obj = val.get(ii);
                 [obj,hash] = build_hash(obj);
+                % as this code updates self and hence glc, need to refetch it every
+                % time here
+                glc = self.global_container('value',self.global_name);                
                 [~,loc] = ismember( hash, glc.stored_hashes_ );
                 if loc == 0 || isempty(loc)
                     self = self.add_single_( obj, [], hash );
@@ -859,6 +862,8 @@ classdef unique_references_container < serializable
 
             if strcmpi(opflag,'list')
                 disp(glcontainer);
+                % ensure glc is returned for this op
+                glc = glcontainer;
                 return;
             end
 


### PR DESCRIPTION
Responding to #1791 this fixes unique_references_container for the existing implementation

A handle was used as a reference handle although it was CoW. Handle now refetched after every update.