### PR TITLE
attaching objects to images

### DIFF
--- a/_test/test_IX_classes/test_plot_IX_dataset.m
+++ b/_test/test_IX_classes/test_plot_IX_dataset.m
@@ -794,7 +794,7 @@ classdef test_plot_IX_dataset < TestCase
                 assertEqual(numel(fig_h),1);
                 assertEqual(numel(axes_h),1);
                 assertEqual(numel(plot_h),3);   % original and two overplotted
-                assertEqualToTol([fig_h.UserData{:}],data2D_arr);
+                assertEqualToTol([fig_h.UserData{:}],[0.5*obj.data1D,data1D_arr]);
             end
         end
 

--- a/_test/test_IX_classes/test_plot_IX_dataset.m
+++ b/_test/test_IX_classes/test_plot_IX_dataset.m
@@ -3,7 +3,7 @@ classdef test_plot_IX_dataset < TestCase
     %
     % This test suite mainly exercises the plot interface, plotting of arrays of
     % data, and some tests of altering plot ranges.
-    
+
     properties
         data1D
         data2D
@@ -14,20 +14,20 @@ classdef test_plot_IX_dataset < TestCase
     methods
         function obj = test_plot_IX_dataset(varargin)
             obj = obj@TestCase('test_plot_IX_dataset');
-            
+
             % Load example 1D, 2D, 3D, IX_dataset_*d objects
             hp = horace_paths().test_common;    % common data location
 
             sqw_1d_file = fullfile(hp, 'sqw_1d_1.sqw');
             sqw_2d_file = fullfile(hp, 'sqw_2d_1.sqw');
             sqw_3d_file = fullfile(hp, 'w3d_sqw.sqw');
-            
+
             obj.data1D = IX_dataset_1d(read_dnd(sqw_1d_file));
             obj.data2D = IX_dataset_2d(read_dnd(sqw_2d_file));
-            obj.data3D = IX_dataset_3d(read_dnd(sqw_3d_file));           
+            obj.data3D = IX_dataset_3d(read_dnd(sqw_3d_file));
         end
-        
-        
+
+
         %------------------------------------------------------------------
         % Spaghetti_plot tests
         %------------------------------------------------------------------
@@ -88,10 +88,10 @@ classdef test_plot_IX_dataset < TestCase
             % Test all 3D plot methods produce a figure
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = [T.methodsND_plot(:); T.methods3D_plot(:)];
-            
+
             clear_figures()
             for i=1:numel(methods)
                 meth = methods{i};
@@ -101,7 +101,7 @@ classdef test_plot_IX_dataset < TestCase
                 assertTrue(isstruct(plot_h));
                 if i>1  % Must have cleared existing figure window and reused it
                     assertTrue(fig_h==fig_h_ref);
-                else    
+                else
                     fig_h_ref = fig_h;  % store fig handle first time through loop
                 end
             end
@@ -112,7 +112,7 @@ classdef test_plot_IX_dataset < TestCase
             % Test all plot methods for 1D and 2D throw an error with 3D data
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             other_methods = [ ...
                 T.methods1D_plot(:); T.methods1D_plotOver(:); ...
@@ -129,7 +129,7 @@ classdef test_plot_IX_dataset < TestCase
                     func2str(other_methods{i})));
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX3D_plot3D_methods_do_not_work_with_array(obj)
             % Test that all 3D 'plot' methods do not plot arrays of data
@@ -153,7 +153,7 @@ classdef test_plot_IX_dataset < TestCase
             end
         end
 
-        
+
         %------------------------------------------------------------------
         % Two-dimensional data
         %------------------------------------------------------------------
@@ -161,13 +161,13 @@ classdef test_plot_IX_dataset < TestCase
             % Test all 2D plot methods produce a figure
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = [...
                 T.methodsND_plot(:); T.methods2D_plot(:); ...
                 T.methodsND_plotOver(:); T.methods2D_plotOver(:); ...
                 T.methods2D_plotOverCurr(:)];
-            
+
             clear_figures()
             for i=1:numel(methods)
                 meth = methods{i};
