### PR TITLE
get_exp_info returns fully filled experiment

### DIFF
--- a/_test/common_functions/create_test_instrument.m
+++ b/_test/common_functions/create_test_instrument.m
@@ -9,5 +9,17 @@ function instrument = create_test_instrument(ei,hz,chopper)
 %   hz          Chopper frequency
 %   chopper     Fermi chopper package name ('S','A', or 'B')
 
+ninst = numel(ei);
+if ninst ~= numel(hz) || ninst ~= numel(chopper)
+    error('HORACE:common_functions:invalid_argument', ...
+        'Number of energies, frequencies and chopper definitions in the function should be equal')
+end
 
-instrument = maps_instrument(ei,hz,chopper);
+inst = cell(1,ninst);
+if ninst == 1 && ~iscell(chopper)
+    chopper = {chopper};
+end
+for i=1:ninst
+    inst{i} = maps_instrument(ei(i),hz(i),chopper{i});
+end
+instrument = [inst{:}];

--- a/_test/test_admin/test_upgrade_file_format.m
+++ b/_test/test_admin/test_upgrade_file_format.m
@@ -33,9 +33,11 @@ classdef test_upgrade_file_format< TestCase
         function test_no_upgrade_for_legacy_alignment(obj)
             % legacy aligned file. Does not get upgraded as need
             % lattice to be upgraded
-            laf = fullfile(obj.test_common,'sqw_4d.sqw');
-            clWarn = set_temporary_warning('off', 'HORACE:legacy_alignment');
-            fl = upgrade_file_format(laf);
+            source = fullfile(obj.test_common,'sqw_4d.sqw');
+            [clFile,test_fl] = obj.copy_my_file(source);
+
+            clWarn = set_temporary_warning('off', 'HORACE:old_file_format');
+            fl = upgrade_file_format(test_fl);
             assertTrue(isa(fl{1},'sqw'));
             assertTrue(fl{1}.is_filebacked);
         end

--- a/_test/test_admin/test_upgrade_file_format.m
+++ b/_test/test_admin/test_upgrade_file_format.m
@@ -21,23 +21,17 @@ classdef test_upgrade_file_format< TestCase
             obj.ff_source_sqw = fullfile(obj.test_common,obj.source_sqw1);
             obj.working_dir = tmp_dir();
         end
-        function test_upgrade_legacy_alignment_with_lattice(obj)
+        function test_upgrade_for_legacy_alignment(obj)
+            %
             source = fullfile(obj.test_common,'sqw_4d.sqw');
             [clFile,test_fl] = obj.copy_my_file(source);
 
-
+            clWarn = set_temporary_warning('off', 'HORACE:old_file_format','HORACE:test_warning');
+            warning('HORACE:test_warning','test warning issued to ensure other warning do not polute workspace')
             fl = upgrade_file_format(test_fl);
-            assertTrue(isa(fl{1},'sqw'));
-            assertTrue(fl{1}.is_filebacked);
-        end
-        function test_no_upgrade_for_legacy_alignment(obj)
-            % legacy aligned file. Does not get upgraded as need
-            % lattice to be upgraded
-            source = fullfile(obj.test_common,'sqw_4d.sqw');
-            [clFile,test_fl] = obj.copy_my_file(source);
+            [~,wcl] = lastwarn;
 
-            clWarn = set_temporary_warning('off', 'HORACE:old_file_format');
-            fl = upgrade_file_format(test_fl);
+            assertEqual(wcl,'HORACE:old_file_format')
             assertTrue(isa(fl{1},'sqw'));
             assertTrue(fl{1}.is_filebacked);
         end

--- a/_test/test_admin/test_upgrade_file_format.m
+++ b/_test/test_admin/test_upgrade_file_format.m
@@ -31,7 +31,7 @@ classdef test_upgrade_file_format< TestCase
             fl = upgrade_file_format(test_fl);
             [~,wcl] = lastwarn;
 
-            assertEqual(wcl,'HORACE:old_file_format')
+            assertEqual(wcl,'SQW_FILE:old_version')
             assertTrue(isa(fl{1},'sqw'));
             assertTrue(fl{1}.is_filebacked);
         end

--- a/_test/test_sqw_file/change_header_test.m
+++ b/_test/test_sqw_file/change_header_test.m
@@ -35,7 +35,7 @@ tmpfromfile=read_sqw(tmpsqwfile);
 % ignore file creation date by setting to match other's
 wnew.creation_date = tmpfromfile.creation_date;
 
-assertEqualToTol(wnew,tmpfromfile,[1.e-8,1.e-8],'ignore_str',1)
+assertEqualToTol(wnew,tmpfromfile,[1.e-8,1.e-8],'-ignore_str')
 
 % Delete output file, if can
 delete(tmpsqwfile)

--- a/_test/test_sqw_file/test_binfile_v2_common.m
+++ b/_test/test_sqw_file/test_binfile_v2_common.m
@@ -142,18 +142,18 @@ classdef test_binfile_v2_common <  TestCase %WithSave
             tob = tob.delete();
             assertTrue(tob.sqw_type) % its still sqw reader, you know...
             assertEqual(tob.num_dim,'undefined')
-            
+
         end
         %
         function obj = test_set_missing_file_to_update_opens_in_wb_plus(obj)
-            tob = binfile_v2_common_tester();            
+            tob = binfile_v2_common_tester();
 
             test_f = fullfile(tmp_dir,'test_change_file_to_write.sqw');
             clob = onCleanup(@()delete(test_f));
 
             tob=tob.set_file_to_update(test_f);
             assertTrue(exist(test_f,'file')==2);
-            assertEqual(tob.get_faccess_mode(),'wb+')            
+            assertEqual(tob.get_faccess_mode(),'wb+')
 
             tob=tob.delete();
             assertFalse(tob.sqw_type) % its still sqw reader, you know...
@@ -288,7 +288,12 @@ classdef test_binfile_v2_common <  TestCase %WithSave
             % Get the permission of an open file from its path
             %   If the file is not open the permission will be empty
             permission = '';
-            file_ids = fopen('all');
+
+            if matlab_version_num() < 24.01
+                file_ids = fopen('all');
+            else
+                file_ids = openFiles();
+            end
             for i = 1:numel(file_ids)
                 [open_file_path, open_permission] = fopen(file_ids(i));
                 if strcmp(open_file_path, file_path)

