### PR TITLE
Solves Issue #1894:

### DIFF
--- a/_test/test_IX_classes/test_plot_IX_dataset_3.m
+++ b/_test/test_IX_classes/test_plot_IX_dataset_3.m
@@ -183,12 +183,16 @@ classdef test_plot_IX_dataset_3 < TestCase
             % Until we can find a way of changing Matlab behaviour in a robut
             % way, catch this test.
             % The following will be interpreted as >> aline
-            clWarn = set_temporary_warning('off','MATLAB:colon:operandsNotRealScalar');
-            aline  :  0.5;
-            styles = genieplot.get('line_styles');
-            widths = genieplot.get('line_widths');
-            assertFalse(isequal(styles, ':'), 'Mysteriously now working ???')
-            assertFalse(isequal(widths, '0.5'), 'Mysteriously now working ???')
+            if verLessThan('matlab', '25.1')
+                % As of R2025a it is an error that is thrown, not just a warning
+                % Skip this test for R2025a and later
+                clWarn = set_temporary_warning('off','MATLAB:colon:operandsNotRealScalar');
+                aline  :  0.5;
+                styles = genieplot.get('line_styles');
+                widths = genieplot.get('line_widths');
+                assertFalse(isequal(styles, ':'), 'Mysteriously now working ???')
+                assertFalse(isequal(widths, '0.5'), 'Mysteriously now working ???')
+            end
 
             % This will work:
             aline ':' 0.5

--- a/herbert_core/graphics/genie_figure_create.m
+++ b/herbert_core/graphics/genie_figure_create.m
@@ -277,7 +277,9 @@ function colordef_suppressedDeprecationWarning(varargin)
 % but until then, just suppress the warning message as colordef continues to
 % work.
 
-S = warning('query', 'MATLAB:colordef:ColordefWillBeRemoved');
-cleanupObj = onCleanup(@()warning(S));
-warning('off', 'MATLAB:colordef:ColordefWillBeRemoved');
-colordef(varargin{:})
+if verLessThan('MATLAB','25.1')  % prior to R2025a
+    S = warning('query', 'MATLAB:colordef:ColordefWillBeRemoved');
+    cleanupObj = onCleanup(@()warning(S));
+    warning('off', 'MATLAB:colordef:ColordefWillBeRemoved');
+    colordef(varargin{:})
+end

--- a/herbert_core/graphics/private/set_axScale.m
+++ b/herbert_core/graphics/private/set_axScale.m
@@ -15,5 +15,5 @@ genieplot.set(name, axScale);
 
 % Change current axes on the figure (if there is such a figure window and axes)
 if ~isempty(get(groot,'CurrentFigure')) && ~isempty(get(gcf,'CurrentAxes'))
-    set (gca, 'XScale', axScale);
+    set (gca, name, axScale);
 end

--- a/herbert_core/graphics/sliceomatic/sliceomatic.m
+++ b/herbert_core/graphics/sliceomatic/sliceomatic.m
@@ -1475,7 +1475,9 @@ function colordef_suppressedDeprecationWarning(varargin)
 % but until then, just suppress the warning message as colordef continues to
 % work.
 
-S = warning('query', 'MATLAB:colordef:ColordefWillBeRemoved');
-cleanupObj = onCleanup(@()warning(S));
-warning('off', 'MATLAB:colordef:ColordefWillBeRemoved');
-colordef(varargin{:})
+if verLessThan('MATLAB','25.1')  % prior to R2025a
+    S = warning('query', 'MATLAB:colordef:ColordefWillBeRemoved');
+    cleanupObj = onCleanup(@()warning(S));
+    warning('off', 'MATLAB:colordef:ColordefWillBeRemoved');
+    colordef(varargin{:})
+end

--- a/herbert_core/utilities/classes/@IX_dataset_1d/pm.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/pm.m
@@ -14,4 +14,4 @@ new_axes = false;
 force_current_axes = false;
 
 varargout = cell(1, nargout);   % output only if requested
-[varargout{:}] = plot_oned(w, new_axes, force_current_axes, 'l', varargin{:});
+[varargout{:}] = plot_oned(w, new_axes, force_current_axes, 'm', varargin{:});

--- a/herbert_core/utilities/misc/@fig_spread/fig_spread.m
+++ b/herbert_core/utilities/misc/@fig_spread/fig_spread.m
@@ -90,6 +90,9 @@ classdef fig_spread
             % screen tight, namely overlapping figure borders and resizing
             % them to fit on the screen requested number.
             
+            % This warning needs to be suppressed from R2019b to R2024b because
+            % the JavaFrame property was deprecated in R2019b. The property
+            % became obsolete in R2025a.
             warning('off','MATLAB:HandleGraphics:ObsoletedProperty:JavaFrame');
             
             

--- a/herbert_core/utilities/misc/@fig_spread/private/rize_figure_.m
+++ b/herbert_core/utilities/misc/@fig_spread/private/rize_figure_.m
@@ -1,14 +1,29 @@
 function rize_figure_(fig_h)
-% Function to rize a image on top of any window
+% Function to raise a Matlab figure window above all other windows.
 %
-% as old way does not work for new Matlab graphics.
+% The history of this function is as follows:
+% - The conventional matlab way to do this is to use the figure function with
+%   the figure handle as the input argument: 
+%       >> figure(fig_h)
 %
+% - Apparently, the behaviour changed in R2014b when Matlab overhauled the
+%   graphics. An algorithm was written using Java calls.
 %
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
+% - This became deprecated from R2019b, which is why a warning printed 
+%   to the command window was suppressed in the classdef file for fig_spread:
+%       >> warning('off','MATLAB:HandleGraphics:ObsoletedProperty:JavaFrame');
+%   However, the algorithm continued to work.
 %
+% - From R2025a the JavaFrame property became obsolete. The original call
+%       >> figure(fig_h)
+%   appears to work. [Indeed, it seems to work for R2014b to R2024b in the
+%   intended manner, but in case there are circumstances where that is not true
+%   the Java algorithm has been retained]
+
 if verLessThan('matlab','8.4')
     figure(fig_h);
-else
+    
+elseif verLessThan('matlab','25.1')
     fJFrame = get(fig_h,'JavaFrame');
     drawnow expose
     jw = fJFrame.fHG2Client.getWindow();
@@ -18,5 +33,7 @@ else
         jw.setAlwaysOnTop(true);
         jw.setAlwaysOnTop(false);
     end
+    
+else
+    figure(fig_h);
 end
-


### PR DESCRIPTION
Solve plotting bugs:
- 'plot markers' `>> pm(w)` was overplotting a line, not markers
- liny, linz, logy, logz were acting on the x-axis of plots Solve issues appearing in Matlab R2025a:
- `colordef` obsolete from R2025a onwards; solution implemented
- obsolete graphics property 'JavaFrame' from R2025a; solution implemented
- behaviour of colon (:) in command mode (as opposed to function mode) implementation was causing a test to fail due to changed matlab behaviour. Test now not applied to R2025a onwards as the behaviour previously expected in Horace seems now to be deemed in admissable.