### PR TITLE
Dispersion relations for the Heisenberg ferromagnet on simple cubic, bcc and fcc lattices generalised.

### DIFF
--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -65,6 +65,7 @@ set(HORACE_TESTS
     "test_sqw"
     "test_sqw_class"
     "test_sqw_file"
+    "test_sqw_models"
     "test_sqw_pageOpMethods"
     "test_sqw_pixels"
     "test_sym_op"

--- a/_test/test_sqw_models/test_disp_bcc_hfm.m
+++ b/_test/test_sqw_models/test_disp_bcc_hfm.m
@@ -1,0 +1,438 @@
+classdef test_disp_bcc_hfm < TestCase
+    % Test bcc Heisenberg ferromagnet dispersion relation disp_bcc_hfm
+    %
+    % Tests that the symmetry of the contributions from each site degeneracy
+    % type is respected, by testing for equality of the excitation energy at
+    % every symmetry equivalent wavevector of a given wavevector, and about
+    % several lattice gamma points.
+    %
+    % This is done by testing the contribution from each of the first 15
+    % neighbours, which collectively cover the contributions from the six
+    % different cases of site symmetry (with site degeneracy M):
+    %   [x 0 0]     M = 6
+    %   [x x 0]     M = 12
+    %   [x x x]     M = 8
+    %   [x y 0]     M = 24
+    %   [x x z]     M = 24
+    %   [x y z]     M = 48
+    % 
+    % and for each of the first 15 neighbours, check for the six different
+    % symmetries of wavevector:
+    %
+    %   Q_h00 = [h,0,0];      6-fold
+    %   Q_hh0 = [h,h,0];      12-fold
+    %   Q_hhh = [h,h,h];      8-fold
+    %   Q_hk0 = [h,k,0];      24-fold
+    %   Q_hhk = [h,h,k];      24-fold
+    %   Q_hkl = [h,k,l];      48-fold
+    %
+    % In addition, the excitation energies are tested for equality against
+    % stored values to confirm the absolute values, not just the symmetry.
+
+    properties
+        Seff
+        gap
+        par0
+        JS
+        qh_ref
+        qk_ref
+        ql_ref
+        w_JS
+        w_tot
+        Qh
+        Qk
+        Ql
+        tol
+    end
+    
+    methods
+        %--------------------------------------------------------------------------
+        function obj = test_disp_bcc_hfm(name)
+            obj = obj@TestCase(name);
+            
+            % Create sets of symmetry related points in reciprocal space
+            qh_ref = 0.216;
+            qk_ref = 0.314;
+            ql_ref = 0.271;
+            
+            rlp = [0,0,0; 1,1,0; -2,2,4];
+            
+            Q_h00 = QsymRelated (qh_ref, 0, 0, rlp);
+            Q_hh0 = QsymRelated (qh_ref, qh_ref, 0, rlp);
+            Q_hhh = QsymRelated (qh_ref, qh_ref, qh_ref, rlp);
+            Q_hk0 = QsymRelated (qh_ref, qk_ref, 0, rlp);
+            Q_hhk = QsymRelated (qh_ref, qh_ref, qk_ref, rlp);
+            Q_hkl = QsymRelated (qh_ref, qk_ref, ql_ref, rlp);
+
+            obj.qh_ref = qh_ref;
+            obj.qk_ref = qk_ref;
+            obj.ql_ref = ql_ref;
+            obj.Qh = {Q_h00(:,1), Q_hh0(:,1), Q_hhh(:,1), Q_hk0(:,1), Q_hhk(:,1), Q_hkl(:,1)};
+            obj.Qk = {Q_h00(:,2), Q_hh0(:,2), Q_hhh(:,2), Q_hk0(:,2), Q_hhk(:,2), Q_hkl(:,2)};
+            obj.Ql = {Q_h00(:,3), Q_hh0(:,3), Q_hhh(:,3), Q_hk0(:,3), Q_hhk(:,3), Q_hkl(:,3)};
+            
+            % Some random exchange parameters and corresponding excitation
+            % energies for each exchange parameter individually at [qh_ref, qk_ref, ql_ref]
+            obj.Seff = 10;
+            obj.gap = 3.94;
+            obj.JS = [0.762368339977811   0.080068138934902   0.938246224630109 ...
+                0.974473843479017   0.607110428021082   0.957494958695934 ...
+                0.330650541159530   0.901215142217029   0.000365623763306 ...
+                0.483280019453646   0.147474747267827   0.314992086852311 ...
+                0.171375458208079   0.592906936782863   0.657608011954500];
+
+            obj.w_JS = [4.373082526631028   0.530200153173490  11.481791003296113 ...
+                31.377318004399211   4.803863639321013    10.664848701393527 ...
+                4.936824265569184    19.490447148602474   0.008621153138463 ...
+                13.257772891438805   1.612818613826166    1.033756435200059 ...
+                6.426932593773794    2.701274574774424    17.281668078687623];
+            obj.w_tot = 1.339212197832254e+02;      % energy with all parameters set
+
+            % Initial parameters argument for dispersion relation evaluation
+            % All zero, except for the spectral weight
+            % In general, par0 contains [Seff, gap, JS1, JS2,...JS15]
+            obj.par0 = [obj.Seff, zeros(1,16)];
+
+            % Acceptable absolute and tolerance criterion
+            obj.tol = [1e-12, 1e-12];
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_gap (obj)
+            % Gap only
+            par = [obj.Seff, obj.gap];
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(w{1}(1), obj.gap, obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS1 (obj)
+            % Test JS1 only
+            par = obj.par0;
+            par(3) = obj.JS(1);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS2 (obj)
+            % Test JS2 only
+            par = obj.par0;
+            par(4) = obj.JS(2);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS3 (obj)
+            % Test JS3 only
+            par = obj.par0;
+            par(5) = obj.JS(3);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS4 (obj)
+            % Test JS4 only
+            par = obj.par0;
+            par(6) = obj.JS(4);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS5 (obj)
+            % Test JS5 only
+            par = obj.par0;
+            par(7) = obj.JS(5);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS6 (obj)
+            % Test JS6 only
+            par = obj.par0;
+            par(8) = obj.JS(6);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS7 (obj)
+            % Test JS7 only
+            par = obj.par0;
+            par(9) = obj.JS(7);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS8 (obj)
+            % Test JS8 only
+            par = obj.par0;
+            par(10) = obj.JS(8);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS9 (obj)
+            % Test JS9 only
+            par = obj.par0;
+            par(11) = obj.JS(9);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS10 (obj)
+            % Test JS10 only
+            par = obj.par0;
+            par(12) = obj.JS(10);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS11 (obj)
+            % Test JS11 only
+            par = obj.par0;
+            par(13) = obj.JS(11);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS12 (obj)
+            % Test JS12 only
+            par = obj.par0;
+            par(14) = obj.JS(12);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS13 (obj)
+            % Test JS13 only
+            par = obj.par0;
+            par(15) = obj.JS(13);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS14 (obj)
+            % Test JS14 only
+            par = obj.par0;
+            par(16) = obj.JS(14);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS15 (obj)
+            % Test JS15 only
+            par = obj.par0;
+            par(17) = obj.JS(15);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS1_to_JS15 (obj)
+            % Test JS1 to JS15 all non-zero
+            par = obj.par0;
+            par(3:17) = obj.JS;
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_bcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS1_to_JS6 (obj)
+            % Test JS1 to JS6 only is the same as full parameter array with JS7
+            % onwards set to zero. Tests variable length parameter array input.
+            par = obj.par0;
+            par(3:8) = obj.JS(1:6);
+            
+            [wfull, wtfull] = disp_bcc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par);
+            [w, wt] = disp_bcc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par(1:8));
+            assertEqualToTol(wfull, w, obj.tol);
+            assertEqualToTol(wtfull, wt, obj.tol);
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_absolute_energy_JS_one_at_a_time (obj)
+            % Test absolute energy value - a test that no foolish factors of 2
+            % or whatever have crept into a change to the code!
+            for i=1:15
+                par = obj.par0;
+                par(i+2) = obj.JS(i);
+                [w, wt] = disp_bcc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par);
+                assertEqualToTol(w{1}, obj.w_JS(i), obj.tol);
+                assertEqualToTol(wt{1}, obj.Seff/2, obj.tol);
+            end
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_absolute_energy_value_gap_JS1_to_JS15 (obj)
+            % Test absolute energy value - a test that no foolish factors of 2
+            % or whatever have crept into a change!
+            par = [obj.Seff, obj.gap, obj.JS];
+            
+            [w, wt] = disp_bcc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par);
+            assertEqualToTol(w{1}, obj.w_tot, obj.tol);
+            assertEqualToTol(wt{1}, obj.Seff/2, obj.tol);
+        end
+        
+        %--------------------------------------------------------------------------
+    end
+end
+
+
+%==================================================================================
+function Q = QsymRelated (qh, qk, ql, rlp)
+% Get all symmetry related Q points of an input point for a cubic lattice.
+% The excitation energies from a dispersion relation at each of the output points
+% should all be identical.
+%
+%   >> Q = QsymRelated (h, k, l)
+%   >> Q = QsymRelated (h, k, l, rlp)
+%
+% Input:
+% ------
+%   h, k, l     Point in reciprocal lattice (in rlu) (each is scalar)
+% Optional:
+%   rlp         Set of reciprocal lattice points; size(rlp) is [nrlp,3]
+%               Each element should be an integer and each row corresponds to a
+%               zone centre in the reciprocal lattice
+%               For example, for bcc cubic h+k+l is even, fcc h,k,l are all odd
+%               or all even, and for simple cubic h,k,l are all even.
+%               [No check of rlp is performed by this algorithm.]
+%               If rlp is not given, the default is [0,0,0] i.e. no offset to Q
+%
+% Output:
+% -------
+%   Q           Array size [n,3] of symmetry related Q points offset by all the
+%               zone centres in input argument rlp, if given.
+%
+% Q_h00 = [h,0,0];      6-fold
+% Q_hh0 = [h,h,0];      12-fold
+% Q_hhh = [h,h,h];      8-fold
+% Q_hk0 = [h,k,0];      24-fold
+% Q_hhk = [h,h,k];      24-fold
+% Q_hkl = [h,k,l];      48-fold
+
+% Permute the cubic axes and all inversions of axes
+Q = perms([qh,qk,ql]);
+Q = [Q; perms([qh,qk,-ql])];
+Q = [Q; perms([qh,-qk,ql])];
+Q = [Q; perms([qh,-qk,-ql])];
+Q = [Q; perms([-qh,qk,ql])];
+Q = [Q; perms([-qh,qk,-ql])];
+Q = [Q; perms([-qh,-qk,ql])];
+Q = [Q; perms([-qh,-qk,-ql])];
+
+% Retain unique values only (e.g. if [qh,qk,ql] = [0.1,0.1,0] there will be only
+% 12 symmetry related sites.
+Q = unique(Q,'rows');
+nQ = size(Q,1);     % number of Q points
+
+% Accumulate for each rlp in turn
+if exist('rlp','var')
+    nrlu = size(rlp,1); % number of rlp
+    if nrlu==1
+        Q = Q + rlp;    % to get get correct array dimensions cannot use repelem
+    else
+        Q = repmat(Q,[nrlu,1]) + ...
+            [repelem(rlp(:,1),nQ), repelem(rlp(:,2),nQ), repelem(rlp(:,3),nQ)];
+    end
+end
+
+end

--- a/_test/test_sqw_models/test_disp_fcc_hfm.m
+++ b/_test/test_sqw_models/test_disp_fcc_hfm.m
@@ -1,0 +1,438 @@
+classdef test_disp_fcc_hfm < TestCase
+    % Test fcc Heisenberg ferromagnet dispersion relation disp_fcc_hfm
+    %
+    % Tests that the symmetry of the contributions from each site degeneracy
+    % type is respected, by testing for equality of the excitation energy at
+    % every symmetry equivalent wavevector of a given wavevector, and about
+    % several lattice gamma points.
+    %
+    % This is done by testing the contribution from each of the first 15
+    % neighbours, which collectively cover the contributions from the six
+    % different cases of site symmetry (with site degeneracy M):
+    %   [x 0 0]     M = 6
+    %   [x x 0]     M = 12
+    %   [x x x]     M = 8
+    %   [x y 0]     M = 24
+    %   [x x z]     M = 24
+    %   [x y z]     M = 48
+    % 
+    % and for each of the first 15 neighbours, check for the six different
+    % symmetries of wavevector:
+    %
+    %   Q_h00 = [h,0,0];      6-fold
+    %   Q_hh0 = [h,h,0];      12-fold
+    %   Q_hhh = [h,h,h];      8-fold
+    %   Q_hk0 = [h,k,0];      24-fold
+    %   Q_hhk = [h,h,k];      24-fold
+    %   Q_hkl = [h,k,l];      48-fold
+    %
+    % In addition, the excitation energies are tested for equality against
+    % stored values to confirm the absolute values, not just the symmetry.
+
+    properties
+        Seff
+        gap
+        par0
+        JS
+        qh_ref
+        qk_ref
+        ql_ref
+        w_JS
+        w_tot
+        Qh
+        Qk
+        Ql
+        tol
+    end
+    
+    methods
+        %--------------------------------------------------------------------------
+        function obj = test_disp_fcc_hfm(name)
+            obj = obj@TestCase(name);
+            
+            % Create sets of symmetry related points in reciprocal space
+            qh_ref = 0.216;
+            qk_ref = 0.314;
+            ql_ref = 0.271;
+            
+            rlp = [0,0,0; 3,1,5; -2,2,4];
+            
+            Q_h00 = QsymRelated (qh_ref, 0, 0, rlp);
+            Q_hh0 = QsymRelated (qh_ref, qh_ref, 0, rlp);
+            Q_hhh = QsymRelated (qh_ref, qh_ref, qh_ref, rlp);
+            Q_hk0 = QsymRelated (qh_ref, qk_ref, 0, rlp);
+            Q_hhk = QsymRelated (qh_ref, qh_ref, qk_ref, rlp);
+            Q_hkl = QsymRelated (qh_ref, qk_ref, ql_ref, rlp);
+
+            obj.qh_ref = qh_ref;
+            obj.qk_ref = qk_ref;
+            obj.ql_ref = ql_ref;
+            obj.Qh = {Q_h00(:,1), Q_hh0(:,1), Q_hhh(:,1), Q_hk0(:,1), Q_hhk(:,1), Q_hkl(:,1)};
+            obj.Qk = {Q_h00(:,2), Q_hh0(:,2), Q_hhh(:,2), Q_hk0(:,2), Q_hhk(:,2), Q_hkl(:,2)};
+            obj.Ql = {Q_h00(:,3), Q_hh0(:,3), Q_hhh(:,3), Q_hk0(:,3), Q_hhk(:,3), Q_hkl(:,3)};
+            
+            % Some random exchange parameters and corresponding excitation
+            % energies for each exchange parameter individually at [qh_ref, qk_ref, ql_ref]
+            obj.Seff = 10;
+            obj.gap = 3.94;
+            obj.JS = [0.762368339977811   0.080068138934902   0.938246224630109 ...
+                0.974473843479017   0.607110428021082   0.957494958695934 ...
+                0.330650541159530   0.901215142217029   0.000365623763306 ...
+                0.483280019453646   0.147474747267827   0.314992086852311 ...
+                0.171375458208079   0.592906936782863   0.657608011954500];
+
+            obj.w_JS = [5.166073062143445    0.530200153173490   23.870445966181734 ...
+                11.925126598208013   22.010263997136050    7.576340323959727 ...
+                15.162957213294591   10.037988244073540    0.011996036719715 ...
+                2.643096671642505    3.189414638890848     7.636762446438667 ...
+                4.040913686864440    17.654798298519786    17.676886641695624];
+            obj.w_tot = 1.530732639789422e+02;      % energy with all parameters set
+
+            % Initial parameters argument for dispersion relation evaluation
+            % All zero, except for the spectral weight
+            % In general, par0 contains [Seff, gap, JS1, JS2,...JS15]
+            obj.par0 = [obj.Seff, zeros(1,16)];
+
+            % Acceptable absolute and tolerance criterion
+            obj.tol = [1e-12, 1e-12];
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_gap (obj)
+            % Gap only
+            par = [obj.Seff, obj.gap];
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(w{1}(1), obj.gap, obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS1 (obj)
+            % Test JS1 only
+            par = obj.par0;
+            par(3) = obj.JS(1);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS2 (obj)
+            % Test JS2 only
+            par = obj.par0;
+            par(4) = obj.JS(2);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS3 (obj)
+            % Test JS3 only
+            par = obj.par0;
+            par(5) = obj.JS(3);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS4 (obj)
+            % Test JS4 only
+            par = obj.par0;
+            par(6) = obj.JS(4);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS5 (obj)
+            % Test JS5 only
+            par = obj.par0;
+            par(7) = obj.JS(5);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS6 (obj)
+            % Test JS6 only
+            par = obj.par0;
+            par(8) = obj.JS(6);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS7 (obj)
+            % Test JS7 only
+            par = obj.par0;
+            par(9) = obj.JS(7);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS8 (obj)
+            % Test JS8 only
+            par = obj.par0;
+            par(10) = obj.JS(8);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS9 (obj)
+            % Test JS9 only
+            par = obj.par0;
+            par(11) = obj.JS(9);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS10 (obj)
+            % Test JS10 only
+            par = obj.par0;
+            par(12) = obj.JS(10);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS11 (obj)
+            % Test JS11 only
+            par = obj.par0;
+            par(13) = obj.JS(11);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS12 (obj)
+            % Test JS12 only
+            par = obj.par0;
+            par(14) = obj.JS(12);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS13 (obj)
+            % Test JS13 only
+            par = obj.par0;
+            par(15) = obj.JS(13);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS14 (obj)
+            % Test JS14 only
+            par = obj.par0;
+            par(16) = obj.JS(14);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS15 (obj)
+            % Test JS15 only
+            par = obj.par0;
+            par(17) = obj.JS(15);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS1_to_JS15 (obj)
+            % Test JS1 to JS15 all non-zero
+            par = obj.par0;
+            par(3:17) = obj.JS;
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_fcc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS1_to_JS6 (obj)
+            % Test JS1 to JS6 only is the same as full parameter array with JS7
+            % onwards set to zero. Tests variable length parameter array input.
+            par = obj.par0;
+            par(3:8) = obj.JS(1:6);
+            
+            [wfull, wtfull] = disp_fcc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par);
+            [w, wt] = disp_fcc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par(1:8));
+            assertEqualToTol(wfull, w, obj.tol);
+            assertEqualToTol(wtfull, wt, obj.tol);
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_absolute_energy_JS_one_at_a_time (obj)
+            % Test absolute energy value - a test that no foolish factors of 2
+            % or whatever have crept into a change to the code!
+            for i=1:15
+                par = obj.par0;
+                par(i+2) = obj.JS(i);
+                [w, wt] = disp_fcc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par);
+                assertEqualToTol(w{1}, obj.w_JS(i), obj.tol);
+                assertEqualToTol(wt{1}, obj.Seff/2, obj.tol);
+            end
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_absolute_energy_value_gap_JS1_to_JS15 (obj)
+            % Test absolute energy value - a test that no foolish factors of 2
+            % or whatever have crept into a change!
+            par = [obj.Seff, obj.gap, obj.JS];
+            
+            [w, wt] = disp_fcc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par);
+            assertEqualToTol(w{1}, obj.w_tot, obj.tol);
+            assertEqualToTol(wt{1}, obj.Seff/2, obj.tol);
+        end
+        
+        %--------------------------------------------------------------------------
+    end
+end
+
+
+%==================================================================================
+function Q = QsymRelated (qh, qk, ql, rlp)
+% Get all symmetry related Q points of an input point for a cubic lattice.
+% The excitation energies from a dispersion relation at each of the output points
+% should all be identical.
+%
+%   >> Q = QsymRelated (h, k, l)
+%   >> Q = QsymRelated (h, k, l, rlp)
+%
+% Input:
+% ------
+%   h, k, l     Point in reciprocal lattice (in rlu) (each is scalar)
+% Optional:
+%   rlp         Set of reciprocal lattice points; size(rlp) is [nrlp,3]
+%               Each element should be an integer and each row corresponds to a
+%               zone centre in the reciprocal lattice
+%               For example, for bcc cubic h+k+l is even, fcc h,k,l are all odd
+%               or all even, and for simple cubic h,k,l are all even.
+%               [No check of rlp is performed by this algorithm.]
+%               If rlp is not given, the default is [0,0,0] i.e. no offset to Q
+%
+% Output:
+% -------
+%   Q           Array size [n,3] of symmetry related Q points offset by all the
+%               zone centres in input argument rlp, if given.
+%
+% Q_h00 = [h,0,0];      6-fold
+% Q_hh0 = [h,h,0];      12-fold
+% Q_hhh = [h,h,h];      8-fold
+% Q_hk0 = [h,k,0];      24-fold
+% Q_hhk = [h,h,k];      24-fold
+% Q_hkl = [h,k,l];      48-fold
+
+% Permute the cubic axes and all inversions of axes
+Q = perms([qh,qk,ql]);
+Q = [Q; perms([qh,qk,-ql])];
+Q = [Q; perms([qh,-qk,ql])];
+Q = [Q; perms([qh,-qk,-ql])];
+Q = [Q; perms([-qh,qk,ql])];
+Q = [Q; perms([-qh,qk,-ql])];
+Q = [Q; perms([-qh,-qk,ql])];
+Q = [Q; perms([-qh,-qk,-ql])];
+
+% Retain unique values only (e.g. if [qh,qk,ql] = [0.1,0.1,0] there will be only
+% 12 symmetry related sites.
+Q = unique(Q,'rows');
+nQ = size(Q,1);     % number of Q points
+
+% Accumulate for each rlp in turn
+if exist('rlp','var')
+    nrlu = size(rlp,1); % number of rlp
+    if nrlu==1
+        Q = Q + rlp;    % to get get correct array dimensions cannot use repelem
+    else
+        Q = repmat(Q,[nrlu,1]) + ...
+            [repelem(rlp(:,1),nQ), repelem(rlp(:,2),nQ), repelem(rlp(:,3),nQ)];
+    end
+end
+
+end

--- a/_test/test_sqw_models/test_disp_sc_hfm.m
+++ b/_test/test_sqw_models/test_disp_sc_hfm.m
@@ -1,0 +1,438 @@
+classdef test_disp_sc_hfm < TestCase
+    % Test simple cubic Heisenberg ferromagnet dispersion relation disp_sc_hfm
+    %
+    % Tests that the symmetry of the contributions from each site degeneracy
+    % type is respected, by testing for equality of the excitation energy at
+    % every symmetry equivalent wavevector of a given wavevector, and about
+    % several lattice gamma points.
+    %
+    % This is done by testing the contribution from each of the first 15
+    % neighbours, which collectively cover the contributions from the six
+    % different cases of site symmetry (with site degeneracy M):
+    %   [x 0 0]     M = 6
+    %   [x x 0]     M = 12
+    %   [x x x]     M = 8
+    %   [x y 0]     M = 24
+    %   [x x z]     M = 24
+    %   [x y z]     M = 48
+    % 
+    % and for each of the first 15 neighbours, check for the six different
+    % symmetries of wavevector:
+    %
+    %   Q_h00 = [h,0,0];      6-fold
+    %   Q_hh0 = [h,h,0];      12-fold
+    %   Q_hhh = [h,h,h];      8-fold
+    %   Q_hk0 = [h,k,0];      24-fold
+    %   Q_hhk = [h,h,k];      24-fold
+    %   Q_hkl = [h,k,l];      48-fold
+    %
+    % In addition, the excitation energies are tested for equality against
+    % stored values to confirm the absolute values, not just the symmetry.
+
+    properties
+        Seff
+        gap
+        par0
+        JS
+        qh_ref
+        qk_ref
+        ql_ref
+        w_JS
+        w_tot
+        Qh
+        Qk
+        Ql
+        tol
+    end
+    
+    methods
+        %--------------------------------------------------------------------------
+        function obj = test_disp_sc_hfm(name)
+            obj = obj@TestCase(name);
+            
+            % Create sets of symmetry related points in reciprocal space
+            qh_ref = 0.216;
+            qk_ref = 0.314;
+            ql_ref = 0.271;
+            
+            rlp = [0,0,0; 3,1,5; -2,2,4];
+            
+            Q_h00 = QsymRelated (qh_ref, 0, 0, rlp);
+            Q_hh0 = QsymRelated (qh_ref, qh_ref, 0, rlp);
+            Q_hhh = QsymRelated (qh_ref, qh_ref, qh_ref, rlp);
+            Q_hk0 = QsymRelated (qh_ref, qk_ref, 0, rlp);
+            Q_hhk = QsymRelated (qh_ref, qh_ref, qk_ref, rlp);
+            Q_hkl = QsymRelated (qh_ref, qk_ref, ql_ref, rlp);
+
+            obj.qh_ref = qh_ref;
+            obj.qk_ref = qk_ref;
+            obj.ql_ref = ql_ref;
+            obj.Qh = {Q_h00(:,1), Q_hh0(:,1), Q_hhh(:,1), Q_hk0(:,1), Q_hhk(:,1), Q_hkl(:,1)};
+            obj.Qk = {Q_h00(:,2), Q_hh0(:,2), Q_hhh(:,2), Q_hk0(:,2), Q_hhk(:,2), Q_hkl(:,2)};
+            obj.Ql = {Q_h00(:,3), Q_hh0(:,3), Q_hhh(:,3), Q_hk0(:,3), Q_hhk(:,3), Q_hkl(:,3)};
+            
+            % Some random exchange parameters and corresponding excitation
+            % energies for each exchange parameter individually at [qh_ref, qk_ref, ql_ref]
+            obj.Seff = 10;
+            obj.gap = 3.94;
+            obj.JS = [0.762368339977811   0.080068138934902   0.938246224630109 ...
+                0.974473843479017   0.607110428021082   0.957494958695934 ...
+                0.330650541159530   0.901215142217029   0.000365623763306 ...
+                0.483280019453646   0.147474747267827   0.314992086852311 ...
+                0.171375458208079   0.592906936782863   0.657608011954500];
+
+            obj.w_JS = [5.048297812435594   0.979834091670183   7.424031469731702 ...
+                10.853964305277847   13.129887810807286  22.577062807909687 ...
+                1.085145116316240   4.105921855598267   0.009608442117904 ...
+                10.982700111336113   3.644208262492817   4.055695765415019 ...
+                5.058154188712554  29.783769654738464   1.995420775159630];
+            obj.w_tot = 1.246737024697193e+02;      % energy with all parameters set
+
+            % Initial parameters argument for dispersion relation evaluation
+            % All zero, except for the spectral weight
+            % In general, par0 contains [Seff, gap, JS1, JS2,...JS15]
+            obj.par0 = [obj.Seff, zeros(1,16)];
+
+            % Acceptable absolute and tolerance criterion
+            obj.tol = [1e-12, 1e-12];
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_gap (obj)
+            % Gap only
+            par = [obj.Seff, obj.gap];
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(w{1}(1), obj.gap, obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS1 (obj)
+            % Test JS1 only
+            par = obj.par0;
+            par(3) = obj.JS(1);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS2 (obj)
+            % Test JS2 only
+            par = obj.par0;
+            par(4) = obj.JS(2);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS3 (obj)
+            % Test JS3 only
+            par = obj.par0;
+            par(5) = obj.JS(3);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS4 (obj)
+            % Test JS4 only
+            par = obj.par0;
+            par(6) = obj.JS(4);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS5 (obj)
+            % Test JS5 only
+            par = obj.par0;
+            par(7) = obj.JS(5);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS6 (obj)
+            % Test JS6 only
+            par = obj.par0;
+            par(8) = obj.JS(6);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS7 (obj)
+            % Test JS7 only
+            par = obj.par0;
+            par(9) = obj.JS(7);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS8 (obj)
+            % Test JS8 only
+            par = obj.par0;
+            par(10) = obj.JS(8);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS9 (obj)
+            % Test JS9 only
+            par = obj.par0;
+            par(11) = obj.JS(9);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS10 (obj)
+            % Test JS10 only
+            par = obj.par0;
+            par(12) = obj.JS(10);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS11 (obj)
+            % Test JS11 only
+            par = obj.par0;
+            par(13) = obj.JS(11);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS12 (obj)
+            % Test JS12 only
+            par = obj.par0;
+            par(14) = obj.JS(12);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS13 (obj)
+            % Test JS13 only
+            par = obj.par0;
+            par(15) = obj.JS(13);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS14 (obj)
+            % Test JS14 only
+            par = obj.par0;
+            par(16) = obj.JS(14);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS15 (obj)
+            % Test JS15 only
+            par = obj.par0;
+            par(17) = obj.JS(15);
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS1_to_JS15 (obj)
+            % Test JS1 to JS15 all non-zero
+            par = obj.par0;
+            par(3:17) = obj.JS;
+            for i=1:numel(obj.Qh)
+                [w, wt] = disp_sc_hfm(obj.Qh{i}, obj.Qk{i}, obj.Ql{i}, par);
+                assertTrue(w{1}(1)>0, 'energy must be greater than zero')
+                assertEqualToTol(w{1}, repmat(w{1}(1), size(w{1})), obj.tol);
+                assertEqualToTol(wt{1}, repmat(obj.Seff/2, size(wt{1})), obj.tol);
+            end
+
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_JS1_to_JS6 (obj)
+            % Test JS1 to JS6 only is the same as full parameter array with JS7
+            % onwards set to zero. Tests variable length parameter array input.
+            par = obj.par0;
+            par(3:8) = obj.JS(1:6);
+            
+            [wfull, wtfull] = disp_sc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par);
+            [w, wt] = disp_sc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par(1:8));
+            assertEqualToTol(wfull, w, obj.tol);
+            assertEqualToTol(wtfull, wt, obj.tol);
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_absolute_energy_JS_one_at_a_time (obj)
+            % Test absolute energy value - a test that no foolish factors of 2
+            % or whatever have crept into a change to the code!
+            for i=1:15
+                par = obj.par0;
+                par(i+2) = obj.JS(i);
+                [w, wt] = disp_sc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par);
+                assertEqualToTol(w{1}, obj.w_JS(i), obj.tol);
+                assertEqualToTol(wt{1}, obj.Seff/2, obj.tol);
+            end
+        end
+        
+        %--------------------------------------------------------------------------
+        function test_absolute_energy_value_gap_JS1_to_JS15 (obj)
+            % Test absolute energy value - a test that no foolish factors of 2
+            % or whatever have crept into a change!
+            par = [obj.Seff, obj.gap, obj.JS];
+            
+            [w, wt] = disp_sc_hfm(obj.qh_ref, obj.qk_ref, obj.ql_ref, par);
+            assertEqualToTol(w{1}, obj.w_tot, obj.tol);
+            assertEqualToTol(wt{1}, obj.Seff/2, obj.tol);
+        end
+        
+        %--------------------------------------------------------------------------
+    end
+end
+
+
+%==================================================================================
+function Q = QsymRelated (qh, qk, ql, rlp)
+% Get all symmetry related Q points of an input point for a cubic lattice.
+% The excitation energies from a dispersion relation at each of the output points
+% should all be identical.
+%
+%   >> Q = QsymRelated (h, k, l)
+%   >> Q = QsymRelated (h, k, l, rlp)
+%
+% Input:
+% ------
+%   h, k, l     Point in reciprocal lattice (in rlu) (each is scalar)
+% Optional:
+%   rlp         Set of reciprocal lattice points; size(rlp) is [nrlp,3]
+%               Each element should be an integer and each row corresponds to a
+%               zone centre in the reciprocal lattice
+%               For example, for bcc cubic h+k+l is even, fcc h,k,l are all odd
+%               or all even, and for simple cubic h,k,l are all even.
+%               [No check of rlp is performed by this algorithm.]
+%               If rlp is not given, the default is [0,0,0] i.e. no offset to Q
+%
+% Output:
+% -------
+%   Q           Array size [n,3] of symmetry related Q points offset by all the
+%               zone centres in input argument rlp, if given.
+%
+% Q_h00 = [h,0,0];      6-fold
+% Q_hh0 = [h,h,0];      12-fold
+% Q_hhh = [h,h,h];      8-fold
+% Q_hk0 = [h,k,0];      24-fold
+% Q_hhk = [h,h,k];      24-fold
+% Q_hkl = [h,k,l];      48-fold
+
+% Permute the cubic axes and all inversions of axes
+Q = perms([qh,qk,ql]);
+Q = [Q; perms([qh,qk,-ql])];
+Q = [Q; perms([qh,-qk,ql])];
+Q = [Q; perms([qh,-qk,-ql])];
+Q = [Q; perms([-qh,qk,ql])];
+Q = [Q; perms([-qh,qk,-ql])];
+Q = [Q; perms([-qh,-qk,ql])];
+Q = [Q; perms([-qh,-qk,-ql])];
+
+% Retain unique values only (e.g. if [qh,qk,ql] = [0.1,0.1,0] there will be only
+% 12 symmetry related sites.
+Q = unique(Q,'rows');
+nQ = size(Q,1);     % number of Q points
+
+% Accumulate for each rlp in turn
+if exist('rlp','var')
+    nrlu = size(rlp,1); % number of rlp
+    if nrlu==1
+        Q = Q + rlp;    % to get get correct array dimensions cannot use repelem
+    else
+        Q = repmat(Q,[nrlu,1]) + ...
+            [repelem(rlp(:,1),nQ), repelem(rlp(:,2),nQ), repelem(rlp(:,3),nQ)];
+    end
+end
+
+end

--- a/horace_core/sqw_models/disp_bcc_hfm.m
+++ b/horace_core/sqw_models/disp_bcc_hfm.m
@@ -1,72 +1,400 @@
-function [wdisp,sf] = disp_bcc_hfm(qh,qk,ql,par)
-% Spin wave dispersion relation for body centred cubic Heisenberg ferromagnet
+function [wdisp, sf] = disp_bcc_hfm(qh, qk, ql, par)
+% Spin wave dispersion relation for the body centred cubic Heisenberg ferromagnet
 %
-%   >> [wdisp,sf] = disp_bcc_hfm (qh qk, ql, par)
+%   >> [wdisp, sf] = disp_bcc_hfm (qh qk, ql, par)
+%
+% The dispersion is for the following Hamiltonian:
+%           H = -(1/2)Sum(J(i,j) S(i).S(j))
+%
+% so that positive J favours ferromagnetism and each pair of spins appears only
+% once. In addition, a single ion anisotropy is included that opens a gap at the
+% magnetic zone centre.
+%
+% The algorithm works for intersite interactions out to arbitrarily great
+% distance, as determined by the length of the vector containing the interaction
+% parameters, input argument par, below.
+%
+% [Reference: 
+% For a derivation of the linear spin wave theory dispersion relation and 
+% spectral weight see e.g. 
+%   "Principles of Neutron Scattering from Condensed Matter"
+%   Author: A.T. Boothroyd (Oxford University press, 2020)
+% The general expression for the spin wave energies for a Heisenberg ferromagnet
+% is given in Eq. 8.56 (page 273). Note the opposite sign convention for the
+% exchange constants J]
 %
 % Input:
 % ------
-%   qh,qk,ql    Arrays of h,k,l
-%   par         Parameters [Seff, gap, JS_p5p5p5, JS_100, JS_110, JS_3p5p5p5, JS_111]
-%                   Seff        Intensity scale factor
-%                   gap         Gap at zone centre
-%                   JS_p5p5p5   First neighbour exchange constant
-%                   JS_100      Second neighbour exchange constant
-%                   JS_110      Third neighbour exchange constant
-%                   JS_3p5p5p5  Fourth neighbour exchange constant
-%                   JS_111      Fifth neighbour exchange constant
+%   qh,qk,ql    Arrays of h,k,l at which to compute the spin wave energies and
+%               spectral weights
 %
-%              Note: each pair of spins in the Hamiltonian appears only once
+%   par         Parameters [Seff, gap, JS1, JS2, JS3, JS4,...]:
+%                 Seff          Intensity scale factor as an effective local
+%                              moment spin with value Seff on each atomic site
+%                 gap           Gap at zone centre
+%                 JS1, JS2,...  First, second etc. neighbour exchange constants.
+%                               The exchange constants JS1, JS2,... are each the
+%                              product of J and Seff for the first neighbour, 
+%                              second, third neighbour etc.
+%
+%               The length of the parameters vector determines the range of the
+%              interactions. The vector can have have an unlimited number of
+%              interaction parameters. 
+%
+%               EXAMPLE
+%               If input argument par has length five, that is, par is:
+%                 [Seff, gap, JS1, JS2, JS3]
+%               then it is assumed that all interactions beyond the 3rd
+%              neighbour are zero.
+%
+%               The first 15 neighbours are 
+%                   JS1         JS to [0.5, 0.5, 0.5]   (nearest neighbour)
+%                   JS2         JS to [1, 0, 0]         (2nd neighbour)
+%                   JS3         JS to [1, 1, 0]         (3rd neighbour)
+%                   JS4         JS to [1.5, 0.5, 0.5]   (4th neighbour)
+%                   JS5         JS to [1, 1, 1]         (5th neighbour)
+%                   JS6         JS to [2, 0, 0]         (6th neighbour)
+%                   JS7         JS to [1.5, 1.5, 0.5]   (7th neighbour)
+%                   JS8         JS to [2, 1, 0]         (8th neighbour)
+%                   JS9         JS to [2, 1, 1]         (9th neighbour)
+%                   JS10        JS to [2.5, 0.5, 0.5]   (equal 10th neighbour)
+%                   JS11        JS to [1.5, 1.5, 1.5]   (equal 10th neighbour)
+%                   JS12        JS to [2, 2, 0]         (12th neighbour)
+%                   JS13        JS to [2.5, 1.5, 0.5]   (13th neighbour)
+%                   JS14        JS to [3, 0, 0]         (equal 14th neighbour)
+%                   JS15        JS to [2, 2, 1]         (equal 14th neighbour)
+%
+%               Note that if there are inequivalent sites at the same distance
+%               then the order is always decreasing x, followed by decreasing y.
+%
 % Output:
 % -------
-%   wdisp       Array of energies for the dispersion
-%   sf          Array of spectral weights
+%   wdisp       Cell array containing a single array with the spin wave energies
+%              at the array of points defined by qh, qk, ql
+%
+%   sf          Cell array containing a single array with the corresponding
+%              spectral weights, Seff/2 (i.e. par(1)/2)
 
-Seff=par(1);
-gap=par(2);
-JS_p5p5p5=par(3);
-JS_100=par(4);
-JS_110=par(5);
-JS_3p5p5p5=par(6);
-JS_111=par(7);
 
-w=gap*ones(size(qh));
+persistent rho
 
-% Precompute some arrays used in more than one exchange pathway
-if JS_p5p5p5~=0 || JS_3p5p5p5~=0
-    cos1h = cos(pi*qh);
-    cos1k = cos(pi*qk);
-    cos1l = cos(pi*ql);
-end
-if JS_110~=0 || JS_111~=0
-    cos2h = cos((2*pi)*qh);
-    cos2k = cos((2*pi)*qk);
-    cos2l = cos((2*pi)*ql);
+Seff = par(1);
+gap = par(2);
+JS = par(3:end);
+npar = numel(JS);
+
+if npar > size(rho,1)
+    % Populate rho with the positions of unique nearest neighbour locations in
+    % order of increasing separation. Initialise with the first 15 distinct
+    % nearest neighbours
+    d_upper_bound = d_upper_bound_bcc (max(npar,15));
+    rho = bcc_atom_sites (d_upper_bound);
 end
 
-% Contributions to dispersion
-if JS_p5p5p5~=0
-    w = w + (8*JS_p5p5p5)*(1-cos1h.*cos1k.*cos1l);
+% Accumulate spin wave energies
+w = gap*ones(size(qh));
+for i = 1:npar
+    if JS(i)~=0
+        w = w + JS(i) * fdisp(qh, qk, ql, rho(i,:));
+    end
 end
 
-if JS_100~=0
-    w = w + (4*JS_100)*(sin(pi*qh).^2 + sin(pi*qk).^2 + sin(pi*ql).^2);
-end
-
-if JS_110~=0
-    w = w + (4*JS_110)*(3 - cos2h.*cos2k - cos2k.*cos2l - cos2l.*cos2h);
-end
-
-if JS_3p5p5p5~=0
-    cos3h = cos((3*pi)*qh);
-    cos3k = cos((3*pi)*qk);
-    cos3l = cos((3*pi)*ql);
-    w = w + (8*JS_3p5p5p5)*(3 - cos3h.*cos1k.*cos1l - cos3k.*cos1l.*cos1h...
-        - cos3l.*cos1h.*cos1k);
-end
-
-if JS_111~=0
-    w = w + (8*JS_111)*(1-cos2h.*cos2k.*cos2l);
-end
-
+% Set output arguments
 wdisp{1} = w;
 sf{1} = (Seff/2)*ones(size(w));
+
+
+%-------------------------------------------------------------------------------
+function d_upper_bound = d_upper_bound_bcc (N)
+% Return an upper bound for the distance of the Nth neighbour interaction for
+% a body-centred cubic lattice, expressed in units of the cube side.
+%
+% The upper bound returned is:
+%       d_upper_bound = (18*N/pi)^(1/3)         ....(1)
+%
+% Explanation:
+% - Volume of a sphere radius d (in uits of cube side) is: V = (4/3)*pi*(d^3)
+% - Volume of a cube: 1
+% - Each cube contains 2 sites so the estimated number of sites in the sphere
+%   is: 
+%       N(estimated) = 2*V = (8/3)*pi*(d^3)     ....(2)
+%
+%     Note: this can be an underestimate or overestimate, due to whether or
+%     not sites are included in cubes that are intersected by by the sphere
+%     surface. As d gets larger, the relative error gets smaller.
+%
+% - For the general atomic site (x,y,z) (x~=y~=z~=x) there are 48 symmetry
+%   equivalent sites. The number of *distinct* nearest neighbours can be
+%   estimated as (1/48) of the estimated number of sites above i.e.
+%
+%       N(distinct,estimated) = (1/18)*pi*d^3   ....(3)
+%
+%     In fact, there are many atomic sites with fewer than 48 symmetry related 
+%     positions: [x,x,0], [x,x,x], [x,y,0], [x,x,z], with respectively 6, 12, 8,
+%     24, 24 equivalent positions. Consequently, estimating the number of
+%     distinct sites by dividing by 48 results in an *underestimate* of the true
+%     number of distinct sites, N.
+%     It turns out that this underestimate always more than compensates
+%     for the error of the number sites enclosed within the sphere, equation (2)
+%     (see numerical results below). Therefore equation (3) becomes:
+%   
+%       N > (1/18)*pi*d^3   ==>  d < (18*N/pi)^(1/3)
+%
+%     and therefore equation (1) gives an upper bound for d.
+%
+% Numerical results:
+% ------------------
+% - min (d_upper_bound - d) = 0.9234  
+%   (for the first neighbour:  d_upper_bound = 1.7894, d = sqrt(3)/2 = 0.8660)
+%
+% - max (d_upper_bound - d) = 1.4828
+%   (for the 52nd neighbour: d_upper_bound = 6.6790, d = 5.1962)
+%
+% The above has been numerically tested out to the 1426481st neighbour, which
+% has d = 200. Numerically it is seen that (d_upper_bound - d) 
+% asymptotically approaches 1.434, with the fluctuations around this value
+% getting ever smaller. This is expected as the number of cubes intersecting the
+% sphere surface gets smaller as a proportion of the total number of cubes 
+% inside the volume of the sphere.
+
+d_upper_bound = (18*N/pi)^(1/3);
+
+
+%-------------------------------------------------------------------------------
+function [rho, dist] = bcc_atom_sites (rmax)
+% Get distances to neighbouring atoms for the bcc lattice in a sphere of radius rmax.
+% Recall bcc lattice has side length a, with sites at (0,0,0) and (0.5,0.5,0.5)
+%
+% Input
+% -----
+%   rmax    Maximum distance from origin in units of the cube side length
+%
+% Output:
+% -------
+%   rho     Array of unique sites size [npar,3], where npar is the number of
+%           unique sites within or on the surface of the sphere radius rmax).
+%           For example, if rmax = 2, rho is returned as:
+%                   [0.5, 0.5, 0.5; ...   % nearest neighbour
+%                    1,   0,   0;   ...   % 2nd neighbour
+%                    1,   1,   0;   ...   % 3rd neighbour
+%                    1.5, 0.5, 0.5; ...   % 4th neighbour
+%                    1,   1,   1;   ...   % 5th neighbour
+%                    2,   0,   0]         % 6th neighbour
+%
+%           The sites are sorted in order of increasing distance from the
+%           origin, and for the ith site has rho(i,1) >= rho(i,2) >=rho(i,3).
+%           If two or more inequivalent sites have the same distance from the
+%           origin, then the those sites are ordered by decreasing rho(:,1), and
+%           if the rho(:,1) are the same, by decreasing rho(:,2).
+%
+%   dist    Column vector of distances from the origin, length npar, where npar
+%           is the number of unique sites within or on the surface of the sphere
+%           radius rmax).
+
+small = 1e-10;
+
+R = ceil(rmax);     % round to closest larger integer
+
+% Fill an array with the cube corners within or on the surface of an irreducible
+% repeat volume of the cubic lattice. The repeat volume chosen here is the 3D
+% wedge defined by rmax >= x >= y >= z.
+% The number of points for each value of x is:
+%   x = 0   npnt = 1
+%   x = 1   npnt = 3    (2 + 1)
+%   x = 2   npnt = 6    (3 + 2 + 1)
+%   x = 3   npnt = 10   (4 + 3 + 2 + 1)
+%       :
+%   x = R   npnt = (R+1)*(R+2)/2    ((R+1) + R + (R-1) + ... 2 + 1)
+
+N_vertices = ((R+1)*(R+2)*(R+3))/6;     % total number of vertices out to R
+x = zeros(N_vertices,1);
+y = zeros(N_vertices,1);
+z = zeros(N_vertices,1);
+
+% Loop over x,y,z, filling site positions as multiples of 1/2 (this will allow
+% the body centres to be appended later on as being at integer coordinates, thus
+% avoiding any rounding errors).
+i = 0;
+for ix = 0:2:2*R
+    for iy = 0:2:ix
+        for iz = 0:2:iy
+            i = i + 1;
+            x(i) = ix;
+            y(i) = iy;
+            z(i) = iz;
+        end
+    end
+end
+
+% Now append the positions of cube centres (i.e. the body centred sites).
+% The positions are the same as the cube corners, except shifted by
+% [1/2, 1/2, 1/2]. That is, in our unit of measure being units of 0.5, shifted
+% by [1,1,1].
+% The number of points for each value of x is 
+%   x = 1/2     npnt = 1
+%   x = 3/2     npnt = 3    (2 + 1)
+%   x = 5/2     npnt = 6    (3 + 2 + 1)
+%   x = 7/2     npnt = 10   (4 + 3 + 2 + 1)
+%       :
+%   x = R-1/2   npnt = R*(R+1)/2  (R + (R-1) + (r-2) + ... + 2 +1)
+
+N_centres = (R*(R+1)*(R+2))/6;      % total number of cube centres out to R
+x = [x; x(1:N_centres) + 1];
+y = [y; y(1:N_centres) + 1];
+z = [z; z(1:N_centres) + 1];
+
+% Distances from origin
+dsqr = x.^2 + y.^2 + z.^2;
+
+% Get sites within or on the surface of a sphere radius rmax (exluding origin)
+% - Exclude the site at the origin i.e. dsqr==0
+% - Add a tiny tolerance in case rmax is not an integer
+ok = (dsqr>0) & dsqr<=4*(rmax^2 + small);   % the 4 arises as x,y,z in multiples of 0.5
+dsqr = dsqr(ok);
+x = x(ok);
+y = y(ok);
+z = z(ok);
+
+% Sort into order of increasing distance from the origin, ensuring that x>y>z
+% in the case when there are inequivalent sites at the same distance from the
+% origin.
+dsqr_rho = sortrows([dsqr, x, y, z],{'ascend','descend','descend','descend'});
+
+rho = dsqr_rho(:,2:4)/2;        % divide by 2 to get in units of cube side
+dist = sqrt(dsqr_rho(:,1))/2;   % ditto
+
+
+%-------------------------------------------------------------------------------
+function w = fdisp (qh, qk, ql, r)
+% Return the contribution from symmetry equivalent sites to cubic Heisenberg ferromagnet.
+% In more detail: returns
+%
+%       w = M - Sum({r"}, exp(2*pi*i*(hx"+ky"+lz")) )
+%
+%   where M   is the number of atomic sites symmetry equivalent to r = [x,y,z]
+%        {r"} is the set of position vectors of those symmetry equivalent sites
+%       h,k,l give a point in the cubic reciprocal point q = ha* + kb* + lc*
+%
+%   e.g. if r = [1,0,0], then 
+%         M = 6
+%        {r"} = {[1,0,0], [0,1,0], [0,-1,0], [0,0,1], [0,0,-1]}
+%
+% There are six different cases of site symmetry
+%   [x 0 0]     M = 6
+%   [x x 0]     M = 12
+%   [x x x]     M = 8
+%   [x y 0]     M = 24
+%   [x x z]     M = 24
+%   [x y z]     M = 48
+%
+% where x>0, y>0, y>0 and x~=y, y~=z, z~=x
+%
+%
+% Input:
+% ------
+%   qh, qk, ql  Arrays giving h,k,l for a set of wavevectors in reciprocal space
+%               of the conventional cubic lattice for simple cubic (sc), bcc or
+%               fcc crystals. The arrays all must have the same size.
+%   r           Vector of an atomic position [x,y,z]
+%
+% Output:
+% -------
+%   w           M - Sum({r"}, exp(2*pi*i*(hx"+ky"+lz")) ) defined above
+
+
+isNonZero = (r~=0);
+numNonZero = sum(isNonZero);
+ind = find(isNonZero);
+if numNonZero == 1
+    w = f_x00 (qh, qk, ql, r(ind(1)));
+elseif numNonZero == 2
+    if r(ind(1)) == r(ind(2))
+        w = f_xx0 (qh, qk, ql, r(ind(1)));
+    else
+        w = f_xy0 (qh, qk, ql, r(ind(1)), r(ind(2)));
+    end
+elseif numNonZero == 3
+    if r(ind(1)) == r(ind(2)) && r(ind(2)) == r(ind(3)) % all are the same
+        w = f_xxx (qh, qk, ql, r(ind(1)));
+    elseif r(ind(1)) ~= r(ind(2)) && r(ind(2)) ~= r(ind(3)) ...
+            && r(ind(3)) ~= r(ind(1))                   % all are different
+        w = f_xyz (qh, qk, ql, r(ind(1)), r(ind(2)), r(ind(3)));
+    else    % two are the same, one is different
+        if r(ind(1)) == r(ind(2))       % x==y~=z
+            w = f_xxy (qh, qk, ql, r(ind(2)), r(ind(3)));
+        elseif r(ind(2)) == r(ind(3))   % x~=y==z
+            w = f_xxy (qh, qk, ql, r(ind(3)), r(ind(1)));
+        elseif r(ind(3)) == r(ind(1))   % y~=z==x
+            w = f_xxy (qh, qk, ql, r(ind(1)), r(ind(2)));
+        end
+    end
+end
+
+%-------------------------------------------------------------------------------
+function w = f_x00 (qh, qk, ql, x)
+% Contribution from interactions along [x,0,0] in real space
+% Accounts for the 6-fold degeneracy of symmetry equivalent sites
+w = 4 * (sin((pi*x)*qh).^2 + sin((pi*x)*qk).^2 + sin((pi*x)*ql).^2);
+
+%-------------------------------------------------------------------------------
+function w = f_xx0 (qh, qk, ql, x)
+% Contribution from interactions along [x,x,0] in real space
+% Accounts for the 12-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+w = 4 * (3 - cos_xh.*cos_xk - cos_xk.*cos_xl - cos_xl.*cos_xh);
+
+%-------------------------------------------------------------------------------
+function w = f_xxx (qh, qk, ql, x)
+% Contribution from interactions along [x,x,x] in real space
+% Accounts for the 8-fold degeneracy of symmetry equivalent sites
+w = 8 * (1 - cos((2*pi*x)*qh).*cos((2*pi*x)*qk).*cos((2*pi*x)*ql));
+
+%-------------------------------------------------------------------------------
+function w = f_xy0 (qh, qk, ql, x, y)
+% Contribution from interactions along [x,y,0] (x~=y) in real space
+% Accounts for the 24-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+cos_yh = cos((2*pi*y)*qh);
+cos_yk = cos((2*pi*y)*qk);
+cos_yl = cos((2*pi*y)*ql);
+w = 4 * (6 ...
+    - cos_xh.*cos_yk - cos_yh.*cos_xk...
+    - cos_xk.*cos_yl - cos_yk.*cos_xl...
+    - cos_xl.*cos_yh - cos_yl.*cos_xh);
+
+%-------------------------------------------------------------------------------
+function w = f_xxy (qh, qk, ql, x, y)
+% Contribution from interactions along [x,x,y] (x~=y) in real space
+% Accounts for the 24-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+w = 8 * (3 ...
+    - cos_xh.*cos_xk.*cos((2*pi*y)*ql)...
+    - cos_xk.*cos_xl.*cos((2*pi*y)*qh)...
+    - cos_xl.*cos_xh.*cos((2*pi*y)*qk));
+
+%-------------------------------------------------------------------------------
+function w = f_xyz (qh, qk, ql, x, y, z)
+% Contribution from interactions along [x,y,z] (x,y,z all different) in real space
+% Accounts for the 48-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+cos_yh = cos((2*pi*y)*qh);
+cos_yk = cos((2*pi*y)*qk);
+cos_yl = cos((2*pi*y)*ql);
+cos_zh = cos((2*pi*z)*qh);
+cos_zk = cos((2*pi*z)*qk);
+cos_zl = cos((2*pi*z)*ql);
+w = 8 * (6 ...
+    - cos_xh.*cos_yk.*cos_zl...
+    - cos_yh.*cos_zk.*cos_xl...
+    - cos_zh.*cos_xk.*cos_yl...
+    - cos_xh.*cos_zk.*cos_yl...
+    - cos_yh.*cos_xk.*cos_zl...
+    - cos_zh.*cos_yk.*cos_xl);

--- a/horace_core/sqw_models/disp_fcc_hfm.m
+++ b/horace_core/sqw_models/disp_fcc_hfm.m
@@ -1,67 +1,429 @@
-function [wdisp,sf] = disp_fcc_hfm(qh,qk,ql,par)
-% Spin wave dispersion relation for face centred cubic Heisenberg ferromagnet
+function [wdisp, sf] = disp_fcc_hfm(qh, qk, ql, par)
+% Spin wave dispersion relation for the face centred cubic Heisenberg ferromagnet
 %
-%   >> [wdisp,sf] = disp_fccc_hfm (qh qk, ql, par)
+%   >> [wdisp, sf] = disp_fcc_hfm (qh qk, ql, par)
+%
+% The dispersion is for the following Hamiltonian:
+%           H = -(1/2)Sum(J(i,j) S(i).S(j))
+%
+% so that positive J favours ferromagnetism and each pair of spins appears only
+% once. In addition, a single ion anisotropy is included that opens a gap at the
+% magnetic zone centre.
+%
+% The algorithm works for intersite interactions out to arbitrarily great
+% distance, as determined by the length of the vector containing the interaction
+% parameters, input argument par, below.
+%
+% [Reference: 
+% For a derivation of the linear spin wave theory dispersion relation and 
+% spectral weight see e.g. 
+%   "Principles of Neutron Scattering from Condensed Matter"
+%   Author: A.T. Boothroyd (Oxford University press, 2020)
+% The general expression for the spin wave energies for a Heisenberg ferromagnet
+% is given in Eq. 8.56 (page 273). Note the opposite sign convention for the
+% exchange constants J]
 %
 % Input:
 % ------
-%   qh,qk,ql    Arrays of h,k,l
-%   par         Parameters [Seff, gap, JS_p5p50, JS_100, JS_1p5p5, JS_110]
-%                   Seff        Intensity scale factor
-%                   gap         Gap at zone centre
-%                   JS_p5p50    First neighbour exchange constant
-%                   JS_100      Second neighbour exchange constant
-%                   JS_1p5p5    Third neighbour exchange constant
-%                   JS_110      Fourth neighbour exchange constant
+%   qh,qk,ql    Arrays of h,k,l at which to compute the spin wave energies and
+%               spectral weights
 %
-%              Note: each pair of spins in the Hamiltonian appears only once
+%   par         Parameters [Seff, gap, JS1, JS2, JS3, JS4,...]:
+%                 Seff          Intensity scale factor as an effective local
+%                              moment spin with value Seff on each atomic site
+%                 gap           Gap at zone centre
+%                 JS1, JS2,...  First, second etc. neighbour exchange constants.
+%                               The exchange constants JS1, JS2,... are each the
+%                              product of J and Seff for the first neighbour, 
+%                              second, third neighbour etc.
+%
+%               The length of the parameters vector determines the range of the
+%              interactions. The vector can have have an unlimited number of
+%              interaction parameters. 
+%
+%               EXAMPLE
+%               If input argument par has length five, that is, par is:
+%                 [Seff, gap, JS1, JS2, JS3]
+%               then it is assumed that all interactions beyond the 3rd
+%              neighbour are zero.
+%
+%               The first 15 neighbours are 
+%                   JS1         JS to [0.5, 0.5, 0]     (nearest neighbour)
+%                   JS2         JS to [1, 0, 0]         (2nd neighbour)
+%                   JS3         JS to [1, 0.5, 0.5]     (3rd neighbour)
+%                   JS4         JS to [1, 1, 0]         (4th neighbour)
+%                   JS5         JS to [1.5, 0.5, 0]     (5th neighbour)
+%                   JS6         JS to [1, 1, 1]         (6th neighbour)
+%                   JS7         JS to [1.5, 1, 0.5]     (7th neighbour)
+%                   JS8         JS to [2, 0, 0]         (8th neighbour)
+%                   JS9         JS to [2, 0.5, 0.5]     (equal 9th neighbour)
+%                   JS10        JS to [1.5, 1.5, 0]     (equal 9th neighbour)
+%                   JS11        JS to [2, 1, 0]         (11th neighbour)
+%                   JS12        JS to [1.5, 1.5, 1]     (12th neighbour)
+%                   JS13        JS to [2, 1, 1]         (13th neighbour)
+%                   JS14        JS to [2.5, 0.5, 0]     (equal 14th neighbour)
+%                   JS15        JS to [2, 1.5, 0.5]     (equal 14th neighbour)
+%
+%               Note that if there are inequivalent sites at the same distance
+%               then the order is always decreasing x, followed by decreasing y.
+%
 % Output:
 % -------
-%   wdisp       Array of energies for the dispersion
-%   sf          Array of spectral weights
+%   wdisp       Cell array containing a single array with the spin wave energies
+%              at the array of points defined by qh, qk, ql
+%
+%   sf          Cell array containing a single array with the corresponding
+%              spectral weights, Seff/2 (i.e. par(1)/2)
 
-Seff=par(1);
-gap=par(2);
-JS_p5p50=par(3);
-JS_100=par(4);
-JS_1p5p5=par(5);
-JS_110=par(6);
 
-w=gap*ones(size(qh));
+persistent rho
 
-% Precompute some arrays used in more than one exchange pathway
-if JS_p5p50~=0 || JS_1p5p5
-    cos1h = cos(pi*qh);
-    cos1k = cos(pi*qk);
-    cos1l = cos(pi*ql);
+Seff = par(1);
+gap = par(2);
+JS = par(3:end);
+npar = numel(JS);
+
+if npar > size(rho,1)
+    % Populate rho with the positions of unique nearest neighbour locations in
+    % order of increasing separation. initialise with at least the first 15
+    % distinct nearest neighbours
+    rmax = d_upper_bound_fcc (max(npar,15));
+    rho = fcc_atom_sites (rmax);
 end
 
-if JS_1p5p5~=0 || JS_110~=0
-    cos2h = cos((2*pi)*qh);
-    cos2k = cos((2*pi)*qk);
-    cos2l = cos((2*pi)*ql);
+% Accumulate spin wave energies
+w = gap*ones(size(qh));
+for i = 1:npar
+    if JS(i)~=0
+        w = w + JS(i) * fdisp(qh, qk, ql, rho(i,:));
+    end
 end
 
-% 1st nn
-if JS_p5p50~=0
-    w = w + (4*JS_p5p50)*(3 - cos1h.*cos1k - cos1k.*cos1l - cos1l.*cos1h);
-end
-
-% 2nd nn
-if JS_100~=0
-    w = w + (4*JS_100)*(sin(pi*qh).^2 + sin(pi*qk).^2 + sin(pi*ql).^2);
-end
-
-% 3rd nn
-if JS_1p5p5~=0
-    w = w + (8*JS_1p5p5)*(3 - cos2h.*cos1k.*cos1l - cos2k.*cos1l.*cos1h...
-        - cos2l.*cos1h.*cos1k);
-end
-
-% 4th nn
-if JS_110~=0
-    w = w + (4*JS_110)*(3 - cos2h.*cos2k - cos2k.*cos2l - cos2l.*cos2h);
-end
-
+% Set output arguments
 wdisp{1} = w;
 sf{1} = (Seff/2)*ones(size(w));
+
+
+%-------------------------------------------------------------------------------
+function d_upper_bound = d_upper_bound_fcc (N)
+% Return an upper bound for the distance of the Nth neighbour interaction for
+% a face-centred cubic lattice, expressed in units of the cube side.
+%
+% The upper bound returned is:
+%       d_upper_bound = (9*N/pi)^(1/3)         ....(1)
+%
+% Explanation:
+% - Volume of a sphere radius d (in uits of cube side) is: V = (4/3)*pi*(d^3)
+% - Volume of a cube: 1
+% - Each cube contains 4 sites so the estimated number of sites in the sphere
+%   is: 
+%       N(estimated) = 4*V = (16/3)*pi*(d^3)     ....(2)
+%
+%     Note: this can be an underestimate or overestimate, due to whether or
+%     not sites are included in cubes that are intersected by by the sphere
+%     surface. As d gets larger, the relative error gets smaller.
+%
+% - For the general atomic site (x,y,z) (x~=y~=z~=x) there are 48 symmetry
+%   equivalent sites. The number of *distinct* nearest neighbours can be
+%   estimated as (1/48) of the estimated number of sites above i.e.
+%
+%       N(distinct,estimated) = (1/9)*pi*d^3   ....(3)
+%
+%     In fact, there are many atomic sites with fewer than 48 symmetry related 
+%     positions: [x,x,0], [x,x,x], [x,y,0], [x,x,z], with respectively 6, 12, 8,
+%     24, 24 equivalent positions. Consequently, estimating the number of
+%     distinct sites by dividing by 48 results in an *underestimate* of the true
+%     number of distinct sites, N.
+%     It turns out that this underestimate always more than compensates
+%     for the error of the number sites enclosed within the sphere, equation (2)
+%     (see numerical results below). Therefore equation (3) becomes:
+%   
+%       N > (1/9)*pi*d^3   ==>  d < (9*N/pi)^(1/3)
+%
+%     and therefore equation (1) gives an upper bound for d.
+%
+% Numerical results:
+% ------------------
+% - min (d_upper_bound - d) = 0.7131  
+%   (for the first neighbour:  d_upper_bound = 1.4202, d = sqrt(2)/2 = 0.7071)
+%
+% - max (d_upper_bound - d) = 0.9715
+%   (for the 35th neighbour: d_upper_bound = 4.6457, d = 3.6742)
+%
+% The above has been numerically tested out to the 2830600th neighbour, which
+% has d = 200. Numerically it is seen that (d_upper_bound - d) 
+% asymptotically approaches 0.9056, with the fluctuations around this value
+% getting ever smaller. This is expected as the number of cubes intersecting the
+% sphere surface gets smaller as a proportion of the total number of cubes 
+% inside the volume of the sphere.
+
+d_upper_bound = (9*N/pi)^(1/3);
+
+
+%-------------------------------------------------------------------------------
+function [rho, dist] = fcc_atom_sites (rmax)
+% Get distances to neighbouring atoms for the fcc lattice in a sphere of radius rmax.
+% Recall fcc lattice has side length a, with sites at (0,0,0), (0.5,0.5,0),
+% (0,0.5,0.5) (0.5,0,0.5).
+%
+% Input
+% -----
+%   rmax    Maximum distance from origin in units of the cube side length
+%
+% Output:
+% -------
+%   rho     Array of unique sites size [npar,3], where npar is the number of
+%           unique sites within or on the surface of the sphere radius rmax).
+%           For example, if rmax = 2, rho is returned as:
+%                   [0.5, 0.5, 0;   ...   % nearest neighbour
+%                    1,   0,   0;   ...   % 2nd neighbour
+%                    1,   0.5, 0.5; ...   % 3rd neighbour
+%                    1,   1,   0;   ...   % 4th neighbour
+%                    1.5, 0.5, 0;   ...   % 5th neighbour
+%                    1,   1,   1;   ...   % 6th neighbour
+%                    1.5, 1,   0.5; ...   % 7th neighbour
+%                    2,   0,   0]         % 8th neighbour
+%
+%           The sites are sorted in order of increasing distance from the
+%           origin, and for the ith site has rho(i,1) >= rho(i,2) >=rho(i,3).
+%           If two or more inequivalent sites have the same distance from the
+%           origin, then the those sites are ordered by decreasing rho(:,1), and
+%           if the rho(:,1) are the same, by decreasing rho(:,2).
+%
+%   dist    Column vector of distances from the origin, length npar, where npar
+%           is the number of unique sites within or on the surface of the sphere
+%           radius rmax).
+
+small = 1e-10;
+
+R = ceil(rmax);     % round to closest larger integer
+
+% Fill an array with the cube corners within or on the surface of an irreducible
+% repeat volume of the cubic lattice. The repeat volume chosen here is the 3D
+% wedge defined by rmax >= x >= y >= z.
+% The number of points for each value of x is 
+%   x = 0   npnt = 1
+%   x = 1   npnt = 3    (2 + 1)
+%   x = 2   npnt = 6    (3 + 2 + 1)
+%   x = 3   npnt = 10   (4 + 3 + 2 + 1)
+%       :
+%   x = R   npnt = (R+1)*(R+2)/2    ((R+1) + R + (R-1) + ... 2 + 1)
+
+N_vertices = ((R+1)*(R+2)*(R+3))/6;     % total number of vertices out to R
+x = zeros(N_vertices,1);
+y = zeros(N_vertices,1);
+z = zeros(N_vertices,1);
+
+% Loop over x,y,z, filling site positions as multiples of 1/2 (this will allow
+% the face centres to be appended later on as being at integer coordinates, thus
+% avoiding any rounding errors).
+i = 0;
+for ix = 0:2:2*R
+    for iy = 0:2:ix
+        for iz = 0:2:iy
+            i = i + 1;
+            x(i) = ix;
+            y(i) = iy;
+            z(i) = iz;
+        end
+    end
+end
+
+% Now append the positions of cube face centres (i.e. the face centred sites).
+% The positions are the same as the cube corners, except shifted by
+% (i) [1/2, 1/2, 0], (ii) [1, 1/2, 1/2], and (iii) [3/2, 1, 1/2] for the three
+% orientations of the faces. That is, in our unit of measure being units of 0.5,
+% shifted by [1,1,0], [2,1,1] and [3,2,1].
+% The number of points for each value of x is:
+%
+% Shift by [1/2, 1/2, 0]:
+%   x = 1/2     npnt = 1
+%   x = 3/2     npnt = 3    (2 + 1)
+%   x = 5/2     npnt = 6    (3 + 2 + 1)
+%       :
+%   x = R-1/2   npnt = R*(R+1)/2  (R + (R-1) + (R-2) + ... + 2 + 1)
+%
+%   npnt_tot = R*(R+1)*(R+2)/6
+%
+%
+% Shift by [1, 1/2, 1/2,]:
+%   x = 1       npnt = 1
+%   x = 3       npnt = 3    (2 + 1)
+%   x = 5       npnt = 6    (3 + 2 + 1)
+%       :
+%   x = R       npnt = R*(R+1)/2  (R + (R-1) + (R-2) + ... + 2 + 1)
+%
+%   npnt_tot = R*(R+1)*(R+2)/6
+%
+%
+% Shift by [3/2, 1, 1/2]:
+%   x = 3/2     npnt = 1
+%   x = 5/2     npnt = 3    (2 + 1)
+%   x = 7/2     npnt = 6    (3 + 2 + 1)
+%       :
+%   x = R-1/2   npnt = R*(R-1)/2  ((R-1) + (R-2) + (R-3) + ... + 2 + 1)
+%
+%   npnt_tot = R*(R-1)*(R+1)/6
+
+N_1by2_1by2_0 = R*(R+1)*(R+2)/6;
+N_1_1by2_1by2 = R*(R+1)*(R+2)/6;
+N_3by2_1_1by2 = R*(R-1)*(R+1)/6;
+x = [x; x(1:N_1by2_1by2_0) + 1; x(1:N_1_1by2_1by2) + 2; x(1:N_3by2_1_1by2) + 3];
+y = [y; y(1:N_1by2_1by2_0) + 1; y(1:N_1_1by2_1by2) + 1; y(1:N_3by2_1_1by2) + 2];
+z = [z; z(1:N_1by2_1by2_0);     z(1:N_1_1by2_1by2) + 1; z(1:N_3by2_1_1by2) + 1];
+
+% Distances from origin
+dsqr = x.^2 + y.^2 + z.^2;
+
+% Get sites within or on the surface of a sphere radius rmax (exluding origin)
+% - Exclude the site at the origin i.e. dsqr==0
+% - Add a tiny tolerance in case rmax is not an integer
+ok = (dsqr>0) & dsqr<=4*(rmax^2 + small);   % the 4 arises as x,y,z in multiples of 0.5
+dsqr = dsqr(ok);
+x = x(ok);
+y = y(ok);
+z = z(ok);
+
+% Sort into order of increasing distance from the origin, ensuring that x>y>z
+% in the case when there are inequivalent sites at the same distance from the
+% origin.
+dsqr_rho = sortrows([dsqr, x, y, z],{'ascend','descend','descend','descend'});
+
+rho = dsqr_rho(:,2:4)/2;        % divide by 2 to get in units of cube side
+dist = sqrt(dsqr_rho(:,1))/2;   % ditto
+
+
+%-------------------------------------------------------------------------------
+function w = fdisp (qh, qk, ql, r)
+% Return the contribution from symmetry equivalent sites to cubic Heisenberg ferromagnet.
+% In more detail: returns
+%
+%       w = M - Sum({r"}, exp(2*pi*i*(hx"+ky"+lz")) )
+%
+%   where M   is the number of atomic sites symmetry equivalent to r = [x,y,z]
+%        {r"} is the set of position vectors of those symmetry equivalent sites
+%       h,k,l give a point in the cubic reciprocal point q = ha* + kb* + lc*
+%
+%   e.g. if r = [1,0,0], then 
+%         M = 6
+%        {r"} = {[1,0,0], [0,1,0], [0,-1,0], [0,0,1], [0,0,-1]}
+%
+% There are six different cases of site symmetry
+%   [x 0 0]     M = 6
+%   [x x 0]     M = 12
+%   [x x x]     M = 8
+%   [x y 0]     M = 24
+%   [x x z]     M = 24
+%   [x y z]     M = 48
+%
+% where x>0, y>0, y>0 and x~=y, y~=z, z~=x
+%
+%
+% Input:
+% ------
+%   qh, qk, ql  Arrays giving h,k,l for a set of wavevectors in reciprocal space
+%               of the conventional cubic lattice for simple cubic (sc), bcc or
+%               fcc crystals. The arrays all must have the same size.
+%   r           Vector of an atomic position [x,y,z]
+%
+% Output:
+% -------
+%   w           M - Sum({r"}, exp(2*pi*i*(hx"+ky"+lz")) ) defined above
+
+
+isNonZero = (r~=0);
+numNonZero = sum(isNonZero);
+ind = find(isNonZero);
+if numNonZero == 1
+    w = f_x00 (qh, qk, ql, r(ind(1)));
+elseif numNonZero == 2
+    if r(ind(1)) == r(ind(2))
+        w = f_xx0 (qh, qk, ql, r(ind(1)));
+    else
+        w = f_xy0 (qh, qk, ql, r(ind(1)), r(ind(2)));
+    end
+elseif numNonZero == 3
+    if r(ind(1)) == r(ind(2)) && r(ind(2)) == r(ind(3)) % all are the same
+        w = f_xxx (qh, qk, ql, r(ind(1)));
+    elseif r(ind(1)) ~= r(ind(2)) && r(ind(2)) ~= r(ind(3)) ...
+            && r(ind(3)) ~= r(ind(1))                   % all are different
+        w = f_xyz (qh, qk, ql, r(ind(1)), r(ind(2)), r(ind(3)));
+    else    % two are the same, one is different
+        if r(ind(1)) == r(ind(2))       % x==y~=z
+            w = f_xxy (qh, qk, ql, r(ind(2)), r(ind(3)));
+        elseif r(ind(2)) == r(ind(3))   % x~=y==z
+            w = f_xxy (qh, qk, ql, r(ind(3)), r(ind(1)));
+        elseif r(ind(3)) == r(ind(1))   % y~=z==x
+            w = f_xxy (qh, qk, ql, r(ind(1)), r(ind(2)));
+        end
+    end
+end
+
+%-------------------------------------------------------------------------------
+function w = f_x00 (qh, qk, ql, x)
+% Contribution from interactions along [x,0,0] in real space
+% Accounts for the 6-fold degeneracy of symmetry equivalent sites
+w = 4 * (sin((pi*x)*qh).^2 + sin((pi*x)*qk).^2 + sin((pi*x)*ql).^2);
+
+%-------------------------------------------------------------------------------
+function w = f_xx0 (qh, qk, ql, x)
+% Contribution from interactions along [x,x,0] in real space
+% Accounts for the 12-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+w = 4 * (3 - cos_xh.*cos_xk - cos_xk.*cos_xl - cos_xl.*cos_xh);
+
+%-------------------------------------------------------------------------------
+function w = f_xxx (qh, qk, ql, x)
+% Contribution from interactions along [x,x,x] in real space
+% Accounts for the 8-fold degeneracy of symmetry equivalent sites
+w = 8 * (1 - cos((2*pi*x)*qh).*cos((2*pi*x)*qk).*cos((2*pi*x)*ql));
+
+%-------------------------------------------------------------------------------
+function w = f_xy0 (qh, qk, ql, x, y)
+% Contribution from interactions along [x,y,0] (x~=y) in real space
+% Accounts for the 24-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+cos_yh = cos((2*pi*y)*qh);
+cos_yk = cos((2*pi*y)*qk);
+cos_yl = cos((2*pi*y)*ql);
+w = 4 * (6 ...
+    - cos_xh.*cos_yk - cos_yh.*cos_xk...
+    - cos_xk.*cos_yl - cos_yk.*cos_xl...
+    - cos_xl.*cos_yh - cos_yl.*cos_xh);
+
+%-------------------------------------------------------------------------------
+function w = f_xxy (qh, qk, ql, x, y)
+% Contribution from interactions along [x,x,y] (x~=y) in real space
+% Accounts for the 24-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+w = 8 * (3 ...
+    - cos_xh.*cos_xk.*cos((2*pi*y)*ql)...
+    - cos_xk.*cos_xl.*cos((2*pi*y)*qh)...
+    - cos_xl.*cos_xh.*cos((2*pi*y)*qk));
+
+%-------------------------------------------------------------------------------
+function w = f_xyz (qh, qk, ql, x, y, z)
+% Contribution from interactions along [x,y,z] (x,y,z all different) in real space
+% Accounts for the 48-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+cos_yh = cos((2*pi*y)*qh);
+cos_yk = cos((2*pi*y)*qk);
+cos_yl = cos((2*pi*y)*ql);
+cos_zh = cos((2*pi*z)*qh);
+cos_zk = cos((2*pi*z)*qk);
+cos_zl = cos((2*pi*z)*ql);
+w = 8 * (6 ...
+    - cos_xh.*cos_yk.*cos_zl...
+    - cos_yh.*cos_zk.*cos_xl...
+    - cos_zh.*cos_xk.*cos_yl...
+    - cos_xh.*cos_zk.*cos_yl...
+    - cos_yh.*cos_xk.*cos_zl...
+    - cos_zh.*cos_yk.*cos_xl);

--- a/horace_core/sqw_models/disp_sc_hfm.m
+++ b/horace_core/sqw_models/disp_sc_hfm.m
@@ -1,57 +1,376 @@
-function [wdisp,sf] = disp_sc_hfm(qh,qk,ql,par)
-% Spin wave dispersion relation for simple cubic Heisenberg ferromagnet
+function [wdisp, sf] = disp_sc_hfm(qh, qk, ql, par)
+% Spin wave dispersion relation for the simple cubic Heisenberg ferromagnet
 %
-%   >> [wdisp,sf] = disp_sc_hfm (qh qk, ql, par)
+%   >> [wdisp, sf] = disp_sc_hfm (qh qk, ql, par)
+%
+% The dispersion is for the following Hamiltonian:
+%           H = -(1/2)Sum(J(i,j) S(i).S(j))
+%
+% so that positive J favours ferromagnetism and each pair of spins appears only
+% once. In addition, a single ion anisotropy is included that opens a gap at the
+% magnetic zone centre.
+%
+% The algorithm works for intersite interactions out to arbitrarily great
+% distance, as determined by the length of the vector containing the interaction
+% parameters, input argument par, below.
+%
+% [Reference: 
+% For a derivation of the linear spin wave theory dispersion relation and 
+% spectral weight see e.g. 
+%   "Principles of Neutron Scattering from Condensed Matter"
+%   Author: A.T. Boothroyd (Oxford University press, 2020)
+% The general expression for the spin wave energies for a Heisenberg ferromagnet
+% is given in Eq. 8.56 (page 273). Note the opposite sign convention for the
+% exchange constants J]
 %
 % Input:
 % ------
-%   qh,qk,ql    Arrays of h,k,l
-%   par         Parameters [Seff, gap, JS_100, JS_110, JS_111, JS_200]
-%                   Seff    Intensity scale factor
-%                   gap     Gap at zone centre
-%                   JS_100  First neighbour exchange constant
-%                           (If dispersion maximum 12*JS_100)
-%                   JS_110  Second neighbour exchange constant
-%                   JS_111  Third neighbour exchange constant
-%                   JS_200  Fourth neighbour exchange constant
+%   qh,qk,ql    Arrays of h,k,l at which to compute the spin wave energies and
+%               spectral weights
 %
-%              Note: each pair of spins in the Hamiltonian appears only once
+%   par         Parameters [Seff, gap, JS1, JS2, JS3, JS4,...]:
+%                 Seff          Intensity scale factor as an effective local
+%                              moment spin with value Seff on each atomic site
+%                 gap           Gap at zone centre
+%                 JS1, JS2,...  First, second etc. neighbour exchange constants.
+%                               The exchange constants JS1, JS2,... are each the
+%                              product of J and Seff for the first neighbour, 
+%                              second, third neighbour etc.
+%
+%               The length of the parameters vector determines the range of the
+%              interactions. The vector can have have an unlimited number of
+%              interaction parameters. 
+%
+%               EXAMPLE
+%               If input argument par has length five, that is, par is:
+%                 [Seff, gap, JS1, JS2, JS3]
+%               then it is assumed that all interactions beyond the 3rd
+%              neighbour are zero.
+%
+%               The first 15 neighbours are 
+%                   JS1         JS to [1, 0, 0]     (nearest neighbour)
+%                   JS2         JS to [1, 1, 0]     (2nd neighbour)
+%                   JS3         JS to [1, 1, 1]     (3rd neighbour)
+%                   JS4         JS to [2, 0, 0]     (4th neighbour)
+%                   JS5         JS to [2, 1, 0]     (5th neighbour)
+%                   JS6         JS to [2, 1, 1]     (6th neighbour)
+%                   JS7         JS to [2, 2, 0]     (7th neighbour)
+%                   JS8         JS to [3, 0, 0]     (equal 8th neighbour)
+%                   JS9         JS to [2, 2, 1]     (equal 8th neighbour)
+%                   JS10        JS to [3, 1, 0]     (10th neighbour)
+%                   JS11        JS to [3, 1, 1]     (11th neighbour)
+%                   JS12        JS to [2, 2, 2]     (12th neighbour)
+%                   JS13        JS to [3, 2, 0]     (13th neighbour)
+%                   JS14        JS to [3, 2, 1]     (14th neighbour)
+%                   JS15        JS to [4, 0, 0]     (15th neighbour)
+%
+%               Note that if there are inequivalent sites at the same distance
+%               then the order is always decreasing x, followed by decreasing y.
+%
 % Output:
 % -------
-%   wdisp       Array of energies for the dispersion
-%   sf          Array of spectral weights
+%   wdisp       Cell array containing a single array with the spin wave energies
+%              at the array of points defined by qh, qk, ql
+%
+%   sf          Cell array containing a single array with the corresponding
+%              spectral weights, Seff/2 (i.e. par(1)/2)
 
-Seff=par(1);
-gap=par(2);
-JS_100=par(3);
-JS_110=par(4);
-JS_111=par(5);
-JS_200=par(6);
 
-w=gap*ones(size(qh));
+persistent rho
 
-% Precompute some arrays used in more than one exchange pathway
-if JS_110~=0 || JS_111~=0
-    cos2h = cos((2*pi)*qh);
-    cos2k = cos((2*pi)*qk);
-    cos2l = cos((2*pi)*ql);
+Seff = par(1);
+gap = par(2);
+JS = par(3:end);
+npar = numel(JS);
+
+if npar > size(rho,1)
+    % Populate rho with the positions of unique nearest neighbour locations in
+    % order of increasing separation. initialise with at least the first 15
+    % distinct nearest neighbours
+    d_upper_bound = d_upper_bound_sc (max(npar,15));
+    rho = sc_atom_sites (d_upper_bound);
 end
 
-if JS_100~=0
-    w = w + (4*JS_100)*(sin(pi*qh).^2 + sin(pi*qk).^2 + sin(pi*ql).^2);
+% Accumulate spin wave energies
+w = gap*ones(size(qh));
+for i = 1:npar
+    if JS(i)~=0
+        w = w + JS(i) * fdisp(qh, qk, ql, rho(i,:));
+    end
 end
 
-if JS_110~=0
-    w = w + (4*JS_110)*(3 - cos2h.*cos2k - cos2k.*cos2l - cos2l.*cos2h);
-end
-
-if JS_111~=0
-    w = w + (8*JS_111)*(1-cos2h.*cos2k.*cos2l);
-end
-
-if JS_200~=0
-    w = w + (4*JS_200)*(sin((2*pi)*qh).^2 + sin((2*pi)*qk).^2 + sin((2*pi)*ql).^2);
-end
-
+% Set output arguments
 wdisp{1} = w;
 sf{1} = (Seff/2)*ones(size(w));
+
+
+%-------------------------------------------------------------------------------
+function d_upper_bound = d_upper_bound_sc (N)
+% Return an upper bound for the distance of the Nth neighbour interaction for
+% a simple cubic lattice, expressed in units of the cube side.
+%
+% The upper bound returned is:
+%       d_upper_bound = (36*N/pi)^(1/3)         ....(1)
+%
+% Explanation:
+% - Volume of a sphere radius d (in uits of cube side) is: V = (4/3)*pi*(d^3)
+% - Volume of a cube: 1
+% - Each cube contains 1 site so the estimated number of sites in the sphere
+%   is: 
+%       N(estimated) = (4/3)*pi*(d^3)     ....(2)
+%
+%     Note: this can be an underestimate or overestimate, due to whether or
+%     not sites are included in cubes that are intersected by by the sphere
+%     surface. As d gets larger, the relative error gets smaller.
+%
+% - For the general atomic site (x,y,z) (x~=y~=z~=x) there are 48 symmetry
+%   equivalent sites. The number of *distinct* nearest neighbours can be
+%   estimated as (1/48) of the estimated number of sites above i.e.
+%
+%       N(distinct,estimated) = (1/36)*pi*d^3   ....(3)
+%
+%     In fact, there are many atomic sites with fewer than 48 symmetry related 
+%     positions: [x,x,0], [x,x,x], [x,y,0], [x,x,z], with respectively 6, 12, 8,
+%     24, 24 equivalent positions. Consequently, estimating the number of
+%     distinct sites by dividing by 48 results in an *underestimate* of the true
+%     number of distinct sites, N.
+%     It turns out that this underestimate always more than compensates
+%     for the error of the number sites enclosed within the sphere, equation (2)
+%     (see numerical results below). Therefore equation (3) becomes:
+%   
+%       N > (1/36)*pi*d^3   ==>  d < (36*N/pi)^(1/3)
+%
+%     and therefore equation (1) gives an upper bound for d.
+%
+% Numerical results:
+% ------------------
+% - min (d_upper_bound - d) = 1.2545  
+%   (for the first neighbour:  d_upper_bound = 2.2545, d = 1)
+%
+% - max (d_upper_bound - d) = 1.8536
+%   (for the 68th neighbour: d_upper_bound = 9.2021, d = 7.3485)
+%
+% The above has been numerically tested out to the 5661084th neighbour, which
+% has d = 400. Numerically it is seen that (d_upper_bound - d) 
+% asymptotically approaches 1.8095, with the fluctuations around this value
+% getting ever smaller. This is expected as the number of cubes intersecting the
+% sphere surface gets smaller as a proportion of the total number of cubes 
+% inside the volume of the sphere.
+
+d_upper_bound = (36*N/pi)^(1/3);
+
+
+%-------------------------------------------------------------------------------
+function [rho, dist] = sc_atom_sites (rmax)
+% Get distances to neighbouring atoms for the sc lattice in a sphere of radius rmax.
+%
+% Input
+% -----
+%   rmax    Maximum distance from origin in units of the cube side length
+%
+% Output:
+% -------
+%   rho     Array of unique sites size [npar,3], where npar is the number of
+%           unique sites within or on the surface of the sphere radius rmax).
+%           For example, if rmax = 2, rho is returned as:
+%                   [1, 0, 0; ...   % nearest neighbour
+%                    1, 1, 0; ...   % 2nd neighbour
+%                    1, 1, 1; ...   % 3rd neighbour
+%                    2, 0, 0]       % 4th neighbour
+%
+%           The sites are sorted in order of increasing distance from the
+%           origin, and for the ith site has rho(i,1) >= rho(i,2) >=rho(i,3).
+%           If two or more inequivalent sites have the same distance from the
+%           origin, then the those sites are ordered by decreasing rho(:,1), and
+%           if the rho(:,1) are the same, by decreasing rho(:,2).
+%
+%   dist    Column vector of distances from the origin, length npar, where npar
+%           is the number of unique sites within or on the surface of the sphere
+%           radius rmax).
+
+small = 1e-10;
+
+R = ceil(rmax);     % round to closest larger integer
+
+% Fill an array with the cube corners within or on the surface of an irreducible
+% repeat volume of the cubic lattice. The repeat volume chosen here is the 3D
+% wedge defined by rmax >= x >= y >= z.
+% The number of points for each value of x is (note: ignore [0,0,0]):
+%   x = 1   npnt = 3    (2 + 1)
+%   x = 2   npnt = 6    (3 + 2 + 1)
+%   x = 3   npnt = 10   (4 + 3 + 2 + 1)
+%       :
+%   x = R   npnt = (R+1)*(R+2)/2    ((R+1) + R + (R-1) + ... 2 + 1)
+
+N_vertices = ((R+1)*(R+2)*(R+3))/6 - 1;     % total number of vertices out to R
+x = zeros(N_vertices,1);
+y = zeros(N_vertices,1);
+z = zeros(N_vertices,1);
+
+% Loop over x,y,z
+i = 0;
+for ix = 1:R
+    for iy = 0:ix
+        for iz = 0:iy
+            i = i + 1;
+            x(i) = ix;
+            y(i) = iy;
+            z(i) = iz;
+        end
+    end
+end
+
+% Distances from origin
+dsqr = x.^2 + y.^2 + z.^2;
+
+% Get sites within or on the surface of a sphere radius rmax (exluding origin)
+% Add a tiny tolerance in case rmax is not an integer
+ok = dsqr<=(rmax^2 + small);
+dsqr = dsqr(ok);
+x = x(ok);
+y = y(ok);
+z = z(ok);
+
+% Sort into order of increasing distance from the origin, ensuring that x>y>z
+% in the case when there are inequivalent sites at the same distance from the
+% origin.
+dsqr_rho = sortrows([dsqr, x, y, z],{'ascend','descend','descend','descend'});
+
+rho = dsqr_rho(:,2:4);
+dist = sqrt(dsqr_rho(:,1));
+
+
+%-------------------------------------------------------------------------------
+function w = fdisp (qh, qk, ql, r)
+% Return the contribution from symmetry equivalent sites to cubic Heisenberg ferromagnet.
+% In more detail: returns
+%
+%       w = M - Sum({r"}, exp(2*pi*i*(hx"+ky"+lz")) )
+%
+%   where M   is the number of atomic sites symmetry equivalent to r = [x,y,z]
+%        {r"} is the set of position vectors of those symmetry equivalent sites
+%       h,k,l give a point in the cubic reciprocal point q = ha* + kb* + lc*
+%
+%   e.g. if r = [1,0,0], then 
+%         M = 6
+%        {r"} = {[1,0,0], [0,1,0], [0,-1,0], [0,0,1], [0,0,-1]}
+%
+% There are six different cases of site symmetry
+%   [x 0 0]     M = 6
+%   [x x 0]     M = 12
+%   [x x x]     M = 8
+%   [x y 0]     M = 24
+%   [x x z]     M = 24
+%   [x y z]     M = 48
+%
+% where x>0, y>0, y>0 and x~=y, y~=z, z~=x
+%
+%
+% Input:
+% ------
+%   qh, qk, ql  Arrays giving h,k,l for a set of wavevectors in reciprocal space
+%               of the conventional cubic lattice for simple cubic (sc), bcc or
+%               fcc crystals. The arrays all must have the same size.
+%   r           Vector of an atomic position [x,y,z]
+%
+% Output:
+% -------
+%   w           M - Sum({r"}, exp(2*pi*i*(hx"+ky"+lz")) ) defined above
+
+
+isNonZero = (r~=0);
+numNonZero = sum(isNonZero);
+ind = find(isNonZero);
+if numNonZero == 1
+    w = f_x00 (qh, qk, ql, r(ind(1)));
+elseif numNonZero == 2
+    if r(ind(1)) == r(ind(2))
+        w = f_xx0 (qh, qk, ql, r(ind(1)));
+    else
+        w = f_xy0 (qh, qk, ql, r(ind(1)), r(ind(2)));
+    end
+elseif numNonZero == 3
+    if r(ind(1)) == r(ind(2)) && r(ind(2)) == r(ind(3)) % all are the same
+        w = f_xxx (qh, qk, ql, r(ind(1)));
+    elseif r(ind(1)) ~= r(ind(2)) && r(ind(2)) ~= r(ind(3)) ...
+            && r(ind(3)) ~= r(ind(1))                   % all are different
+        w = f_xyz (qh, qk, ql, r(ind(1)), r(ind(2)), r(ind(3)));
+    else    % two are the same, one is different
+        if r(ind(1)) == r(ind(2))       % x==y~=z
+            w = f_xxy (qh, qk, ql, r(ind(2)), r(ind(3)));
+        elseif r(ind(2)) == r(ind(3))   % x~=y==z
+            w = f_xxy (qh, qk, ql, r(ind(3)), r(ind(1)));
+        elseif r(ind(3)) == r(ind(1))   % y~=z==x
+            w = f_xxy (qh, qk, ql, r(ind(1)), r(ind(2)));
+        end
+    end
+end
+
+%-------------------------------------------------------------------------------
+function w = f_x00 (qh, qk, ql, x)
+% Contribution from interactions along [x,0,0] in real space
+% Accounts for the 6-fold degeneracy of symmetry equivalent sites
+w = 4 * (sin((pi*x)*qh).^2 + sin((pi*x)*qk).^2 + sin((pi*x)*ql).^2);
+
+%-------------------------------------------------------------------------------
+function w = f_xx0 (qh, qk, ql, x)
+% Contribution from interactions along [x,x,0] in real space
+% Accounts for the 12-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+w = 4 * (3 - cos_xh.*cos_xk - cos_xk.*cos_xl - cos_xl.*cos_xh);
+
+%-------------------------------------------------------------------------------
+function w = f_xxx (qh, qk, ql, x)
+% Contribution from interactions along [x,x,x] in real space
+% Accounts for the 8-fold degeneracy of symmetry equivalent sites
+w = 8 * (1 - cos((2*pi*x)*qh).*cos((2*pi*x)*qk).*cos((2*pi*x)*ql));
+
+%-------------------------------------------------------------------------------
+function w = f_xy0 (qh, qk, ql, x, y)
+% Contribution from interactions along [x,y,0] (x~=y) in real space
+% Accounts for the 24-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+cos_yh = cos((2*pi*y)*qh);
+cos_yk = cos((2*pi*y)*qk);
+cos_yl = cos((2*pi*y)*ql);
+w = 4 * (6 ...
+    - cos_xh.*cos_yk - cos_yh.*cos_xk...
+    - cos_xk.*cos_yl - cos_yk.*cos_xl...
+    - cos_xl.*cos_yh - cos_yl.*cos_xh);
+
+%-------------------------------------------------------------------------------
+function w = f_xxy (qh, qk, ql, x, y)
+% Contribution from interactions along [x,x,y] (x~=y) in real space
+% Accounts for the 24-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+w = 8 * (3 ...
+    - cos_xh.*cos_xk.*cos((2*pi*y)*ql)...
+    - cos_xk.*cos_xl.*cos((2*pi*y)*qh)...
+    - cos_xl.*cos_xh.*cos((2*pi*y)*qk));
+
+%-------------------------------------------------------------------------------
+function w = f_xyz (qh, qk, ql, x, y, z)
+% Contribution from interactions along [x,y,z] (x,y,z all different) in real space
+% Accounts for the 48-fold degeneracy of symmetry equivalent sites
+cos_xh = cos((2*pi*x)*qh);
+cos_xk = cos((2*pi*x)*qk);
+cos_xl = cos((2*pi*x)*ql);
+cos_yh = cos((2*pi*y)*qh);
+cos_yk = cos((2*pi*y)*qk);
+cos_yl = cos((2*pi*y)*ql);
+cos_zh = cos((2*pi*z)*qh);
+cos_zk = cos((2*pi*z)*qk);
+cos_zl = cos((2*pi*z)*ql);
+w = 8 * (6 ...
+    - cos_xh.*cos_yk.*cos_zl...
+    - cos_yh.*cos_zk.*cos_xl...
+    - cos_zh.*cos_xk.*cos_yl...
+    - cos_xh.*cos_zk.*cos_yl...
+    - cos_yh.*cos_xk.*cos_zl...
+    - cos_zh.*cos_yk.*cos_xl);


### PR DESCRIPTION
Ref #1913 The dispersion relations for the Heisenberg ferromagnet on simple cubic, bcc and fcc lattices in /sqw_models have been generalised to an arbitrary number of atomic neighbours. Corresponding test suites have been created and added to the CI tests.