--- a/_test/test_sqw_file/test_faccess_sqw_prototype.m
+++ b/_test/test_sqw_file/test_faccess_sqw_prototype.m
@@ -79,9 +79,12 @@ classdef test_faccess_sqw_prototype< TestCase
             assertEqual(expdata.filename,'map11014.spe')
 
             det = to.get_detpar();
-            assertEqual(det.filename,'demo_par.PAR')
-            assertEqual(det.filepath,'d:\users\abuts\SVN\ISIS\HoraceV1.0final\documentation\')
-            assertEqual(numel(det.group),28160)
+            assertTrue(isa(det,'unique_objects_container'))
+            assertEqual(det.n_objects,1);
+            udi = det.unique_objects;
+            assertEqual(udi{1}.filename,'demo_par.PAR')
+            assertEqual(udi{1}.filepath,'d:\users\abuts\SVN\ISIS\HoraceV1.0final\documentation\')
+            assertEqual(numel(udi{1}.group),28160)
 
             data = to.get_data();
             assertEqual(size(data.s,1),numel(data.p{1})-1)

--- a/_test/test_sqw_file/test_faccess_sqw_v2.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v2.m
@@ -100,9 +100,13 @@ classdef test_faccess_sqw_v2< TestCase
             assertEqual(exp_info.filename,'slice_n_c_m1_ei140')
 
             det = to.get_detpar();
-            assertEqual(det.filename,'slice_n_c_m1_ei140.par')
-            assertEqual(det.filepath,'C:\Russell\PCMO\ARCS_Oct10\Data\')
-            assertEqual(numel(det.group),58880)
+            assertTrue(isa(det,'unique_objects_container'))
+            assertEqual(det.n_objects,1);
+            udi = det.unique_objects;
+            
+            assertEqual(udi{1}.filename,'slice_n_c_m1_ei140.par')
+            assertEqual(udi{1}.filepath,'C:\Russell\PCMO\ARCS_Oct10\Data\')
+            assertEqual(numel(udi{1}.group),58880)
 
             data = to.get_data();
             assertEqual(size(data.s,1),numel(data.p{1})-1)
@@ -130,9 +134,13 @@ classdef test_faccess_sqw_v2< TestCase
             assertEqual(header.filename,'map11014.spe;1')
 
             det = to.get_detpar();
-            assertEqual(det.filename,'9cards_4_4to1.par')
-            assertEqual(det.filepath,'c:\data\Fe\')
-            assertEqual(numel(det.group),36864)
+            assertTrue(isa(det,'unique_objects_container'))
+            assertEqual(det.n_objects,1);
+            udi = det.unique_objects;
+            
+            assertEqual(udi{1}.filename,'9cards_4_4to1.par')
+            assertEqual(udi{1}.filepath,'c:\data\Fe\')
+            assertEqual(numel(udi{1}.group),36864)
 
             data = to.get_data();
             assertEqual(size(data.s,1),numel(data.p{1})-1)

--- a/_test/test_sqw_file/test_faccess_sqw_v3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3.m
@@ -123,9 +123,13 @@ classdef test_faccess_sqw_v3< TestCase
             assertElementsAlmostEqual(inf.psi,0.2967,'absolute',1.e-4);
 
             det = to.get_detpar();
-            assertEqual(det.filename,'')
-            assertEqual(det.filepath,'.\')
-            assertEqual(numel(det.group),96)
+            assertTrue(isa(det,'unique_objects_container'))
+            assertEqual(det.n_objects,1);
+            udi = det.unique_objects;
+            
+            assertEqual(udi{1}.filename,'')
+            assertEqual(udi{1}.filepath,'.\')
+            assertEqual(numel(udi{1}.group),96)
 
             data = to.get_data();
             assertEqual(size(data.s,1),numel(data.p{1})-1)

--- a/_test/test_sqw_file/test_faccess_sqw_v3_3.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v3_3.m
@@ -81,9 +81,13 @@ classdef test_faccess_sqw_v3_3< TestCase
 
 
             det = file_accessor.get_detpar();
-            assertEqual(det.filename,'')
-            assertEqual(det.filepath,'.\')
-            assertEqual(numel(det.group),96)
+            assertTrue(isa(det,'unique_objects_container'))
+            assertEqual(det.n_objects,1);
+            udi = det.unique_objects;
+            
+            assertEqual(udi{1}.filename,'')
+            assertEqual(udi{1}.filepath,'.\')
+            assertEqual(numel(udi{1}.group),96)
 
             data = file_accessor.get_data();
 

--- a/_test/test_sqw_file/test_faccess_sqw_v4.m
+++ b/_test/test_sqw_file/test_faccess_sqw_v4.m
@@ -396,6 +396,26 @@ classdef test_faccess_sqw_v4< TestCase
             assertEqual(exi.instruments(1),inst1);
             assertEqual(exi.samples(1),sam1);
         end
+
+        function obj = test_get_experiment(obj)
+            to = faccess_sqw_v4();
+            to = to.init(obj.sample_file);
+
+            [exp_info,~] = to.get_exp_info('-all');
+
+            assertTrue(isa(exp_info.expdata,'IX_experiment'))
+            assertTrue(isa(exp_info.detector_arrays,'unique_references_container'))
+            assertTrue(isa(exp_info.samples,'unique_references_container'))
+            assertTrue(isa(exp_info.instruments,'unique_references_container'))
+
+            assertEqual(numel(exp_info.expdata),exp_info.detector_arrays.n_objects);
+            assertEqual(exp_info.detector_arrays.n_unique_objects,1);
+            assertEqual(numel(exp_info.expdata),exp_info.samples.n_objects);
+            assertEqual(exp_info.samples.n_unique_objects,1);
+            assertEqual(numel(exp_info.expdata),exp_info.instruments.n_objects);
+            assertEqual(exp_info.instruments.n_unique_objects,1);
+
+        end
         %
         function obj = test_get_inst_or_sample(obj)
             to = faccess_sqw_v4();
@@ -445,7 +465,7 @@ classdef test_faccess_sqw_v4< TestCase
         end
         %
         function test_serialize_deserialize_faccess(obj)
-            skipTest('Re #1795 no proper comparison for sqw faccessors')            
+            skipTest('Re #1795 no proper comparison for sqw faccessors')
             fo = faccess_sqw_v4();
             fo = fo.init(obj.sample_file);
 
@@ -456,7 +476,7 @@ classdef test_faccess_sqw_v4< TestCase
         end
         %
         function test_serialize_deserialize_empty_faccess(~)
-            skipTest('Re #1795 no proper comparison for sqw faccessors')            
+            skipTest('Re #1795 no proper comparison for sqw faccessors')
             fo = faccess_sqw_v4();
 
             bys = fo.to_struct();
@@ -602,6 +622,8 @@ classdef test_faccess_sqw_v4< TestCase
             f = @() faccess.get_pix_in_ranges(pix_starts, bl_sizes);
             assertExceptionThrown(f, 'HORACE:validate_ranges:invalid_argument');
         end
+
+        %%-----------------------------------------------------------------
         function obj = test_write_read_correctV4_filebacked(obj)
 
             clobC = set_temporary_config_options(hor_config, 'mem_chunk_size', 1000, 'fb_scale_factor', 3);
@@ -655,6 +677,7 @@ classdef test_faccess_sqw_v4< TestCase
 
             assertEqualToTol(sample,rdd,'ignore_str',true)
         end
+
         function test_get_set_pix_metadata(obj)
 
             test_f = fullfile(tmp_dir,'set_get_pix_metadata.sqw');
@@ -686,6 +709,7 @@ classdef test_faccess_sqw_v4< TestCase
             assertElementsAlmostEqual(meta.data_range(:,4:end),ref_range(:,4:end));
 
         end
+
         %         function test_build_correct(obj)
         %             % TEST used in preparation of first v4 sample file and
         %             % is not testing
@@ -706,6 +730,7 @@ classdef test_faccess_sqw_v4< TestCase
         %
         %             assertEqualToTol(sample,rdd)
         %         end
+
         function test_read_correct(obj)
             sample = read_sqw(obj.old_origin);
 
@@ -725,8 +750,9 @@ classdef test_faccess_sqw_v4< TestCase
             % work
             sample.data.proj = rdd.data.proj;
 
-            assertEqualToTol(sample,rdd,1.e-15,'-ignore_date','ignore_str',true)
+            assertEqualToTol(sample,rdd,1.e-15,'-ignore_date','-ignore_str')
         end
+
         function test_should_load_file(obj)
             to = faccess_sqw_v4();
             co = onCleanup(@()to.delete());

--- a/_test/test_sqw_file/test_horace_binfile_interface.m
+++ b/_test/test_sqw_file/test_horace_binfile_interface.m
@@ -55,5 +55,40 @@ classdef test_horace_binfile_interface < TestCase
             assertTrue(isa(uob{1},'IX_detector_array'));
             assertEqual(uob{1}.ndet,96);
         end
+        %
+        function test_works_with_null_inputs(~)
+            detr = unique_objects_container('baseclass','IX_detector_array');
+            deta = horace_binfile_interface.convert_old_det_forms(detr,0);
+
+            assertEqual(detr,deta);
+        end
+        function test_throw_with_wrong_input(~)
+            function detr = thrower()
+                detr = horace_binfile_interface.convert_old_det_forms('wrong',0);
+            end
+            assertExceptionThrown(@thrower,'HORACE:horace_binfile_interface:invalid_argument');
+        end
+        function test_vector_n_objects_throw_with_container(~)
+            detr = unique_objects_container('baseclass','IX_detector_array');
+
+            function detr = thrower(detr)
+                detr = horace_binfile_interface.convert_old_det_forms(detr,[1,1]);
+            end
+            assertExceptionThrown(@()thrower(detr),'HORACE:horace_binfile_interface:invalid_argument');
+        end
+        function test_non_numeric_n_objects_throw_with_container(~)
+            detr = unique_objects_container('baseclass','IX_detector_array');
+
+            function detr = thrower(detr)
+                detr = horace_binfile_interface.convert_old_det_forms(detr,'a');
+            end
+            assertExceptionThrown(@()thrower(detr),'HORACE:horace_binfile_interface:invalid_argument');
+        end
+        function test_zero_instances_throw(obj)
+            function det = thrower()
+                det = horace_binfile_interface.convert_old_det_forms(obj.basic_det,0);
+            end
+            assertExceptionThrown(@thrower,'HERBERT:unique_objects_container:invalid_argument');
+        end
     end
 end

--- a/_test/test_sqw_file/test_horace_binfile_interface.m
+++ b/_test/test_sqw_file/test_horace_binfile_interface.m
@@ -1,0 +1,59 @@
+classdef test_horace_binfile_interface < TestCase
+    properties
+        basic_det
+    end
+
+    methods
+        % Construction and helpers
+        function obj = test_horace_binfile_interface(varargin)
+            if nargin == 0
+                name = varargin{1};
+            else
+                name = 'test_horace_binfile_interface ';
+            end
+            obj = obj@TestCase(name);
+            hp = horace_paths;
+            test_file = fullfile(hp.test_common,'96dets.par');
+            apr = asciipar_loader(test_file);
+            obj.basic_det = apr.load_par();
+        end
+        %------------------------------------------------------------------
+        function test_convert_det_obj_container(obj)
+            det_arr = IX_detector_array(obj.basic_det);
+            det_ct  = unique_objects_container('baseclass','IX_detector_array');
+            det_ct  = det_ct.add(det_arr);
+            det_ct  = det_ct.replicate_runs(3);
+            det = horace_binfile_interface.convert_old_det_forms(det_ct,3);
+
+            assertTrue(isa(det,'unique_objects_container'));
+            assertEqual(det.n_objects,3)
+            assertEqual(det.n_unique,1)
+            uob = det.unique_objects();
+            assertTrue(isa(uob{1},'IX_detector_array'));
+            assertEqual(uob{1}.ndet,96);
+        end
+
+        function test_convert_det_array(obj)
+            det_arr = IX_detector_array(obj.basic_det);
+            det = horace_binfile_interface.convert_old_det_forms(det_arr,3);
+
+            assertTrue(isa(det,'unique_objects_container'));
+            assertEqual(det.n_objects,3)
+            assertEqual(det.n_unique,1)
+            uob = det.unique_objects();
+            assertTrue(isa(uob{1},'IX_detector_array'));
+            assertEqual(uob{1}.ndet,96);
+        end
+
+        function test_convert_det_structure(obj)
+            det = horace_binfile_interface.convert_old_det_forms(obj.basic_det);
+
+            assertTrue(isa(det,'unique_objects_container'));
+            assertEqual(det.n_objects,1)
+            assertEqual(det.n_unique,1)
+            uob = det.unique_objects();
+            assertTrue(isa(uob{1},'IX_detector_array'));
+            assertEqual(uob{1}.ndet,96);
+        end
+    end
+end

--- a/_test/test_sqw_file/test_write_then_read.m
+++ b/_test/test_sqw_file/test_write_then_read.m
@@ -38,7 +38,7 @@ classdef test_write_then_read < TestCase & common_sqw_file_state_holder
             rec_dnd = read_dnd(test_file);
             assertTrue (isa(rec_dnd,'d2d'))
             assertEqual(size(rec_dnd.s),[16,11]);
-            assertEqual(rec_dnd.filename,test_filename);            
+            assertEqual(rec_dnd.filename,test_filename);
         end
 
 
@@ -102,7 +102,11 @@ classdef test_write_then_read < TestCase & common_sqw_file_state_holder
 
             function del_temp_file(tmp_file_path)
                 if is_file(tmp_file_path)
-                    open_fids = fopen('all');
+                    if matlab_version_num() < 24.01
+                        open_fids = fopen('all');
+                    else
+                        open_fids = openFiles();
+                    end
                     for i = 1:numel(open_fids)
                         fpath = fopen(open_fids(i));
                         if strcmp(fpath, tmp_file_path)

--- a/herbert_core/utilities/classes/@unique_objects_container/unique_objects_container.m
+++ b/herbert_core/utilities/classes/@unique_objects_container/unique_objects_container.m
@@ -327,6 +327,9 @@ classdef unique_objects_container < serializable
             % function expands container onto specified number of runs.
             % only single unique object allowed to be present in the
             % container initially
+            if isempty(n_objects)
+                n_objects = 1;
+            end
             validateattributes(n_objects, {'numeric'}, {'>', 0, 'scalar'})
             if obj.n_unique ~= 1
                 error('HERBERT:unique_objects_container:invalid_argument',...

--- a/herbert_core/utilities/classes/@unique_objects_container/unique_objects_container.m
+++ b/herbert_core/utilities/classes/@unique_objects_container/unique_objects_container.m
@@ -323,17 +323,23 @@ classdef unique_objects_container < serializable
             [is,unique_ind,obj] = contains_(obj,value,nargout);
         end
 
-        function obj = replicate_runs(obj,n_objects)
+        function obj = replicate_runs(obj,n_objects,varargin)
             % function expands container onto specified number of runs.
             % only single unique object allowed to be present in the
             % container initially
             if isempty(n_objects)
                 n_objects = 1;
             end
-            validateattributes(n_objects, {'numeric'}, {'>', 0, 'scalar'})
+            if ~isnumeric(n_objects) || ~isscalar(n_objects)|| n_objects<=0
+                error('HERBERT:unique_objects_container:invalid_argument',[...                
+                    'n_objects have to be numeric positive scalar.\n' ...
+                    'It is: %s of class %s'],...
+                num2str(n_objects),class(n_objects));
+            end
             if obj.n_unique ~= 1
-                error('HERBERT:unique_objects_container:invalid_argument',...
-                    'The method works only on containers containing a single unique run. This container contains %d unique runs.', ...
+                error('HERBERT:unique_objects_container:invalid_argument',[...
+                    'The method works only on containers containing a single unique run.\n' ...
+                    'This container contains %d unique runs.'], ...
                     obj.n_unique);
             end
 

--- a/horace_core/algorithms/resolution_plot.m
+++ b/horace_core/algorithms/resolution_plot.m
@@ -210,12 +210,9 @@ if ~isa(sample,'IX_sample')
     error('HORACE:resolution_plot:invalid_argument',...
         'Sample must be a scalar IX_sample object')
 else
-    sample.alatt = lat.alatt;
+    sample.alatt  = lat.alatt;
     sample.angdeg = lat.angdeg;
 end
-exper = Experiment([],instrument,sample,expdata);
-
-wres.experiment_info = exper;
 
 
 % Check detector
@@ -231,7 +228,10 @@ if ~isfield(detpar,'filename'), detpar.filename = ''; end
 if ~isfield(detpar,'filepath'), detpar.filepath = ''; end
 if ~isfield(detpar,'group'), detpar.group = 1; end
 
-wres.detpar = detpar;
+detpar = IX_detector_array(detpar);
+exper = Experiment(detpar,instrument,sample,expdata);
+wres.experiment_info = exper;
+
 
 
 % Make data structure

--- a/horace_core/sqw/@Experiment/private/build_from_binfile_headers_.m
+++ b/horace_core/sqw/@Experiment/private/build_from_binfile_headers_.m
@@ -7,7 +7,6 @@ n_header = numel(header);
 exper = repmat(IX_experiment,1,n_header);
 samp = unique_references_container('GLOBAL_NAME_SAMPLES_CONTAINER','IX_samp'); %cell(n_header,1);
 inst = unique_references_container('GLOBAL_NAME_INSTRUMENTS_CONTAINER','IX_inst'); %cell(n_header,1);
-detc = unique_references_container('GLOBAL_NAME_DETECTORS_CONTAINER','IX_detector_array'); 
 for i=1:n_header
     if iscell(header)
         hdr = header{i};

--- a/horace_core/sqw/@Experiment/set_instrument.m
+++ b/horace_core/sqw/@Experiment/set_instrument.m
@@ -2,7 +2,7 @@ function   obj = set_instrument(obj,instr_or_fun,varargin)
 % add or reset instrument, related to the given experiment class
 %
 if isa(instr_or_fun,'IX_inst')
-    if numel(instr_or_fun) == 1 %replace all instruments
+    if isscalar(instr_or_fun) %replace all instruments
         % in the container with single input instrument
         uoc = unique_objects_container('IX_inst');
         uoc = uoc.add(instr_or_fun);
@@ -35,7 +35,7 @@ elseif isa(instr_or_fun,'unique_objects_container') && strcmp(instr_or_fun.basec
     obj.instruments = instr_or_fun;
 
 elseif isa(instr_or_fun,"function_handle")
-    if numel(varargin)==1 && iscell(varargin{1})
+    if isscalar(instr_or_fun) && iscell(varargin{1})
         argi = varargin{1};
     else
         argi = varargin;

--- a/horace_core/sqw/@sqw/private/set_from_old_struct_.m
+++ b/horace_core/sqw/@sqw/private/set_from_old_struct_.m
@@ -119,3 +119,6 @@ if S.version == 4
         obj.pix.alignment_matr = al_info.rotmat;
     end
 end
+if S.version == 5
+    
+end

--- a/horace_core/sqw/@sqw/private/set_from_old_struct_.m
+++ b/horace_core/sqw/@sqw/private/set_from_old_struct_.m
@@ -115,6 +115,7 @@ end
 if ~isfield(S,'version')
     S.version = 0;
 end
+%
 if S.version == 4
     % may contain legacy alignment not stored in projection. Deal with this here
     hav  = obj.experiment_info.header_average();
@@ -127,7 +128,7 @@ if S.version < 6
     % may contain detpar stored in their own field and not present within
     % the experiment_info
     if obj.experiment_info.detector_arrays.n_objects == 0
-        obj.detpar = S.detpar; % use setter to deal with possible presence 
-        % of old array format
+        obj.detpar = S.detpar; % use setter to deal with possible presence
+        % of old array format. Setter checks for that and converts appropriately
     end
 end

--- a/horace_core/sqw/@sqw/private/set_from_old_struct_.m
+++ b/horace_core/sqw/@sqw/private/set_from_old_struct_.m
@@ -101,6 +101,11 @@ if ~isfield(S,'version') || S.version<4
                 ss = update_pixels_run_id(ss);
             end
         end
+        if isfield(ss,'detpar')
+            ss.experiment_info.detector_arrays =  ...
+                horace_binfile_interface.convert_old_det_forms( ...
+                ss.detpar,ss.experiment_info.n_runs);
+        end
 
         obj(i) = obj(i).from_bare_struct(ss);
     end

--- a/horace_core/sqw/@sqw/private/set_from_old_struct_.m
+++ b/horace_core/sqw/@sqw/private/set_from_old_struct_.m
@@ -111,6 +111,10 @@ if isfield(S,'array_dat')
 else
     obj = obj.from_bare_struct(S);
 end
+
+if ~isfield(S,'version')
+    S.version = 0;
+end
 if S.version == 4
     % may contain legacy alignment not stored in projection. Deal with this here
     hav  = obj.experiment_info.header_average();
@@ -119,6 +123,11 @@ if S.version == 4
         obj.pix.alignment_matr = al_info.rotmat;
     end
 end
-if S.version == 5
-    
+if S.version < 6
+    % may contain detpar stored in their own field and not present within
+    % the experiment_info
+    if obj.experiment_info.detector_arrays.n_objects == 0
+        obj.detpar = S.detpar; % use setter to deal with possible presence 
+        % of old array format
+    end
 end

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -284,14 +284,14 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
     methods
         function obj = sqw(varargin)
             obj = obj@SQWDnDBase();
-            
+
             obj.experiment_info_ = Experiment();
 
             if nargin==0 % various serializers need empty constructor
                 obj.data_ = d0d();
                 return;
             end
-            
+
             obj = obj.init(varargin{:});
         end
         % initialization of empty sqw object or main part of constructor
@@ -331,7 +331,8 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
         end
         function obj = set.detpar(obj,val)
             ei = obj.experiment_info_;
-            ei.detector_arrays = val;
+            ei.detector_arrays = ...
+                horace_binfile_interface.convert_old_det_forms(val,ei.n_runs);
             obj.experiment_info_ = ei;
         end
         %
@@ -462,7 +463,7 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
     methods(Access = protected)
         % Check if two sqw objects are equal to a given tolerance
         [ok, mess] = equal_to_tol_single(w1, w2, varargin)
-        
+
         % Re #962 TODO: probably delete it
         [proj, pbin] = get_proj_and_pbin(w) % Retrieve the projection and
         % binning of an sqw or dnd object
@@ -526,10 +527,10 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
             % number
             % version 5 -- support for loading previous version
             % data in case if the data were realigned
-            % version 6 -- detectors are detector's arrays and 
+            % version 6 -- detectors are detector's arrays and
             %              loaded/saved together with experiment info
             ver = 6;
-            
+
         end
 
         function flds = saveableFields(~)

--- a/horace_core/sqw/@sqw/sqw.m
+++ b/horace_core/sqw/@sqw/sqw.m
@@ -66,8 +66,6 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
         main_header_ = main_header_cl();
 
         experiment_info_ = []; %Experiment(); now at start of constructor;
-        % detectors array
-        detpar_  = struct([]);
 
         % holder for image data, e.g. appropriate dnd object
         data_;
@@ -332,21 +330,9 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
             val = obj.experiment_info.detector_arrays;
         end
         function obj = set.detpar(obj,val)
-            %TODO: implement checks for validity
-            if isa(val,'unique_references_container')
-                obj.experiment_info_.detector_arrays = val;
-             elseif isstruct(val)
-                detector = IX_detector_array(val);
-                if obj.experiment_info_.detector_arrays.n_runs == 0
-                    obj.experiment_info_.detector_arrays = ...
-                        obj.experiment_info_.detector_arrays.add_copies_( ...
-                                          detector,obj.experiment_info_.n_runs);
-                end
-            elseif isempty(val) && obj.experiment_info_.detector_arrays.n_runs > 0
-                ; % pass, do nothing, info already in experiment_info
-            else
-                error('HORACE:sqw_set_detpar:invalid_argument','incorrect type');
-            end
+            ei = obj.experiment_info_;
+            ei.detector_arrays = val;
+            obj.experiment_info_ = ei;
         end
         %
         function val = get.main_header(obj)
@@ -529,7 +515,7 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
     %======================================================================
     % SERIALIZABLE INTERFACE
     properties(Constant,Access=protected)
-        fields_to_save_ = {'main_header','experiment_info','detpar','data','pix'};
+        fields_to_save_ = {'main_header','experiment_info','data','pix'};
     end
     %
     methods
@@ -538,9 +524,12 @@ classdef (InferiorClasses = {?DnDBase,?PixelDataBase,?IX_dataset,?sigvar}) sqw <
             % and nxsqw data format. Each new version would presumably read
             % the older version, so version substitution is based on this
             % number
-            ver = 5;
             % version 5 -- support for loading previous version
             % data in case if the data were realigned
+            % version 6 -- detectors are detector's arrays and 
+            %              loaded/saved together with experiment info
+            ver = 6;
+            
         end
 
         function flds = saveableFields(~)

--- a/horace_core/sqw/file_io/@faccess_sqw_v4/get_exp_info.m
+++ b/horace_core/sqw/file_io/@faccess_sqw_v4/get_exp_info.m
@@ -45,7 +45,7 @@ end
 [obj,detpar]=obj.get_sqw_block('bl__detpar');
 
 n_instances = numel(exp_data);
-detpar = obj.convet_old_det_forms(detpar,n_instances);
+detpar = obj.convert_old_det_forms(detpar,n_instances);
 if ~isinf(samp_inst_number)
     exp_data = exp_data(samp_inst_number);
     Inst =     Inst(samp_inst_number);

--- a/horace_core/sqw/file_io/@faccess_sqw_v4/get_exp_info.m
+++ b/horace_core/sqw/file_io/@faccess_sqw_v4/get_exp_info.m
@@ -34,13 +34,14 @@ end
 if no_isamp_inst
     if ~isinf(samp_inst_number)
         exp_data = exp_data(samp_inst_number);
-    end    
+    end
     % leave detector arrays to be filled in from detpar
     exper = Experiment([],IX_null_inst(),IX_null_sample,exp_data);
     return;
 end
 [obj,Inst] = obj.get_sqw_block('bl_experiment_info_instruments');
 [obj,samp] = obj.get_sqw_block('bl_experiment_info_samples');
+[obj,detpar]=obj.get_sqw_block('bl_detpar');
 
 if ~isinf(samp_inst_number)
     exp_data = exp_data(samp_inst_number);
@@ -50,6 +51,5 @@ end
 if isa(exp_data,'sqw') % data set to the sqw object
     exper    = exp_data.experiment_info;
 else
-    % leave detector arrays to be filled in from detpar
-    exper    = Experiment([],Inst,samp,exp_data); 
+    exper    = Experiment(detpar,Inst,samp,exp_data);
 end

--- a/horace_core/sqw/file_io/@faccess_sqw_v4/get_exp_info.m
+++ b/horace_core/sqw/file_io/@faccess_sqw_v4/get_exp_info.m
@@ -39,17 +39,18 @@ if no_isamp_inst
     exper = Experiment([],IX_null_inst(),IX_null_sample,exp_data);
     return;
 end
+
 [obj,Inst] = obj.get_sqw_block('bl_experiment_info_instruments');
 [obj,samp] = obj.get_sqw_block('bl_experiment_info_samples');
-[obj,detpar]=obj.get_sqw_block('bl_detpar');
+[obj,detpar]=obj.get_sqw_block('bl__detpar');
 
+n_instances = numel(exp_data);
+detpar = obj.convet_old_det_forms(detpar,n_instances);
 if ~isinf(samp_inst_number)
     exp_data = exp_data(samp_inst_number);
     Inst =     Inst(samp_inst_number);
     samp =     samp(samp_inst_number);
+    detpar =   detpar(samp_inst_number);
 end
-if isa(exp_data,'sqw') % data set to the sqw object
-    exper    = exp_data.experiment_info;
-else
-    exper    = Experiment(detpar,Inst,samp,exp_data);
-end
+exper    = Experiment(detpar,Inst,samp,exp_data);
+

--- a/horace_core/sqw/file_io/@faccess_sqw_v4/get_sqw.m
+++ b/horace_core/sqw/file_io/@faccess_sqw_v4/get_sqw.m
@@ -70,30 +70,17 @@ end
 if ~(opts.head || opts.his)
     % detpar-independent inputs
     sqw_skel.data = DnDBase.dnd(sqw_skel.data.metadata,sqw_skel.data.nd_data);
-    sqw_skel.experiment_info = Experiment([],sqw_skel.experiment_info.instruments, ...
-        sqw_skel.experiment_info.samples,sqw_skel.experiment_info.expdata);
-    
+
     % detpar inputs
-    detpar = sqw_skel.detpar; 
+    detpar = sqw_skel.detpar;
     if ~isempty(detpar)
-        if isstruct(detpar) && ~isempty(detpar.group)
-            detpar = IX_detector_array(detpar);
-            sqw_skel.experiment_info.detector_arrays = ...
-                sqw_skel.experiment_info.detector_arrays.add_copies_( ...
-                                     detpar, numel(sqw_skel.experiment_info.expdata));
-            % the detpar field has now been used so don't leave it around to be spuriously
-            % copied any further
-            sqw_skel = rmfield(sqw_skel,'detpar');
-        elseif isa(detpar,'unique_references_container')
-            sqw_skel.experiment_info.detector_arrays = detpar;
-        else
-            error('HORACE:faccess_v4:invalid_argument', ...
-                  'detpar from file is neither detpar struct or detector arrays');
-        end
-    else
-		% detpar is empty, do nothing (see above for field removal)
-        sqw_skel = rmfield(sqw_skel,'detpar');
+        n_instances = numel(sqw_skel.experiment_info.expdata);
+        sqw_skel.detpar = obj.convet_old_det_forms(detpar,n_instances);
+
     end
+    sqw_skel.experiment_info = Experiment(sqw_skel.detpar, ...
+        sqw_skel.experiment_info.instruments, ...
+        sqw_skel.experiment_info.samples,sqw_skel.experiment_info.expdata);
 end
 
 

--- a/horace_core/sqw/file_io/@faccess_sqw_v4/get_sqw.m
+++ b/horace_core/sqw/file_io/@faccess_sqw_v4/get_sqw.m
@@ -75,7 +75,7 @@ if ~(opts.head || opts.his)
     detpar = sqw_skel.detpar;
     if ~isempty(detpar)
         n_instances = numel(sqw_skel.experiment_info.expdata);
-        sqw_skel.detpar = obj.convet_old_det_forms(detpar,n_instances);
+        sqw_skel.detpar = obj.convert_old_det_forms(detpar,n_instances);
 
     end
     sqw_skel.experiment_info = Experiment(sqw_skel.detpar, ...

--- a/horace_core/sqw/file_io/@horace_binfile_interface/horace_binfile_interface.m
+++ b/horace_core/sqw/file_io/@horace_binfile_interface/horace_binfile_interface.m
@@ -425,54 +425,6 @@ classdef horace_binfile_interface < serializable
             % available
             opts = parse_get_sqw_args_(varargin{:});
         end
-        
-        function det = convet_old_det_forms(detpar,n_instances)
-            % Method used to convert old detector formats into horace 4.01
-            % form.
-            %
-            % Input:
-            % detpar      -- an old or new format detector information.
-            %                Normally obtained from binary sqw file.
-            % n_instances -- number of run, this
-            %
-            % Returns:
-            % det         -- detector information packed in
-            %                unique_object_container container and
-            %                distributed into approriate number of input
-            %                runs.
-            if nargin == 1
-                n_instances = [];
-            end
-
-            if isstruct(detpar) % we do not need do deal with struct array
-                % here as this have never been used and stored in
-                detpar = IX_detector_array(detpar);
-            end
-            if isa(detpar,'IX_detector_array')
-                det = unique_objects_container('baseclass','IX_detector_array');
-                det = det.add(detpar);
-                det = det.replicate_runs(n_instances);
-            elseif isa(detpar,'unique_objects_container') || isa(detpar,'unique_references_container')
-                if detpar.n_objects == 1
-                    det = detpar.replicate_runs(n_instances);
-                elseif ~isempty(n_instances) && detpar.n_objects == n_instances
-                    det = detpar;
-                else
-                    error('HORACE:horace_binfile_interface:invalid_argument', ...
-                        ['Number of IX_detector_array objects %d provided in ' ...
-                        'the input container is not consistent with number of objects, ' ...
-                        'requested to return (%d).\n' ...
-                        'Input should be either 1 or equal to the number of requested'], ...
-                        detpar.n_objects,n_instances)
-                end
-            else
-                error('HORACE:horace_binfile_interface:invalid_argument', ...
-                    ['Unrecognized input class: "%s" provided to the conversion method\n' ...
-                    'Allowed inputs are: "struc", "ID_detector_array", ' ...
-                    '"unique_objects_container" or "unique_references_container" '],...
-                    class(detpar))
-            end
-        end
     end
     %======================================================================
     methods(Static) % helper methods used for binary IO
@@ -520,6 +472,27 @@ classdef horace_binfile_interface < serializable
             end
             check_io_error_(fid,'reading',add_info);
         end
+
+        function det = convert_old_det_forms(detpar,n_instances)
+            % Method used to convert old detector formats into horace 4.01
+            % form.
+            %
+            % Input:
+            % detpar      -- an old or new format detector information.
+            %                Normally obtained from binary sqw file.
+            % n_instances -- number of run, this
+            %
+            % Returns:
+            % det         -- detector information packed in
+            %                unique_object_container container and
+            %                distributed over approriate number of input
+            %                runs.
+            if nargin == 1
+                n_instances = [];
+            end
+            det = convert_old_det_forms_(detpar,n_instances);
+        end
+
     end
     %======================================================================
     % SERIALIZABLE INTERFACE

--- a/horace_core/sqw/file_io/@horace_binfile_interface/private/convert_old_det_forms_.m
+++ b/horace_core/sqw/file_io/@horace_binfile_interface/private/convert_old_det_forms_.m
@@ -1,0 +1,44 @@
+function det = convert_old_det_forms_(detpar,n_instances)
+% Method used to convert detector formats written by any previous version
+% of Horace into Horace 4.01 data form.
+%
+% Input:
+% detpar      -- an old or new format detector information.
+%                Normally obtained from binary sqw file.
+% n_instances -- number of run, this
+%
+% Returns:
+% det         -- detector information packed in
+%                unique_object_container container and
+%                distributed into approriate number of input
+%                runs.
+
+if isstruct(detpar) % we do not need do deal with struct array
+    % here as this have never been used and stored in
+    detpar = IX_detector_array(detpar);
+end
+if isa(detpar,'IX_detector_array')
+    det = unique_objects_container('baseclass','IX_detector_array');
+    det = det.add(detpar);
+    det = det.replicate_runs(n_instances);
+elseif isa(detpar,'unique_objects_container') || isa(detpar,'unique_references_container')
+    if detpar.n_objects == 1
+        det = detpar.replicate_runs(n_instances);
+    elseif ~isempty(n_instances) && detpar.n_objects == n_instances
+        det = detpar;
+    else
+        error('HORACE:horace_binfile_interface:invalid_argument', ...
+            ['Number of IX_detector_array objects %d provided in ' ...
+            'the input container is not consistent with number of objects, ' ...
+            'requested to return (%d).\n' ...
+            'Input should be either 1 or equal to the number of requested'], ...
+            detpar.n_objects,n_instances)
+    end
+else
+    error('HORACE:horace_binfile_interface:invalid_argument', ...
+        ['Unrecognized input class: "%s" provided to the conversion method\n' ...
+        'Allowed inputs are: "struc", "ID_detector_array", ' ...
+        '"unique_objects_container" or "unique_references_container" '],...
+        class(detpar))
+end
+end

--- a/horace_core/sqw/file_io/@horace_binfile_interface/private/convert_old_det_forms_.m
+++ b/horace_core/sqw/file_io/@horace_binfile_interface/private/convert_old_det_forms_.m
@@ -2,6 +2,13 @@ function det = convert_old_det_forms_(detpar,n_instances)
 % Method used to convert detector formats written by any previous version
 % of Horace into Horace 4.01 data form.
 %
+% The routine is a gateway converting various old detector formats into
+% recent sqw object detectors format.
+%
+% If modern formats of detecotors have been provided as input, it checks
+% hem and passes them through, possibly replicating to requested number of
+% runs, if this has not been already done by input container itselt
+%
 % Input:
 % detpar      -- an old or new format detector information.
 %                Normally obtained from binary sqw file.
@@ -12,6 +19,11 @@ function det = convert_old_det_forms_(detpar,n_instances)
 %                unique_object_container container and
 %                distributed into approriate number of input
 %                runs.
+%                if unique_references_container or unique_objects_container
+%                is provided with appropriate  number of runs (1 or
+%                n_instances), routine passes it through,
+%                may be replicating to appropriate number of runs.
+%
 
 if isstruct(detpar) % we do not need do deal with struct array
     % here as this have never been used and stored in
@@ -24,15 +36,16 @@ if isa(detpar,'IX_detector_array')
 elseif isa(detpar,'unique_objects_container') || isa(detpar,'unique_references_container')
     if detpar.n_objects == 1
         det = detpar.replicate_runs(n_instances);
-    elseif ~isempty(n_instances) && detpar.n_objects == n_instances
+    elseif ~isempty(n_instances) && isnumeric(n_instances) && isscalar(n_instances) ...
+            && detpar.n_objects == n_instances
         det = detpar;
     else
         error('HORACE:horace_binfile_interface:invalid_argument', ...
             ['Number of IX_detector_array objects %d provided in ' ...
-            'the input container is not consistent with number of objects, ' ...
-            'requested to return (%d).\n' ...
+            'the input container is not consistent with number or type of objects, ' ...
+            'requested to return (%s).\n' ...
             'Input should be either 1 or equal to the number of requested'], ...
-            detpar.n_objects,n_instances)
+            detpar.n_objects,disp2str(n_instances))
     end
 else
     error('HORACE:horace_binfile_interface:invalid_argument', ...

--- a/horace_core/sqw/file_io/@sqw_binfile_common/get_detpar.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/get_detpar.m
@@ -56,4 +56,4 @@ if obj.convert_to_double
     det = obj.do_convert_to_double(det);
 end
 % convert old detector file formats into the recent one.
-det = obj.convet_old_det_forms(det,1);
+det = obj.convert_old_det_forms(det,1);

--- a/horace_core/sqw/file_io/@sqw_binfile_common/get_detpar.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/get_detpar.m
@@ -37,7 +37,7 @@ try
     do_fseek(obj.file_id_,obj.detpar_pos_,'bof');
 catch ME
     exc = MException('SQW_FILE_INTERFACE:runtime_error',...
-                     'can not move to the start of the detectors data');
+        'can not move to the start of the detectors data');
     throw(exc.addCause(ME))
 end
 bytes = fread(obj.file_id_,sz,'*uint8');
@@ -55,3 +55,5 @@ det = obj.sqw_serializer_.deserialize_bytes(bytes,det_format,1);
 if obj.convert_to_double
     det = obj.do_convert_to_double(det);
 end
+% convert old detector file formats into the recent one.
+det = obj.convet_old_det_forms(det,1);

--- a/horace_core/sqw/file_io/@sqw_binfile_common/get_exp_info.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/get_exp_info.m
@@ -30,7 +30,6 @@ if any(prop_keys)
     argi = varargin(~prop_keys);
 end
 
-
 %
 if ischar(obj.num_contrib_files)
     error('HORACE:sqw_binfile_common:runtime_error',...
@@ -45,7 +44,6 @@ else
         error('HORACE:sqw_binfile_common:invalid_argument',...
             'get_exp_info do not understand input argument: %s',n_header);
     end
-
 end
 
 if n_header<1 || (n_header>obj.num_contrib_files)
@@ -62,9 +60,12 @@ if get_all && obj.num_contrib_files > 1
 else
     [header,pos] = get_single_header(obj,n_header);
 end
-%
 exp_info = Experiment.build_from_binfile_headers(header);
-
+% Get detector parameters
+% -----------------------
+detpar  = obj.get_detpar();
+detpar  = detpar.replicate_runs(exp_info.n_runs);
+exp_info.detector_arrays = detpar;
 
 
 function [head,pos] = get_single_header(obj,n_header)
@@ -79,7 +80,7 @@ try
     do_fseek(obj.file_id_,obj.header_pos_(n_header),'bof');
 catch ME
     exc = MException('HORACE:sqw_binfile_common:runtime_error',...
-                     'get_single_header: can not move at the start of header N%d',n_header);
+        'get_single_header: can not move at the start of header N%d',n_header);
     throw(exc.addCause(ME))
 end
 

--- a/horace_core/sqw/file_io/@sqw_binfile_common/get_sqw.m
+++ b/horace_core/sqw/file_io/@sqw_binfile_common/get_sqw.m
@@ -63,35 +63,6 @@ end
 % ------------------------------------------
 [exp_info,~]  = obj.get_exp_info('-all');
 
-% Get detector parameters
-% -----------------------
-if ~(opts.head||opts.his)
-    detpar = obj.get_detpar();
-    if ~isempty(detpar)
-        if  isstruct(detpar) && IX_detector_array.check_detpar_parms(detpar)
-            detector = IX_detector_array(detpar);
-            det_arrays = exp_info.detector_arrays;
-            if exp_info.detector_arrays.n_runs == 0
-                det_arrays = det_arrays.add_copies_(detector, exp_info.n_runs);
-                exp_info.detector_arrays = det_arrays;
-
-            elseif exp_info.detector_arrays.n_runs == exp_info.n_runs
-                exp_info.detector_arrays = exp_info.detector_arrays.replace_all(detector);
-            else
-                error('HORACE:get_sqw:invalid_data', ...
-                    ['the detector arrays input with exp_info are neither zero length',...
-                    'nor as long as the number of runs in exp_info.\n', ...
-                    'the formation of exp_info upstream may be faulty.']);
-            end
-        else
-            error('HORACE:get_sqw:invalid_data', ...
-                'detpar input is not a struct as per this file format');
-        end
-    else
-        ; % there was no detpar info in the file; currently do nothing, not an error state
-    end
-end
-
 % Get data
 % --------
 if opts.verbatim || opts.keep_original
@@ -104,8 +75,6 @@ if (opts.head || opts.his)
 else
     opt2 = {};
 end
-
-
 data_opt= [opt1, opt2];
 sqw_struc.data = obj.get_data(data_opt{:});
 %
@@ -171,4 +140,3 @@ end
 if nargout>1
     varargout{1} = obj;
 end
-


### PR DESCRIPTION
Solves Re #1808. 

After detectors moved into `Experiment` , `get_exp_info` should return `Experiment` with detectors. 

Here I have modified  `get_exp_info` to return `Experiment` with array of detectors and other file-accessors to use this method to build `sqw`. 

I have also extracted old format conversion into new conversion routine into single place and provided unit tests for it.

Also, small bug in load/save `sqw` fixed to avoid  saving/loading detector information twice.