@@ -183,7 +183,7 @@ classdef test_plot_IX_dataset < TestCase
             % Test all plot methods for 1D and 3D throw an error with 2D data
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             other_methods = [ ...
                 T.methods1D_plot(:); T.methods1D_plotOver(:); ...
@@ -199,14 +199,14 @@ classdef test_plot_IX_dataset < TestCase
                     func2str(other_methods{i})));
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX2D_plot2D_methods_reuseFig_newAxes(obj)
             % Test that all 2D 'plot' (as opposed to 'plot over' and 'plot over
             % curr') methods reuse a 2D figure, but erase the axes and plots
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = [T.methodsND_plot(:); T.methods2D_plot(:)];
 
@@ -226,14 +226,14 @@ classdef test_plot_IX_dataset < TestCase
                 assertFalse(isequal(axes_h, axes_h_ref));
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX2D_plotOver2D_methods_reuseFigAndAxes(obj)
             % Test that all 2D 'plot over' (as opposed to 'plot' and 'plot over
             % current') methods add plots to a 2D figure
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = [T.methodsND_plot(:); T.methods2D_plot(:)];
             methods_over = [T.methodsND_plotOver(:); T.methods2D_plotOver(:)];
@@ -252,7 +252,7 @@ classdef test_plot_IX_dataset < TestCase
                 % Now overplot
                 meth = methods_over{i};
                 [fig_h, axes_h, plot_h] = meth(data2D_shift);
-                
+
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
@@ -262,14 +262,14 @@ classdef test_plot_IX_dataset < TestCase
                 assertTrue(numel(plot_h) == numel(plot_h_ref) + 1);
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX2D_plotOverCurr2D_methods_work(obj)
             % Test that all 2D 'plot over current' add to any current figure
             % regardless of the type of figure
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = T.methods2D_plotOverCurr(:);
 
@@ -279,7 +279,7 @@ classdef test_plot_IX_dataset < TestCase
                 obj.data2D.signal');
             fig_h_prev = gcf;
             axes_h_prev = gca;
-            
+
             % Succesively overplot
             data2D_shift = obj.data2D;
             for i=1:numel(methods)
@@ -296,13 +296,13 @@ classdef test_plot_IX_dataset < TestCase
                 assertTrue(fig_h==fig_h_prev);
                 assertTrue(axes_h==axes_h_prev); % handle objects, hence equality
                 assertTrue(numel(plot_h) == numel(plot_h_prev) + 1);
-                
+
                 fig_h_prev = fig_h;
                 axes_h_prev = axes_h;
                 plot_h_prev = plot_h;
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX2D_plot2D_methods_work_with_array(obj)
             % Test that all 2D 'plot' methods plot arrays of data
@@ -331,14 +331,14 @@ classdef test_plot_IX_dataset < TestCase
                 assertEqual(numel(plot_h),2);
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX2D_plotOver2D_methods_work_with_array(obj)
             % Test that all 2D 'plot over' methods plot arrays of data
             % That is methods like pa, ps,... ('plot over')
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = [T.methodsND_plot(:); T.methods2D_plot(:)];
             methods_over = [T.methodsND_plotOver(:); T.methods2D_plotOver(:)];
@@ -350,7 +350,7 @@ classdef test_plot_IX_dataset < TestCase
             data2D_shift.x = data2D_shift.x + obj.data2D.x(end);
             data2D_shift.y = data2D_shift.y + 0.3*obj.data2D.y(end);
             data2D_arr = [obj.data2D, data2D_shift];
-            
+
             data2D_arr_shift = data2D_arr;
             data2D_arr_shift(1).x = data2D_arr_shift(1).x + obj.data2D.x(end);
             data2D_arr_shift(1).y = data2D_arr_shift(1).y + obj.data2D.y(end);
@@ -364,7 +364,7 @@ classdef test_plot_IX_dataset < TestCase
                 % Now overplot
                 meth = methods_over{i};
                 [fig_h, axes_h, plot_h] = meth(data2D_arr_shift);
-                
+
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
@@ -375,24 +375,24 @@ classdef test_plot_IX_dataset < TestCase
                 assertTrue(numel(plot_h) == numel(plot_h_ref) + 2);
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX2D_plotOverCurr2D_methods_work_with_array(obj)
             % Test that all 2D 'plot over current' methods plot arrays of data
             % That is methods like paoc, psoc,... ('plot over current')
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = T.methods2D_plotOverCurr(:);
-            
+
             % Create a figure on which to overplot, and get the figure, axes and
             % plot handles:
             plot_h_prev = surf(obj.data2D.x(1:end-1), obj.data2D.y(1:end-1), ...
                 obj.data2D.signal');
             fig_h_prev = gcf;
             axes_h_prev = gca;
-            
+
             % Succesively overplot
             data2D_arr_shift = [obj.data2D, obj.data2D];
             data2D_arr_shift(1).x = data2D_arr_shift(1).x + obj.data2D.x(end);
@@ -409,32 +409,32 @@ classdef test_plot_IX_dataset < TestCase
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
-                
+
                 assertTrue(fig_h==fig_h_prev);
                 assertTrue(axes_h==axes_h_prev); % handle objects, hence equality
                 assertTrue(numel(plot_h) == numel(plot_h_prev) + 2);
-                
+
                 fig_h_prev = fig_h;
                 axes_h_prev = axes_h;
                 plot_h_prev = plot_h;
             end
         end
 
-        
+
         %------------------------------------------------------------------
         % Tests of setting and getting limits
-        
+
         function test_IX2D_change_limits_areaPlot(obj)
             % Test that the plot limits are changed
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             % Make plot
             [~, axes_h] = da(obj.data2D);
             XLim_ref = axes_h.XLim;
             YLim_ref = axes_h.YLim;
             ZLim_ref = axes_h.CLim;     % area plot: colour scale as z-axis
-            
+
 
             % Set new limits
             XLim_new = XLim_ref + [-0.53, 0.53].*abs(XLim_ref);
@@ -443,11 +443,11 @@ classdef test_plot_IX_dataset < TestCase
             lx (XLim_new)
             ly (YLim_new)
             lz (ZLim_new)
-            
+
             assertTrue(all(xlim()==XLim_new), 'x-limits not correctly changed')
             assertTrue(all(ylim()==YLim_new), 'y-limits not correctly changed')
             assertTrue(all(caxis()==ZLim_new), 'z-limits not correctly changed')
-            
+
             % Reset limits
             lx
             ly
@@ -456,13 +456,13 @@ classdef test_plot_IX_dataset < TestCase
             assertTrue(all(ylim()==YLim_ref), 'y-limits not correctly reset')
             assertTrue(all(caxis()==ZLim_ref), 'z-limits not correctly reset')
         end
-        
+
 
         function test_IX2D_get_limits_areaPlot(obj)
             % Test that the plot limits are changed
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             % Make plot
             [~, axes_h] = da(obj.data2D);
             XLim_ref = axes_h.XLim;
@@ -477,13 +477,13 @@ classdef test_plot_IX_dataset < TestCase
             assertTrue(all([ylo,yhi]==YLim_ref), 'y-limits not correctly returned')
             assertTrue(all([zlo,zhi]==ZLim_ref), 'z-limits not correctly returned')
         end
-        
+
 
         function test_IX2D_change_limits_areaPlot_commandMode(obj)
             % Test that the plot limits are changed
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             % Make plot
             [~, axes_h] = da(obj.data2D);
             XLim_ref = axes_h.XLim;
@@ -497,18 +497,18 @@ classdef test_plot_IX_dataset < TestCase
             lx XLim_new(1) XLim_new(2)
             ly YLim_new(1) YLim_new(2)
             lz ZLim_new(1) ZLim_new(2)
-            
+
             assertTrue(all(xlim()==XLim_new), 'x-limits not correctly changed')
             assertTrue(all(ylim()==YLim_new), 'y-limits not correctly changed')
             assertTrue(all(caxis()==ZLim_new), 'z-limits not correctly changed')
         end
-        
-        
+
+
         function test_IX2D_change_limits_surfacePlot(obj)
             % Test that the plot limits are changed
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             % Make plot
             [~, axes_h] = ds2(obj.data2D, pi*obj.data2D);
             XLim_ref = axes_h.XLim;
@@ -516,7 +516,7 @@ classdef test_plot_IX_dataset < TestCase
             ZLim_ref = axes_h.ZLim;
             CLim_ref = axes_h.CLim;
             assertEqualToTol(pi*ZLim_ref, CLim_ref, 1e-12)   % Check different!
-            
+
 
             % Set new limits
             XLim_new = XLim_ref + [-0.53, 0.53].*abs(XLim_ref);
@@ -527,12 +527,12 @@ classdef test_plot_IX_dataset < TestCase
             ly (YLim_new)
             lz (ZLim_new)
             lc (CLim_new)
-            
+
             assertTrue(all(xlim()==XLim_new), 'x-limits not correctly changed')
             assertTrue(all(ylim()==YLim_new), 'y-limits not correctly changed')
             assertTrue(all(zlim()==ZLim_new), 'z-limits not correctly changed')
             assertTrue(all(caxis()==CLim_new), 'c-limits not correctly changed')
-            
+
             % Reset limits
             lx
             ly
@@ -543,13 +543,13 @@ classdef test_plot_IX_dataset < TestCase
             assertTrue(all(zlim()==ZLim_ref), 'z-limits not correctly reset')
             assertTrue(all(caxis()==CLim_ref), 'c-limits not correctly reset')
         end
-        
+
 
         function test_IX2D_get_limits_surfacePlot(obj)
             % Test that the plot limits are changed
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             % Make plot
             [~, axes_h] = ds2(obj.data2D, pi*obj.data2D);
             XLim_ref = axes_h.XLim;
@@ -567,13 +567,13 @@ classdef test_plot_IX_dataset < TestCase
             assertTrue(all([zlo,zhi]==ZLim_ref), 'z-limits not correctly returned')
             assertTrue(all([clo,chi]==CLim_ref), 'c-limits not correctly returned')
         end
-        
+
 
         function test_IX2D_change_limits_surfacePlot_commandMode(obj)
             % Test that the plot limits are changed
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             % Make plot
             [~, axes_h] = ds2(obj.data2D, pi*obj.data2D);
             XLim_ref = axes_h.XLim;
@@ -590,14 +590,14 @@ classdef test_plot_IX_dataset < TestCase
             ly YLim_new(1) YLim_new(2)
             lz ZLim_new(1) ZLim_new(2)
             lc CLim_new(1) CLim_new(2)
-            
+
             assertTrue(all(xlim()==XLim_new), 'x-limits not correctly changed')
             assertTrue(all(ylim()==YLim_new), 'y-limits not correctly changed')
             assertTrue(all(zlim()==ZLim_new), 'z-limits not correctly changed')
             assertTrue(all(caxis()==CLim_new), 'c-limits not correctly changed')
         end
-        
-        
+
+
         %------------------------------------------------------------------
         % One-dimensional plot methods
         %------------------------------------------------------------------
@@ -624,19 +624,19 @@ classdef test_plot_IX_dataset < TestCase
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX1D_other_plot_methods_throw(obj)
             % Test all plot methods for 2D and 3D throw an error with 1D data
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             other_methods = [ ...
                 T.methods2D_plot(:); T.methods2D_plotOver(:); ...
                 T.methods2D_plotOverCurr(:); ...
                 T.methods3D_plot(:)];
-            
+
             clear_figures()
             for i=1:numel(other_methods)
                 assertExceptionThrown(...
@@ -646,14 +646,14 @@ classdef test_plot_IX_dataset < TestCase
                     func2str(other_methods{i})));
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX1D_plot1D_methods_reuseFig_newAxes(obj)
             % Test that all 1D 'plot' (as opposed to 'plot over' and 'plot over
             % curr') methods reuse a 1D figure, but erase the axes and plots
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = [T.methodsND_plot(:); T.methods1D_plot(:)];
 
@@ -673,20 +673,20 @@ classdef test_plot_IX_dataset < TestCase
                 plot_h_prev = plot_h;
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX1D_plotOver1D_methods_reuseFigAndAxes(obj)
             % Test that all 1D 'plot over' (as opposed to 'plot' and 'plot over
             % current') methods add plots to a 1D figure
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = [T.methodsND_plotOver(:); T.methods1D_plotOver(:)];
 
             % Create figure on which to overplot:
             [fig_h_prev, axes_h_prev, plot_h_prev] = plot(obj.data1D);
-            
+
             % Succesively overplot
             for i=1:numel(methods)
                 meth = methods{i};
@@ -698,20 +698,20 @@ classdef test_plot_IX_dataset < TestCase
                 assertTrue(fig_h==fig_h_prev);
                 assertTrue(axes_h==axes_h_prev); % handle objects, hence equality
                 assertTrue(numel(plot_h) == numel(plot_h_prev) + 1);
-                
+
                 fig_h_prev = fig_h;
                 axes_h_prev = axes_h;
                 plot_h_prev = plot_h;
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX1D_plotOverCurr1D_methods_work(obj)
             % Test that all 1D 'plot over current' add to any current figure
             % regardless of the type of figure
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = T.methods1D_plotOverCurr(:);
 
@@ -720,7 +720,7 @@ classdef test_plot_IX_dataset < TestCase
             plot_h_prev = plot([0,0.1],[1e4,2e4]);
             fig_h_prev = gcf;
             axes_h_prev = gca;
-            
+
             % Succesively overplot
             for i=1:numel(methods)
                 meth = methods{i};
@@ -732,13 +732,13 @@ classdef test_plot_IX_dataset < TestCase
                 assertTrue(fig_h==fig_h_prev);
                 assertTrue(axes_h==axes_h_prev); % handle objects, hence equality
                 assertTrue(numel(plot_h) == numel(plot_h_prev) + 1);
-                
+
                 fig_h_prev = fig_h;
                 axes_h_prev = axes_h;
                 plot_h_prev = plot_h;
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX1D_plot1D_methods_work_with_array(obj)
             % Test that all 1D 'plot' methods plot arrays of data
@@ -755,16 +755,17 @@ classdef test_plot_IX_dataset < TestCase
                 meth = methods{i};
                 [fig_h, axes_h, plot_h] = meth(data1D_arr);
                 all_fig_h = findobj(groot,'Type','Figure');
-                assertTrue(numel(all_fig_h)==1,'Did not overplot only')
+                assertTrue(isscalar(all_fig_h),'Did not overplot only')
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
                 assertEqual(numel(fig_h),1);
                 assertEqual(numel(axes_h),1);
                 assertEqual(numel(plot_h),2);
+                assertEqualToTol([fig_h.UserData{:}],data1D_arr);
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX1D_plotOver1D_methods_work_with_array(obj)
             % Test that all 1D 'plot over' methods plot arrays of data
@@ -775,27 +776,28 @@ classdef test_plot_IX_dataset < TestCase
             T = obj.interface_tester;
             methods = [T.methodsND_plotOver(:); T.methods1D_plotOver(:)];
             data1D_arr = [obj.data1D, 2*obj.data1D];
-            
+
             for i=1:numel(methods)
                 clear_figures()
                 % Create figure on which to overplot:
                 plot(0.5*obj.data1D);
-                
+
                 % Overplot
                 meth = methods{i};
                 [fig_h, axes_h, plot_h] = meth(data1D_arr);
-                
+
                 all_fig_h = findobj(groot,'Type','Figure');
-                assertTrue(numel(all_fig_h)==1,'Did not overplot only')
+                assertTrue(isscalar(all_fig_h),'Did not overplot only')
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
                 assertEqual(numel(fig_h),1);
                 assertEqual(numel(axes_h),1);
                 assertEqual(numel(plot_h),3);   % original and two overplotted
+                assertEqualToTol([fig_h.UserData{:}],data2D_arr);
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_IX1D_plotOverCurr1D_methods_work_with_array(obj)
             % Test that all 1D 'plot over current' methods plot arrays of data
@@ -806,18 +808,18 @@ classdef test_plot_IX_dataset < TestCase
             T = obj.interface_tester;
             methods = T.methods1D_plotOverCurr(:);
             data1D_arr = [obj.data1D, 2*obj.data1D];
-            
+
             for i=1:numel(methods)
                 clear_figures()
                 % Create figure on which to overplot:
                 plot([0,0.1],[1e4,2e4]);    % *not* a genie_figure
-                
+
                 % Overplot
                 meth = methods{i};
                 [fig_h, axes_h, plot_h] = meth(data1D_arr);
-                
+
                 all_fig_h = findobj(groot,'Type','Figure');
-                assertTrue(numel(all_fig_h)==1,'Did not overplot only')
+                assertTrue(isscalar(all_fig_h),'Did not overplot only')
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
@@ -825,17 +827,33 @@ classdef test_plot_IX_dataset < TestCase
                 assertEqual(numel(axes_h),1);
                 assertEqual(numel(plot_h),3);   % original and two overplotted
             end
-        end 
-        
-        
+        end
+
+        function test_src_two_obj(obj)
+            clear_figures();
+            cleanupObj = onCleanup(@clear_figures);
+            plot(obj.data1D);
+            plotover(2*obj.data1D);
+            res = src(1);
+            assertEqual(res,[obj.data1D,2*obj.data1D]);
+        end
+
+        function test_src_one_obj(obj)
+            clear_figures();
+            cleanupObj = onCleanup(@clear_figures);
+            plot(obj.data1D);
+            res = src(1);
+            assertEqual(res,obj.data1D);
+        end
+
         %------------------------------------------------------------------
         % Tests of setting and getting limits
-        
+
         function test_IX1D_change_limits(obj)
             % Test that the plot limits are changed
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             % Make plot
             [~, axes_h] = dd(obj.data1D);
             XLim_ref = axes_h.XLim;
@@ -846,23 +864,23 @@ classdef test_plot_IX_dataset < TestCase
             YLim_new = YLim_ref .* [0.3, 2.5] + [-500, 2000];
             lx (XLim_new)
             ly (YLim_new)
-            
+
             assertTrue(all(xlim()==XLim_new), 'x-limits not correctly changed')
             assertTrue(all(ylim()==YLim_new), 'y-limits not correctly changed')
-            
+
             % Reset limits
             lx
             ly
             assertTrue(all(xlim()==XLim_ref), 'x-limits not correctly reset')
-            assertTrue(all(ylim()==YLim_ref), 'y-limits not correctly reset') 
+            assertTrue(all(ylim()==YLim_ref), 'y-limits not correctly reset')
         end
-        
+
 
         function test_IX1D_get_limits(obj)
             % Test that the plot limits are changed
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             % Make plot
             [~, axes_h] = dd(obj.data1D);
             XLim_ref = axes_h.XLim;
@@ -874,13 +892,13 @@ classdef test_plot_IX_dataset < TestCase
             assertTrue(all([xlo,xhi]==XLim_ref), 'x-limits not correctly returned')
             assertTrue(all([ylo,yhi]==YLim_ref), 'y-limits not correctly returned')
         end
-        
+
 
         function test_IX1D_change_limits_commandMode(obj)
             % Test that the plot limits are changed
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             % Make plot
             [~, axes_h] = dd(obj.data1D);
             XLim_ref = axes_h.XLim;
@@ -891,11 +909,11 @@ classdef test_plot_IX_dataset < TestCase
             YLim_new = YLim_ref .* [0.3, 2.5] + [-500, 2000];
             lx XLim_new(1) XLim_new(2)
             ly YLim_new(1) YLim_new(2)
-            
+
             assertTrue(all(xlim()==XLim_new), 'x-limits not correctly changed')
             assertTrue(all(ylim()==YLim_new), 'x-limits not correctly changed')
         end
-        
+
 
         %------------------------------------------------------------------
         % Interface test
@@ -912,7 +930,7 @@ classdef test_plot_IX_dataset < TestCase
             % the implementation of plot methods.
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             all_methods = [ ...
                 T.methodsND_plot(:); T.methodsND_plotOver(:); ...
@@ -921,7 +939,7 @@ classdef test_plot_IX_dataset < TestCase
                 T.methods2D_plot(:); T.methods2D_plotOver(:); ...
                 T.methods2D_plotOverCurr(:); ...
                 T.methods3D_plot(:)];
-            
+
             for i=1:numel(all_methods)
                 assertExceptionThrown(...
                     @()function_caller(all_methods{i}, T), ...
@@ -929,7 +947,7 @@ classdef test_plot_IX_dataset < TestCase
                     sprintf('error for method number %d: %s',i, ...
                     func2str(all_methods{i})));
             end
-        %------------------------------------------------------------------
+            %------------------------------------------------------------------
         end
     end
 end

--- a/_test/test_dnd_class/test_plot_dnd.m
+++ b/_test/test_dnd_class/test_plot_dnd.m
@@ -11,7 +11,7 @@ classdef test_plot_dnd < TestCase
     methods
         function obj = test_plot_dnd(varargin)
             obj = obj@TestCase('test_plot_sqw');
-            
+
             % Load example 1D, 2D, 3D, 4D sqw objects
             hp = horace_paths().test_common;    % common data location
 
@@ -19,14 +19,14 @@ classdef test_plot_dnd < TestCase
             sqw_2d_file = fullfile(hp, 'sqw_2d_1.sqw');
             sqw_3d_file = fullfile(hp, 'w3d_sqw.sqw');
             sqw_4d_file = fullfile(hp, 'sqw_4d.sqw');
-            
+
             obj.data1D = read_dnd(sqw_1d_file);
             obj.data2D = read_dnd(sqw_2d_file);
-            obj.data3D = read_dnd(sqw_3d_file);   
-            obj.data4D = read_dnd(sqw_4d_file);           
+            obj.data3D = read_dnd(sqw_3d_file);
+            obj.data4D = read_dnd(sqw_4d_file);
         end
 
-        
+
         %------------------------------------------------------------------
         % Spaghetti_plot tests
         %------------------------------------------------------------------
@@ -50,7 +50,7 @@ classdef test_plot_dnd < TestCase
             close(fig_h);
         end
 
-        
+
         %------------------------------------------------------------------
         % Four-dimensional data
         %------------------------------------------------------------------
@@ -58,7 +58,7 @@ classdef test_plot_dnd < TestCase
             % Test all 1D, 2D, 3D plot methods throw an error
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             other_methods = [ ...
                 T.methodsND_plot(:); ...
@@ -77,8 +77,8 @@ classdef test_plot_dnd < TestCase
                     func2str(other_methods{i})));
             end
         end
-        
-        
+
+
         %------------------------------------------------------------------
         % Three-dimensional data
         %------------------------------------------------------------------
@@ -86,10 +86,10 @@ classdef test_plot_dnd < TestCase
             % Test all 3D plot methods produce a figure
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = [T.methodsND_plot(:); T.methods3D_plot(:)];
-            
+
             clear_figures()
             for i=1:numel(methods)
                 meth = methods{i};
@@ -99,7 +99,7 @@ classdef test_plot_dnd < TestCase
                 assertTrue(isstruct(plot_h));
                 if i>1  % Must have cleared existing figure window and reused it
                     assertTrue(fig_h==fig_h_ref);
-                else    
+                else
                     fig_h_ref = fig_h;  % store fig handle first time through loop
                 end
             end
@@ -110,7 +110,7 @@ classdef test_plot_dnd < TestCase
             % Test all plot methods for 1D and 2D throw an error with 3D data
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             other_methods = [ ...
                 T.methods1D_plot(:); T.methods1D_plotOver(:); ...
@@ -127,7 +127,7 @@ classdef test_plot_dnd < TestCase
                     func2str(other_methods{i})));
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_d3d_plot3D_methods_do_not_work_with_array(obj)
             % Test that all 3D 'plot' methods do not plot arrays of data
@@ -147,8 +147,8 @@ classdef test_plot_dnd < TestCase
                     func2str(methods{i})));
             end
         end
