### PR TITLE
path in `save` command

### DIFF
--- a/_test/test_sqw/test_save.m
+++ b/_test/test_sqw/test_save.m
@@ -374,6 +374,36 @@ classdef test_save < TestCase
 
         end
         %
+        function test_save_tmp_to_permanent_moves_to_new_same_folder(obj)
+            source_to_move = fullfile(tmp_dir,'test_save_tmp_2move.tmp');
+            targ_file      = 'save_filebacked_permanent.sqw';
+            clOb = onCleanup(@()del_memmapfile_files(targ_file));
+
+            % create temporary test object
+            test_obj = obj.sqw_obj.save(source_to_move,'-make_tmp');
+            assertTrue(test_obj.is_filebacked)
+            assertTrue(test_obj.is_tmp_obj)
+
+
+            new_obj = test_obj.save(targ_file);
+            assertFalse(isfile(source_to_move));
+
+            new_file = new_obj.full_filename;
+            [fp,fn,fe] = fileparts(new_file);
+            src_path = fileparts(source_to_move);
+            assertEqual(fp,src_path);
+            assertEqual([fn,fe],targ_file);
+
+            ldr = sqw_formats_factory.instance().get_loader(new_file);
+            rec = ldr.get_sqw();
+            ldr.delete();
+            assertEqualToTol(rec,obj.sqw_obj,'-ignore_str','tol',[4*eps('single'),4*eps('single')]);
+
+            ref_obj = obj.sqw_obj;
+            ref_obj.full_filename = new_file;
+            assertEqualToTol(rec,ref_obj,'-ignore_date','tol',[4*eps('single'),4*eps('single')]);
+        end
+        
         function test_save_tmp_moves_to_new_file_upgrades_all_bar_pix(obj)
             source_to_move = fullfile(tmp_dir,'test_save_tmp_moves.tmp');
             targ_file      = fullfile(tmp_dir,'save_filebacked_different_file.sqw');

--- a/horace_core/sqw/@SQWDnDBase/save.m
+++ b/horace_core/sqw/@SQWDnDBase/save.m
@@ -123,12 +123,11 @@ function wout = save_one(w,filename,assume_updated,return_result,clear_source,ma
 % save single sqw object
 %
 wout = []; % Target sqw object
-targ_filepath = []; %filepath of the target sqw object
+[targ_filepath,~,fe] = fileparts(filename); %filepath of the target sqw object
 if return_result
     if make_tmp
         target_is_tmp  = true;
     else
-        [targ_filepath,~,fe] = fileparts(filename);
         target_is_tmp = strncmp(fe,'.tmp',4);
     end
 else

--- a/horace_core/sqw/@SQWDnDBase/save.m
+++ b/horace_core/sqw/@SQWDnDBase/save.m
@@ -123,11 +123,12 @@ function wout = save_one(w,filename,assume_updated,return_result,clear_source,ma
 % save single sqw object
 %
 wout = []; % Target sqw object
+targ_filepath = []; %filepath of the target sqw object
 if return_result
     if make_tmp
         target_is_tmp  = true;
     else
-        [~,~,fe] = fileparts(filename);
+        [targ_filepath,~,fe] = fileparts(filename);
         target_is_tmp = strncmp(fe,'.tmp',4);
     end
 else
@@ -170,6 +171,10 @@ if w.is_filebacked && (assume_updated || ...
     end
     w = w.deactivate();
     del_memmapfile_files(filename);
+    if isempty(targ_filepath)
+        source_filepath = fileparts(w.pix.full_filename);
+        filename = fullfile(source_filepath,filename);
+    end
     movefile(w.pix.full_filename,filename,'f');
     ldw = ldw.init(filename);
     if target_is_tmp


### PR DESCRIPTION
Solves Re #1925

If you save temporary filebacked object without specifying target path, the object stays in the folder, where temporary object was located.