### PR TITLE
`bragg_positions` work with multift in parallel enabled

### DIFF
--- a/_test/test_change_crystal/test_change_crystal_bragg_coarse.m
+++ b/_test/test_change_crystal/test_change_crystal_bragg_coarse.m
@@ -843,6 +843,32 @@ classdef test_change_crystal_bragg_coarse < TestCaseWithSave
             assertTrue(hpc.parallel_multifit);
             assertEqualWithSave(obj,corr,'',1.e-8)
         end
+        function test_bragg_pos_no_parallel(obj)
+            % ensure that bragg_pos is not failing regardless of parallel
+            % mutlifit enabled or not
+            clOb = set_temporary_config_options(hpc_config,'parallel_multifit',true);
+            bragg_pos= [...
+                0, -1, 0; ...
+                1, 2, 0; ...
+                0, -1, 1];
+
+            radial_cut_length = 1.5;
+            radial_bin_width  = 0.02;
+            radial_thickness  = 0.4;
+            trans_cut_length = 1.5;
+            trans_bin_width  = 0.02;
+            trans_thickness  = 2;
+
+            [rlu_real, width, wcut, wpeak]=bragg_positions(obj.misaligned_sqw_file, ...
+                bragg_pos, radial_cut_length, radial_bin_width, radial_thickness, ...
+                trans_cut_length, trans_bin_width, trans_thickness, 'gauss');
+            rlu_sample = ...
+                [0.04   -0.9999    0.05;...
+                0.90     2.       -0.16;...
+                0.10    -0.95       1.0];
+            assertElementsAlmostEqual(rlu_real, rlu_sample, 'absolute', 1.e-1);
+
+        end
 
         function test_bragg_pos(obj)
             bragg_pos= [...

--- a/horace_core/lattice_functions/bragg_positions.m
+++ b/horace_core/lattice_functions/bragg_positions.m
@@ -116,6 +116,9 @@ end
     radial_cut_length, radial_bin_width, radial_thickness,...
     trans_cut_length, trans_bin_width, trans_thickness, varargin{:});
 
+% Parallel multifit is not working on pic fitting and it should not be
+% working at its current state as it is very inefficient
+clOb = set_temporary_config_options(hpc_config,'parallel_multifit',false);
 
 % Fit Peaks
 % ---------


### PR DESCRIPTION
Fixes Re #1886.

The issue reported by user is twofold. His alignment script is incorrect, and bragg_positions` functions fails if `hpc_config`
`parallel_multifit` option is set to `true`.

Issue with user script has been addressed within the ticket itself. Issue with parallel multifit is addressed here

`bragg_postition` routine use simple fitting to identifty peak positions from cuts build around Bragg peaks. This fitting is quick and simple, so miltifit is not intended to be used in parallel. Neither `parallel_multifit` option in its current implementation is currently working or promicess any benifits for solving `bragg_position` locations.

This is why the solution here is just to disable parallel multifit within `bragg_position` routine.