-        
-        
+
+
         %------------------------------------------------------------------
         % Two-dimensional data
         %------------------------------------------------------------------
@@ -156,13 +156,13 @@ classdef test_plot_dnd < TestCase
             % Test all 2D plot methods produce a figure
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             methods = [...
                 T.methodsND_plot(:); T.methods2D_plot(:); ...
                 T.methodsND_plotOver(:); T.methods2D_plotOver(:); ...
                 T.methods2D_plotOverCurr(:)];
-            
+
             clear_figures()
             for i=1:numel(methods)
                 meth = methods{i};
@@ -170,6 +170,12 @@ classdef test_plot_dnd < TestCase
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h, 'matlab.graphics.primitive.Data'));
+                if isscalar(plot_h)
+                    assertEqualToTol(fig_h.UserData,obj.data2D);
+                else
+                    assertEqualToTol(fig_h.UserData{end},obj.data2D);
+                    assertEqual(numel(fig_h.UserData),numel(plot_h));
+                end
             end
         end
 
@@ -178,7 +184,7 @@ classdef test_plot_dnd < TestCase
             % Test all plot methods for 1D and 3D throw an error with 2D data
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             other_methods = [ ...
                 T.methods1D_plot(:); T.methods1D_plotOver(:); ...
@@ -194,7 +200,7 @@ classdef test_plot_dnd < TestCase
                     func2str(other_methods{i})));
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_d2d_plot2D_methods_work_with_array(obj)
             % Test that all 2D 'plot' methods plot arrays of data
@@ -211,17 +217,18 @@ classdef test_plot_dnd < TestCase
                 meth = methods{i};
                 [fig_h, axes_h, plot_h] = meth(data2D_arr);
                 all_fig_h = findobj(groot,'Type','Figure');
-                assertTrue(numel(all_fig_h)==1,'Did not overplot only')
+                assertTrue(isscalar(all_fig_h),'Did not overplot only')
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
                 assertEqual(numel(fig_h),1);
                 assertEqual(numel(axes_h),1);
                 assertEqual(numel(plot_h),2);
+                assertEqualToTol([fig_h.UserData{:}],data2D_arr);
             end
         end
-        
-        
+
+
         %------------------------------------------------------------------
         % One-dimensional plot methods
         %------------------------------------------------------------------
@@ -246,21 +253,26 @@ classdef test_plot_dnd < TestCase
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
+                if numel(plot_h) > 1
+                    assertEqualToTol(fig_h.UserData{end},obj.data1D);
+                else
+                    assertEqualToTol(fig_h.UserData,obj.data1D);
+                end
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_d1d_other_plot_methods_throw(obj)
             % Test all plot methods for 2D and 3D throw an error with 1D data
             genieplot.reset
             cleanupObj = onCleanup(@clear_figures);
-            
+
             T = obj.interface_tester;
             other_methods = [ ...
                 T.methods2D_plot(:); T.methods2D_plotOver(:); ...
                 T.methods2D_plotOverCurr(:); ...
                 T.methods3D_plot(:)];
-            
+
             clear_figures()
             for i=1:numel(other_methods)
                 assertExceptionThrown(...
@@ -270,7 +282,7 @@ classdef test_plot_dnd < TestCase
                     func2str(other_methods{i})));
             end
         end
-        
+
         %------------------------------------------------------------------
         function test_d1d_plot1D_methods_work_with_array(obj)
             % Test that all 1D 'plot' methods plot arrays of data
@@ -287,16 +299,33 @@ classdef test_plot_dnd < TestCase
                 meth = methods{i};
                 [fig_h, axes_h, plot_h] = meth(data1D_arr);
                 all_fig_h = findobj(groot,'Type','Figure');
-                assertTrue(numel(all_fig_h)==1,'Did not overplot only')
+                assertTrue(isscalar(all_fig_h),'Did not overplot only')
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
                 assertEqual(numel(fig_h),1);
                 assertEqual(numel(axes_h),1);
                 assertEqual(numel(plot_h),2);
+                assertEqualToTol([fig_h.UserData{:}],data1D_arr);
             end
         end
-        
+
+        function test_src_two_obj(obj)
+            clear_figures();
+            cleanupObj = onCleanup(@clear_figures);
+            plot(obj.data1D);
+            plotover(2*obj.data1D);
+            res = src(1);
+            assertEqual(res,[obj.data1D,2*obj.data1D]);
+        end
+        function test_src_one_obj(obj)
+            clear_figures();
+            cleanupObj = onCleanup(@clear_figures);
+            plot(obj.data1D);
+            res = src(1);
+            assertEqual(res,obj.data1D);
+        end
+
         %------------------------------------------------------------------
     end
 end

--- a/_test/test_sqw_class/test_plot_sqw.m
+++ b/_test/test_sqw_class/test_plot_sqw.m
@@ -167,17 +167,16 @@ classdef test_plot_sqw < TestCase
                 [fig_h, axes_h, plot_h] = meth(obj.data2D);
                 assertEqual(numel(fig_h.UserData),numel(plot_h));
                 if isscalar(plot_h)
-                  assertEqualToTol(fig_h.UserData,obj.data2D);                    
+                    assertEqualToTol(fig_h.UserData,obj.data2D);
                 else
-                  assertEqualToTol(fig_h.UserData{end},obj.data2D);
+                    assertEqualToTol(fig_h.UserData{end},obj.data2D);
+                    assertEqual(numel(fig_h.UserData),numel(plot_h));
                 end
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h, 'matlab.graphics.primitive.Data'));
             end
         end
-
-
 
         %------------------------------------------------------------------
         function test_sqw2D_other_plot_methods_throw(obj)
@@ -217,13 +216,14 @@ classdef test_plot_sqw < TestCase
                 meth = methods{i};
                 [fig_h, axes_h, plot_h] = meth(data2D_arr);
                 all_fig_h = findobj(groot,'Type','Figure');
-                assertTrue(numel(all_fig_h)==1,'Did not overplot only')
+                assertTrue(isscalar(all_fig_h),'Did not overplot only')
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
                 assertEqual(numel(fig_h),1);
                 assertEqual(numel(axes_h),1);
                 assertEqual(numel(plot_h),2);
+                assertEqualToTol([fig_h.UserData{:}],data2D_arr);
             end
         end
 
@@ -252,6 +252,11 @@ classdef test_plot_sqw < TestCase
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
+                if numel(plot_h) > 1
+                    assertEqualToTol(fig_h.UserData{end},obj.data1D);
+                else
+                    assertEqualToTol(fig_h.UserData,obj.data1D);
+                end
             end
         end
 
@@ -300,9 +305,26 @@ classdef test_plot_sqw < TestCase
                 assertEqual(numel(fig_h),1);
                 assertEqual(numel(axes_h),1);
                 assertEqual(numel(plot_h),2);
+                assertEqualToTol([fig_h.UserData{:}],data1D_arr);
             end
         end
 
+        %------------------------------------------------------------------
+        function test_src_two_obj(obj)
+            clear_figures();
+            cleanupObj = onCleanup(@clear_figures);
+            plot(obj.data1D);
+            plotover(2*obj.data1D);
+            res = src(1);
+            assertEqual(res,[obj.data1D,2*obj.data1D]);
+        end
+        function test_src_one_obj(obj)
+            clear_figures();
+            cleanupObj = onCleanup(@clear_figures);
+            plot(obj.data1D);
+            res = src(1);
+            assertEqual(res,obj.data1D);
+        end
         %------------------------------------------------------------------
     end
 end

--- a/_test/test_sqw_class/test_plot_sqw.m
+++ b/_test/test_sqw_class/test_plot_sqw.m
@@ -11,7 +11,7 @@ classdef test_plot_sqw < TestCase
     methods
         function obj = test_plot_sqw(varargin)
             obj = obj@TestCase('test_plot_sqw');
-            
+
             % Load example 1D, 2D, 3D, 4D sqw objects
             hp = horace_paths().test_common;    % common data location
 
@@ -19,7 +19,7 @@ classdef test_plot_sqw < TestCase
             sqw_2d_file = fullfile(hp, 'sqw_2d_1.sqw');
             sqw_3d_file = fullfile(hp, 'w3d_sqw.sqw');
             sqw_4d_file = fullfile(hp, 'sqw_4d.sqw');
-            
+
             obj.data1D = read_sqw(sqw_1d_file);
             obj.data2D = read_sqw(sqw_2d_file);
             obj.data3D = read_sqw(sqw_3d_file);
@@ -51,10 +51,10 @@ classdef test_plot_sqw < TestCase
                     'HORACE:graphics:invalid_argument', ...
                     sprintf('error for method number %d: %s',i, ...
                     func2str(all_methods{i})));
-                end
-                end
+            end
+        end
 
-        
+
         %------------------------------------------------------------------
         % Three-dimensional data
         %------------------------------------------------------------------
@@ -73,6 +73,7 @@ classdef test_plot_sqw < TestCase
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isstruct(plot_h));
+                assertTrue(isa(fig_h.UserData,'sqw'))
                 if i>1  % Must have cleared existing figure window and reused it
                     assertTrue(fig_h==fig_h_ref);
                 else
@@ -121,8 +122,8 @@ classdef test_plot_sqw < TestCase
                     'HORACE:graphics:invalid_argument', ...
                     sprintf('error for method number %d: %s',i, ...
                     func2str(methods{i})));
-                end
             end
+        end
 
 
         %------------------------------------------------------------------
@@ -135,19 +136,48 @@ classdef test_plot_sqw < TestCase
 
             T = obj.interface_tester;
             methods = [...
-                T.methodsND_plot(:); T.methods2D_plot(:); ...
-                T.methodsND_plotOver(:); T.methods2D_plotOver(:); ...
-                T.methods2D_plotOverCurr(:)];
+                T.methodsND_plot(:); T.methods2D_plot(:)];
 
             clear_figures()
             for i=1:numel(methods)
                 meth = methods{i};
                 [fig_h, axes_h, plot_h] = meth(obj.data2D);
+                assertEqualToTol(fig_h.UserData,obj.data2D);
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h, 'matlab.graphics.primitive.Data'));
-                end
             end
+        end
+
+        function test_sqw2D_overplot2D_methods_work(obj)
+            % Test all 2D plot methods produce a figure
+            genieplot.reset
+            cleanupObj = onCleanup(@clear_figures);
+
+            T = obj.interface_tester;
+            methods = [
+                T.methodsND_plotOver(:); T.methods2D_plotOver(:); ...
+                T.methods2D_plotOverCurr(:)];
+
+            clear_figures()
+            meth = T.methods2D_plot{1};
+            meth(obj.data2D);
+            for i=1:numel(methods)
+                meth = methods{i};
+                [fig_h, axes_h, plot_h] = meth(obj.data2D);
+                assertEqual(numel(fig_h.UserData),numel(plot_h));
+                if isscalar(plot_h)
+                  assertEqualToTol(fig_h.UserData,obj.data2D);                    
+                else
+                  assertEqualToTol(fig_h.UserData{end},obj.data2D);
+                end
+                assertTrue(isa(fig_h, 'matlab.ui.Figure'));
+                assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
+                assertTrue(isa(plot_h, 'matlab.graphics.primitive.Data'));
+            end
+        end
+
+
 
         %------------------------------------------------------------------
         function test_sqw2D_other_plot_methods_throw(obj)
@@ -222,9 +252,9 @@ classdef test_plot_sqw < TestCase
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
-                end
             end
-        
+        end
+
         %------------------------------------------------------------------
         function test_sqw1D_other_plot_methods_throw(obj)
             % Test all plot methods for 2D and 3D throw an error with 1D data
@@ -236,7 +266,7 @@ classdef test_plot_sqw < TestCase
                 T.methods2D_plot(:); T.methods2D_plotOver(:); ...
                 T.methods2D_plotOverCurr(:); ...
                 T.methods3D_plot(:)];
-            
+
             clear_figures()
             for i=1:numel(other_methods)
                 assertExceptionThrown(...
@@ -244,8 +274,8 @@ classdef test_plot_sqw < TestCase
                     'HORACE:graphics:invalid_argument', ...
                     sprintf('error for method number %d: %s',i, ...
                     func2str(other_methods{i})));
-                end
-                end
+            end
+        end
 
         %------------------------------------------------------------------
         function test_sqw1D_plot1D_methods_work_with_array(obj)
@@ -263,19 +293,19 @@ classdef test_plot_sqw < TestCase
                 meth = methods{i};
                 [fig_h, axes_h, plot_h] = meth(data1D_arr);
                 all_fig_h = findobj(groot,'Type','Figure');
-                assertTrue(numel(all_fig_h)==1,'Did not overplot only')
+                assertTrue(isscalar(all_fig_h),'Did not overplot only')
                 assertTrue(isa(fig_h, 'matlab.ui.Figure'));
                 assertTrue(isa(axes_h, 'matlab.graphics.axis.Axes'));
                 assertTrue(isa(plot_h,'matlab.graphics.primitive.Data'));
                 assertEqual(numel(fig_h),1);
                 assertEqual(numel(axes_h),1);
                 assertEqual(numel(plot_h),2);
-                end
-            end
-
-        %------------------------------------------------------------------
             end
         end
+
+        %------------------------------------------------------------------
+    end
+end
 
 
 %--------------------------------------------------------------------------
@@ -286,8 +316,8 @@ function clear_figures
 fig_handles = findobj(0, 'Type', 'figure');
 if ~isempty(fig_handles)
     delete(fig_handles)
-                end
-            end
+end
+end
 
 %--------------------------------------------------------------------------
 function function_caller(function_handle, varargin)
@@ -295,4 +325,4 @@ function function_caller(function_handle, varargin)
 % Wraps the method or function handle so that the call can be run as an argument
 % in e.g. assertErrorThrown within a loop that loops over function handles
 function_handle(varargin{:});
-            end
+end

--- a/herbert_core/graphics/plot_interfaces/data_plot_interface.m
+++ b/herbert_core/graphics/plot_interfaces/data_plot_interface.m
@@ -312,30 +312,37 @@ classdef (Abstract=true) data_plot_interface
             %          modified to contain information, stored in
             %          obj.obj_holder_ property.
             %
-            if config_store.instance().get_value('hor_config','store_src_in_plots')
-                if isa(obj,'IX_dataset')
-                    if numel(obj)>1
-                        src = num2cell(obj);
+            if ~config_store.instance().get_value('hor_config','store_src_in_plots')
+                return
+            end
+            % if source was not set on top level, it is set at
+            % IX_dataset level
+            if numel(obj)>1
+                src = cell(1,numel(obj));
+                for i=1:numel(obj)
+                    if isempty(obj(i).obj_holder_)
+                        src{i} = obj(i);
                     else
-                        src = obj;
-                    end                    
-                else
-                    if numel(obj)>1
-                        src = arrayfun(@(x)(x.obj_holder_),obj,'UniformOutput',false);
-                    else
-                        src = obj.obj_holder_;
-                    end
-                end                
-                if isempty(fig_h.UserData)
-                    fig_h.UserData = src;
-                else
-                    if new_axes
-                        fig_h.UserData = src;
-                    else
-                        fig_h.UserData = concat_cells_(fig_h.UserData,src);
+                        src{i} = obj(i).obj_holder_;
                     end
                 end
+            else
+                src = obj.obj_holder_;
+                if isempty(src)
+                    src = obj;
+                end
             end
+            % store source data in figure field
+            if isempty(fig_h.UserData)
+                fig_h.UserData = src;
+            else
+                if new_axes
+                    fig_h.UserData = src;
+                else
+                    fig_h.UserData = concat_cells_(fig_h.UserData,src);
+                end
+            end
+
         end
     end
 end

--- a/herbert_core/graphics/plot_interfaces/data_plot_interface.m
+++ b/herbert_core/graphics/plot_interfaces/data_plot_interface.m
@@ -23,16 +23,18 @@ classdef (Abstract=true) data_plot_interface
     % inherits a similar plot interface class, sqw_plot_interface, which also
     % inherits data_plot_interface and defines particular implementations of the
     % plot methods as defined for d1d, d2d and d3d objects.
-    
-    properties
+
+    properties(Access=protected)
+        obj_holder_ = []; % internal property which stores top level object
+        % to plot;
     end
-    
+
     methods(Abstract)
         % This method is needed to enable the generic plot and plot_over methods
         % to work
         nd = dimensions();
     end
-    
+
     %---------------------------------------------------------------------------
     % Plotting methods
     %---------------------------------------------------------------------------
@@ -67,7 +69,7 @@ classdef (Abstract=true) data_plot_interface
             % objects.
             varargout = throw_unavailable_(w, 'dp', varargin{:});
         end
-        
+
         %-----------------------------------------------------------------------
         % OVERPLOT
         function varargout = pd(w, varargin)
@@ -136,8 +138,8 @@ classdef (Abstract=true) data_plot_interface
             % Fails if dataset to overplot is missing.
             varargout = throw_unavailable_(w, 'ppoc', varargin{:});
         end
-        
-        
+
+
         %-----------------------------------------------------------------------
         % 2D plotting functions
         %-----------------------------------------------------------------------
@@ -156,7 +158,7 @@ classdef (Abstract=true) data_plot_interface
             % plot or plots colour scale.
             varargout = throw_unavailable_(w, 'ds2', varargin{:});
         end
-        
+
         %-----------------------------------------------------------------------
         % OVERPLOT
         function varargout = pa(w, varargin)
@@ -192,8 +194,8 @@ classdef (Abstract=true) data_plot_interface
             % Fails if dataset to overplot is missing.
             varargout = throw_unavailable_(w, 'ps2oc', varargin{:});
         end
-        
-        
+
+
         %-----------------------------------------------------------------------
         % 3D plotting functions
         %-----------------------------------------------------------------------
@@ -201,14 +203,14 @@ classdef (Abstract=true) data_plot_interface
             % Plots 3D object using sliceomatic.
             varargout = throw_unavailable_(w, 'sliceomatic', varargin{:});
         end
-        
+
         function varargout = sliceomatic_overview(w, varargin)
             % Plots 3D object using sliceomatic with the view straight down one
             % of the axes.
             varargout = throw_unavailable_(w,'sliceomatic_overview', varargin{:});
         end
-        
-        
+
+
         %-----------------------------------------------------------------------
         % Generic plotting interfaces for N-D objects
         %-----------------------------------------------------------------------
@@ -239,9 +241,9 @@ classdef (Abstract=true) data_plot_interface
             %
             %   >> sliceomatic(w)       % 3D dataset
             %   >> sliceomatic(w, ...)
-            
+
             nd = w(1).dimensions();
-            
+
             varargout = cell(1, nargout);   % output only if requested
             switch nd
                 case 1
@@ -256,7 +258,7 @@ classdef (Abstract=true) data_plot_interface
                         '%d-dimensional objects'], nd)
             end
         end
-        
+
         function varargout = plotover(w,varargin)
             % Overplot a 1D, 2D or 3D object or array of objects on an existing plot
             %
@@ -276,9 +278,9 @@ classdef (Abstract=true) data_plot_interface
             %
             %   >> pa(w)                % 2D dataset
             %   >> pa(w,...)
-            
+
             nd = w(1).dimensions();
-            
+
             varargout = cell(1, nargout);   % output only if requested
             switch nd
                 case 1

--- a/herbert_core/graphics/plot_interfaces/data_plot_interface.m
+++ b/herbert_core/graphics/plot_interfaces/data_plot_interface.m
@@ -293,6 +293,50 @@ classdef (Abstract=true) data_plot_interface
                         '%d-dimensional objects'], nd)
             end
         end
+
+        function fig_h = add_source_data_to_fig_handle(obj,fig_h,new_axes)
+            % Add source data present in obj.obj_holder_ property to
+            % the input figure.
+            % Inputs:
+            % obj   -- an instance of object inheriting from data_plot_iterface
+            % fig_h -- MATLAB graphics handle
+            % new_axes
+            %       -- true:  plot new data, so previous source
+            %                 should be ignorted
+            %          false: Overplot on existing axes on the target figure,
+            %                 if they are available, so previous source is
+            %                 kept
+            %
+            % Result:
+            % fig_h -- input graphic handle with fig_h.UserData property
+            %          modified to contain information, stored in
+            %          obj.obj_holder_ property.
+            %
+            if config_store.instance().get_value('hor_config','store_src_in_plots')
+                if isa(obj,'IX_dataset')
+                    if numel(obj)>1
+                        src = num2cell(obj);
+                    else
+                        src = obj;
+                    end                    
+                else
+                    if numel(obj)>1
+                        src = arrayfun(@(x)(x.obj_holder_),obj,'UniformOutput',false);
+                    else
+                        src = obj.obj_holder_;
+                    end
+                end                
+                if isempty(fig_h.UserData)
+                    fig_h.UserData = src;
+                else
+                    if new_axes
+                        fig_h.UserData = src;
+                    else
+                        fig_h.UserData = concat_cells_(fig_h.UserData,src);
+                    end
+                end
+            end
+        end
     end
 end
 
@@ -300,9 +344,18 @@ end
 %---------------------------------------------------------------------------
 % Utility functions
 %---------------------------------------------------------------------------
+function data = concat_cells_(data,src)
+% input data is always cell
+if ~iscell(src)
+    src = {src};
+end
+if ~iscell(data)
+    data = {data};
+end
+data = [data(:);src(:)]';
+end
 function varargout = throw_unavailable_(obj, method, varargin)
 % Throw method unavailable
-varargout = cell(1, nargout);   % output only if requested
 error(['HORACE:',class(obj),':invalid_argument'],...
     'Method ''%s'' is not available for objects of class ''%s''', ...
     method, class(obj))

--- a/herbert_core/graphics/plot_interfaces/data_plot_interface.m
+++ b/herbert_core/graphics/plot_interfaces/data_plot_interface.m
@@ -26,7 +26,7 @@ classdef (Abstract=true) data_plot_interface
 
     properties(Access=protected)
         obj_holder_ = []; % internal property which stores top level object
-        % to plot;
+        % to attach to the plotted figure
     end
 
     methods(Abstract)

--- a/herbert_core/graphics/plot_interfaces/dnd_plot_interface.m
+++ b/herbert_core/graphics/plot_interfaces/dnd_plot_interface.m
@@ -48,7 +48,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'dd')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'dd');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -72,7 +72,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'de')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'de');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -96,7 +96,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'dh')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'dh');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -119,7 +119,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'dl')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'dl');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -143,7 +143,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'dm')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'dm');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -168,7 +168,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'dp')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'dp');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -195,7 +195,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'pd')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'pd');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -215,7 +215,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'pdoc')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'pdoc');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -239,7 +239,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'pe')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'pe');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -259,7 +259,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'peoc')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'peoc');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -283,7 +283,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'ph')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'ph');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -303,7 +303,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'phoc')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'phoc');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -326,7 +326,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'pl')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'pl');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -345,7 +345,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'ploc')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'ploc');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -368,7 +368,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'pm')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'pm');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -387,7 +387,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'pmoc')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'pmoc');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -411,7 +411,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'pp')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'pp');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -431,7 +431,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 1;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'ppoc')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'ppoc');
 
             genieplot.set('default_fig_name', 'Horace 1D plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -463,7 +463,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 2;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'da')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'da');
 
             genieplot.set('default_fig_name', 'Horace area plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -496,7 +496,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 2;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'ds')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'ds');
 
             genieplot.set('default_fig_name', 'Horace surface plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -544,7 +544,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 2;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'ds2')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'ds2');
 
             genieplot.set('default_fig_name', 'Horace surface plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -574,7 +574,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 2;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'pa')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'pa');
 
             genieplot.set('default_fig_name', 'Horace area plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -594,7 +594,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 2;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'poc')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'poc');
 
             genieplot.set('default_fig_name', 'Horace area plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -617,7 +617,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 2;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'ps')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'ps');
 
             genieplot.set('default_fig_name', 'Horace surface plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -637,7 +637,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 2;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'psoc')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'psoc');
 
             genieplot.set('default_fig_name', 'Horace surface plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -662,7 +662,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 2;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'ps2')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'ps2');
 
             genieplot.set('default_fig_name', 'Horace surface plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -697,7 +697,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 2;
             scalar_only = false;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'ps2oc')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'ps2oc');
 
             genieplot.set('default_fig_name', 'Horace surface plot');
             cleanup = onCleanup(@()genieplot.set('default_fig_name', []));
@@ -741,7 +741,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 3;
             scalar_only = true;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'sliceomatic')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'sliceomatic');
 
             [args, adjust_aspect] = dnd_plot_interface.strip_aspect_option(varargin{:});
             
@@ -794,7 +794,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
             
             ndim = 3;
             scalar_only = true;
-            dnd_plot_interface.check_data (w, ndim, scalar_only, 'sliceomatic')
+            w = dnd_plot_interface.check_data (w, ndim, scalar_only, 'sliceomatic');
             
             [args, adjust_aspect] = dnd_plot_interface.strip_aspect_option(varargin{:});
             
@@ -826,7 +826,7 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
         % being called, with all the possible hard to track errors that may
         % occur.
         %-----------------------------------------------------------------------
-        function check_data (w, ndim, scalar_only, func_name)
+        function w = check_data (w, ndim, scalar_only, func_name)
             % Check that the incoming data has the correct dimensionality, and
             % print an error message if not.
             %
@@ -851,6 +851,9 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
                 end
                 error('HORACE:graphics:invalid_argument', ...
                     ['Plot method ''', func_name, ''' only works for ', string], ndim)
+            end
+            if isempty(w.obj_holder_)
+                w.obj_holder_ = w;
             end
             
         end

--- a/herbert_core/graphics/plot_interfaces/dnd_plot_interface.m
+++ b/herbert_core/graphics/plot_interfaces/dnd_plot_interface.m
@@ -852,10 +852,11 @@ classdef (Abstract=true) dnd_plot_interface < data_plot_interface
                 error('HORACE:graphics:invalid_argument', ...
                     ['Plot method ''', func_name, ''' only works for ', string], ndim)
             end
-            if isempty(w.obj_holder_)
-                w.obj_holder_ = w;
-            end
-            
+            for i=1:numel(w)
+                if isempty(w(i).obj_holder_)
+                    w(i).obj_holder_ = w(i);
+                end
+            end           
         end
         
         %-----------------------------------------------------------------------

--- a/herbert_core/graphics/plot_interfaces/sqw_plot_interface.m
+++ b/herbert_core/graphics/plot_interfaces/sqw_plot_interface.m
@@ -34,7 +34,6 @@ classdef (Abstract=true) sqw_plot_interface < data_plot_interface
             %
             % Return figure, axes and plot handles:
             %   >> [fig_handle, axes_handle, plot_handle] = dd(w,...)
-            
             data = sqw_plot_interface.convert_to_dnd(w);
             varargout = cell(1, nargout);   % output only if requested
             [varargout{:}] = dd(data, varargin{:});
@@ -621,6 +620,9 @@ classdef (Abstract=true) sqw_plot_interface < data_plot_interface
                 error('HORACE:graphics:invalid_argument', ...
                     ['Cannot plot an array of sqw objects with different ', ...
                     'images dimensionality'])
+            end
+            for i=1:numel(w)
+                data(i).obj_holder_ = w(i);
             end
         end
     end

--- a/herbert_core/graphics/private/get_figure_handle.m
+++ b/herbert_core/graphics/private/get_figure_handle.m
@@ -112,7 +112,7 @@ elseif is_string(fig) || (iscell(fig) && all(cellfun(@is_string, fig(:))))
         fig = {fig};    % for convenience of code simplicity
     end
     fig = strtrim(fig); % strim leading and trailing whitespace
-    if numel(fig)==1 && numel(fig{1})>2 && strncmpi(fig{1}, '-all', numel(fig{1}))
+    if isscalar(fig) && numel(fig{1})>2 && strncmpi(fig{1}, '-all', numel(fig{1}))
         % Return handles for all figures
         fig_handle = findobj(0, 'Type', 'figure');
     else

--- a/herbert_core/graphics/src.m
+++ b/herbert_core/graphics/src.m
@@ -31,6 +31,6 @@ if iscell(obj)
     class_name = class(obj{1});
     all_same_class = all(cellfun(@(x)isa(x,class_name),obj));
     if all_same_class
-        obj = cell2arr(obj,true);
+        obj = [obj{:}];
     end
 end

--- a/herbert_core/graphics/src.m
+++ b/herbert_core/graphics/src.m
@@ -1,0 +1,36 @@
+function obj = src(fig)
+% Extract the object which is the source of the figure
+%
+%   >>obj =  src         % get sqw/dnd/IX object attached to current figure
+%   >>obj =  src(fig)    %  get sqw/dnd/IX object attached to given figure
+%
+% Input:
+% ------
+%   fig         Figure name *OR* figure number *OR* figure handle
+%
+%               An empty character string or one containing just whitespace
+%              is a valid name: the name is '' i.e. the empty string.
+%
+%             If fig is not given, or is an empty argument apart from an
+%              empty character string (which is a valid name, see above),
+%              the function returns the figure handle for the current
+%              figure, if one exists.
+
+
+% Determine the figure handle - ensuring there is one and only one figure
+% indicated by input argument fig (throws an error if otherwise)
+if ~exist('fig', 'var')
+    fig_handle = get_figure_handle('-single');  % current figure, if it exists
+else
+    fig_handle = get_figure_handle(fig, '-single');
+end
+
+% get user data
+obj = fig_handle.UserData;
+if iscell(obj)
+    class_name = class(obj{1});
+    all_same_class = all(cellfun(@(x)isa(x,class_name),obj));
+    if all_same_class
+        obj = cell2arr(obj,true);
+    end
+end

--- a/herbert_core/utilities/classes/@IX_dataset_1d/IX_dataset_1d.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/IX_dataset_1d.m
@@ -43,6 +43,7 @@ classdef IX_dataset_1d < IX_data_1d & data_plot_interface
         %------------------------------------------------------------------
         function obj= IX_dataset_1d(varargin)
             obj = obj@IX_data_1d(varargin{:});
+           
         end
         %------------------------------------------------------------------
         % Actual plotting interface:

--- a/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_oned.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_oned.m
@@ -236,17 +236,4 @@ end
 % Get figure, axes and plot handles
 [fig_h, axes_h, plot_h] = genie_figure_all_handles;
 
-if config_store.instance().get_value('hor_config','store_src_in_plots')
-    parent_obj = w.obj_holder_;
-    if isempty(parent_obj)
-        parent_obj = w;
-    end
-    if isempty(fig_h.UserData)
-        fig_h.UserData = parent_obj;
-    elseif iscell(fig_h.UserData)
-        fig_h.UserData{end+1} = parent_obj;
-    else
-        fig_h.UserData = {fig_h.UserData,[]};
-        fig_h.UserData{2} = parent_obj;
-    end
-end
+fig_h = w.add_source_data_to_fig_handle(fig_h,new_axes);

--- a/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_oned.m
+++ b/herbert_core/utilities/classes/@IX_dataset_1d/private/plot_oned.m
@@ -235,3 +235,18 @@ end
 
 % Get figure, axes and plot handles
 [fig_h, axes_h, plot_h] = genie_figure_all_handles;
+
+if config_store.instance().get_value('hor_config','store_src_in_plots')
+    parent_obj = w.obj_holder_;
+    if isempty(parent_obj)
+        parent_obj = w;
+    end
+    if isempty(fig_h.UserData)
+        fig_h.UserData = parent_obj;
+    elseif iscell(fig_h.UserData)
+        fig_h.UserData{end+1} = parent_obj;
+    else
+        fig_h.UserData = {fig_h.UserData,[]};
+        fig_h.UserData{2} = parent_obj;
+    end
+end

--- a/herbert_core/utilities/classes/@IX_dataset_2d/private/plot_twod.m
+++ b/herbert_core/utilities/classes/@IX_dataset_2d/private/plot_twod.m
@@ -297,9 +297,17 @@ if config_store.instance().get_value('hor_config','store_src_in_plots')
     if isempty(fig_h.UserData)
         fig_h.UserData = w.obj_holder_;
     elseif iscell(fig_h.UserData)
-        fig_h.UserData{end+1} = w.obj_holder_;
+        if new_axes
+            fig_h.UserData = w.obj_holder_;
+        else
+            fig_h.UserData{end+1} = w.obj_holder_;
+        end
     else
-        fig_h.UserData = {fig_h.UserData,[]};
-        fig_h.UserData{2} = w.obj_holder_;
+        if new_axes
+            fig_h.UserData = w.obj_holder_;
+        else
+            fig_h.UserData = {fig_h.UserData,[]};
+            fig_h.UserData{2} = w.obj_holder_;
+        end
     end
 end

--- a/herbert_core/utilities/classes/@IX_dataset_2d/private/plot_twod.m
+++ b/herbert_core/utilities/classes/@IX_dataset_2d/private/plot_twod.m
@@ -292,3 +292,14 @@ end
 
 % Get figure, axes and plot handles
 [fig_h, axes_h, plot_h] = genie_figure_all_handles;
+
+if config_store.instance().get_value('hor_config','store_src_in_plots')
+    if isempty(fig_h.UserData)
+        fig_h.UserData = w.obj_holder_;
+    elseif iscell(fig_h.UserData)
+        fig_h.UserData{end+1} = w.obj_holder_;
+    else
+        fig_h.UserData = {fig_h.UserData,[]};
+        fig_h.UserData{2} = w.obj_holder_;
+    end
+end

--- a/herbert_core/utilities/classes/@IX_dataset_2d/private/plot_twod.m
+++ b/herbert_core/utilities/classes/@IX_dataset_2d/private/plot_twod.m
@@ -293,21 +293,4 @@ end
 % Get figure, axes and plot handles
 [fig_h, axes_h, plot_h] = genie_figure_all_handles;
 
-if config_store.instance().get_value('hor_config','store_src_in_plots')
-    if isempty(fig_h.UserData)
-        fig_h.UserData = w.obj_holder_;
-    elseif iscell(fig_h.UserData)
-        if new_axes
-            fig_h.UserData = w.obj_holder_;
-        else
-            fig_h.UserData{end+1} = w.obj_holder_;
-        end
-    else
-        if new_axes
-            fig_h.UserData = w.obj_holder_;
-        else
-            fig_h.UserData = {fig_h.UserData,[]};
-            fig_h.UserData{2} = w.obj_holder_;
-        end
-    end
-end
+fig_h = w.add_source_data_to_fig_handle(fig_h,new_axes);

--- a/herbert_core/utilities/classes/@IX_dataset_3d/sliceomatic.m
+++ b/herbert_core/utilities/classes/@IX_dataset_3d/sliceomatic.m
@@ -114,7 +114,9 @@ plot_data = sliceomatic(ux, uy, uz, signal, xcaption, ycaption, zcaption, ...
 % Return the figure to being a genie_figure.
 % Sliceomatic resets the figure window which removes the 'keep' / 'make current'
 % menu items and resets all the figure properties.
-genie_figure_create(gcf, fig_name)
+fh = gcf;
+genie_figure_create(fh, fig_name)
+fh.UserData = w.obj_holder_;
 
 % Resize the box containing the data
 set(gca, 'Position', [0.2, 0.2, 0.6, 0.6]); 

--- a/herbert_core/utilities/classes/@IX_dataset_3d/sliceomatic.m
+++ b/herbert_core/utilities/classes/@IX_dataset_3d/sliceomatic.m
@@ -115,8 +115,8 @@ plot_data = sliceomatic(ux, uy, uz, signal, xcaption, ycaption, zcaption, ...
 % Sliceomatic resets the figure window which removes the 'keep' / 'make current'
 % menu items and resets all the figure properties.
 fh = gcf;
-genie_figure_create(fh, fig_name)
-fh.UserData = w.obj_holder_;
+fh = genie_figure_create(fh, fig_name);
+fh = w.add_source_data_to_fig_handle(fh,false);
 
 % Resize the box containing the data
 set(gca, 'Position', [0.2, 0.2, 0.6, 0.6]); 

--- a/herbert_core/utilities/maths/equal_to_tol.m
+++ b/herbert_core/utilities/maths/equal_to_tol.m
@@ -165,11 +165,11 @@ function equal_to_tol_private(a,b,opt,present)
 [a,b] = convertStringsToChars(a,b);
 [is,mess] = eq_to_tol_type_equal(a,b,opt.name_a,opt.name_b);
 if ~is
-     error('HERBERT:equal_to_tol:inputs_mismatch',mess);
+    error('HERBERT:equal_to_tol:inputs_mismatch',mess);
 end
 [is,mess] = eq_to_tol_shape_equal(a,b,opt.name_a,opt.name_b,opt.ignore_str);
 if ~is
-     error('HERBERT:equal_to_tol:inputs_mismatch',mess);
+    error('HERBERT:equal_to_tol:inputs_mismatch',mess);
 end
 if opt.ignore_str && (iscellstr(a)||ischar(a)) && (iscellstr(b)||ischar(b))
     % Case of strings and cell array of strings if they are to be ignored
@@ -488,11 +488,24 @@ elseif abs_tol == 0
 
 else
     diff = abs(a-b);
+    rldf = rel_diff(a,b,diff);
     [max_delta_abs, ind_abs] = max(diff);
-    [max_delta_rel, ind_rel] = max(diff./max(abs(a),abs(b)));
+    [max_delta_rel, ind_rel] = max(rldf);
 
     if max_delta_abs > abs_tol && max_delta_rel > rel_tol
         % Absolute or relative tolerance must be satisfied
+        if ind_abs ~= ind_rel
+            accepted = (rldf < rel_tol | diff < abs_tol);
+            if ~all(accepted(:))
+                error('HERBERT:equal_to_tol:inputs_mismatch',[...
+                    '%s and %s: Relative and absolute tolerance failure:\n' ...
+                    ' max. error = %s (absolute) at element %s\n' ...
+                    ' max. error = %s (relative) at element %s'],...
+                    name_a,name_b, ...
+                    num2str(max_delta_abs),['(',arraystr(sz,ind_abs),')'], ...
+                    num2str(max_delta_rel),['(',arraystr(sz,ind_rel),')']);
+            end
+        end
         if max_delta_rel/rel_tol > max_delta_abs/abs_tol
             error('HERBERT:equal_to_tol:inputs_mismatch',...
                 '%s and %s: Relative and absolute tolerance failure; max. error = %s (relative) at element %s',...
@@ -523,8 +536,12 @@ end
 
 end
 
-function rel = rel_diff(a, b)
+function rel = rel_diff(a, b,diff)
 
-rel = abs(a-b)./max(abs(a),abs(b));
+if nargin == 2
+    rel = abs(a-b)./max(abs(a),abs(b));
+else
+    rel = diff./max(abs(a),abs(b));
+end
 
 end

--- a/horace_core/configuration/@hor_config/hor_config.m
+++ b/horace_core/configuration/@hor_config/hor_config.m
@@ -32,6 +32,9 @@ classdef hor_config < config_base
     %   use_mex           - Use mex files for time-consuming operation, if available
     %   delete_tmp        - Automatically delete temporary files after generating sqw files
     %   working_directory - The folder to write tmp files.
+    %   store_src_in_plots
+    %                     - if True, each figure stores in fig.UserData
+    %                       field list of objects, the figure displays.
     %   --
     %   hpc_config        - helper/compatibility property to access high
     %                       performance computing settings. Use "hpc_config"
@@ -96,6 +99,9 @@ classdef hor_config < config_base
         % directory)
         working_directory;
 
+        % if true, plotted figures contain in their fig.UserData field list
+        % of object the figure displays
+        store_src_in_plots;
         % testing and debugging option -- fail if mex can not be used
         % By default if mex file fails, program tries to use Matlab, but
         % if this option is set to true, the whole operation may fail.
@@ -154,6 +160,7 @@ classdef hor_config < config_base
 
         force_mex_if_use_mex_ = false;
         log_level_ = 1;
+        store_src_in_plots_ = true;
         init_tests_ = false;
         spe_file_en_transf_field_width_ = 10;
     end
@@ -168,6 +175,7 @@ classdef hor_config < config_base
             'ignore_inf', ...
             'use_mex',...
             'delete_tmp', ...
+            'store_src_in_plots',...
             'force_mex_if_use_mex', ...
             'log_level', ...
             'init_tests'}
@@ -214,6 +222,10 @@ classdef hor_config < config_base
             use = get_or_restore_field(obj,'use_mex');
         end
 
+        function do = get.store_src_in_plots(obj)
+            do = get_or_restore_field(obj,'store_src_in_plots');
+        end
+
         function force = get.force_mex_if_use_mex(obj)
             force = get_or_restore_field(obj,'force_mex_if_use_mex');
         end
@@ -251,7 +263,7 @@ classdef hor_config < config_base
         function parcc = get.parallel_config(~)
             parcc = parallel_config();
         end
-        
+
 
         %-----------------------------------------------------------------
         % overloaded setters
@@ -324,7 +336,7 @@ classdef hor_config < config_base
                     config_store.instance().store_config('hpc_config','combine_sqw_using','matlab');
                 end
                 if ~can_use_custom_mpi
-                    pc = parallel_config;
+                    pc = parallel_config();
                     if ismember(pc.parallel_cluster,{'mpiexec_mpi','slurm_mpi'})
                         pc.parallel_cluster = 'herbert';
                     end
@@ -332,7 +344,6 @@ classdef hor_config < config_base
 
             end
             config_store.instance().store_config(obj,'use_mex',use);
-
         end
 
         function obj=set.init_tests(obj,val)
@@ -352,9 +363,14 @@ classdef hor_config < config_base
             del = val>0;
             config_store.instance().store_config(obj,'delete_tmp',del);
         end
+        function obj = set.store_src_in_plots(obj,val)
+            do = val>0;
+            config_store.instance().store_config(obj,'store_src_in_plots',do);
+        end
+
 
         function obj = set.working_directory(obj,val)
-            hc = parallel_config;
+            hc = parallel_config();
             hc.working_directory = val;
         end
 

--- a/horace_core/sqw/@DnDBase/private/equal_to_tol_single_.m
+++ b/horace_core/sqw/@DnDBase/private/equal_to_tol_single_.m
@@ -33,11 +33,7 @@ for i=1:numel(flds)
     if ignore_str && istext(tmp1) && istext(tmp2)
         continue;
     end
-    if ismember(flds{i},{'s','e'}) % compare signal and error as single values
-        % regardless of their actual accuracy. this is what actually matter
-        tmp1 = single(tmp1);
-        tmp2 = single(tmp2);
-    end
+
     [iseq,mess] = equal_to_tol (tmp1 , tmp2, lopt,varargin{:});
     if ~iseq
         return;

--- a/horace_core/sqw/@d1d/IX_dataset_1d.m
+++ b/horace_core/sqw/@d1d/IX_dataset_1d.m
@@ -24,6 +24,5 @@ for i=1:numel(wout)
     err(nopix)=0;
 
     wout(i) = IX_dataset_1d (title_squeeze(title_main), signal, err, s_axis, w(i).p{1}, x_axis, true);
+    wout(i).obj_holder_ = w(i).obj_holder_;
 end
-
-

--- a/horace_core/sqw/@d2d/IX_dataset_2d.m
+++ b/horace_core/sqw/@d2d/IX_dataset_2d.m
@@ -34,4 +34,5 @@ for i=1:numel(w)
         wout(i) = IX_dataset_2d (title_squeeze(title_main), signal, err,...
             s_axis, w(i).p{1}, axis_1, true, w(i).p{2}, axis_2, true);
     end
+    wout(i).obj_holder_ = w(i).obj_holder_l;
 end

--- a/horace_core/sqw/@d2d/IX_dataset_2d.m
+++ b/horace_core/sqw/@d2d/IX_dataset_2d.m
@@ -34,5 +34,5 @@ for i=1:numel(w)
         wout(i) = IX_dataset_2d (title_squeeze(title_main), signal, err,...
             s_axis, w(i).p{1}, axis_1, true, w(i).p{2}, axis_2, true);
     end
-    wout(i).obj_holder_ = w(i).obj_holder_l;
+    wout(i).obj_holder_ = w(i).obj_holder_;
 end

--- a/horace_core/sqw/@d3d/IX_dataset_3d.m
+++ b/horace_core/sqw/@d3d/IX_dataset_3d.m
@@ -42,5 +42,6 @@ for i=1:numel(w)
     wout(i) = IX_dataset_3d (title_squeeze(title_main), signal, err, s_axis,...
         p{1}, axis_1, true, p{2}, axis_2, true, p{3}, axis_3, true);
 
+    wout(i).obj_holder_ = w(i).obj_holder_;
 end
 wout=reshape(wout,size(w));


### PR DESCRIPTION
solves Re #1926 


Every plot command attaches object beeing ploted to the figure displaying this object. `src` command (similar to `meta`, works on figure num or directly the handle), extracts plotted objects and provides them to users for further operations. 

The features is controlled by `hor_config.store_src_in_plots` propertiey and may be disabled by putting this property to `false`.

Changes to documentation describinbg this feature are placed in separate branch `1926_a_obj_in_figs_doc` (PR #1928)