### PR TITLE
cleaning-up `obj_lookup`

### DIFF
--- a/herbert_core/utilities/classes/@object_lookup/object_elements.m
+++ b/herbert_core/utilities/classes/@object_lookup/object_elements.m
@@ -6,22 +6,22 @@ function A = object_elements (obj, varargin)
 %
 % Input:
 % ------
-%   obj         object_lookup object containing one or more object arrays
+%   obj        object_lookup object containing one or more object arrays
 %
-%   iarray      Scalar index of the original object array from the
+%   iarray     Scalar index of the original object array from the
 %              cell array of object arrays from which the object lookup
 %              was created.
-%               If there was only one object array, then iarray is not
+%              If there was only one object array, then iarray is not
 %              necessary (as it assumed iarray=1)
 %
-%   ind         Array containing indices of objects in the original
+%   ind        Array containing indices of objects in the original
 %              object array referred to by iarray, from which to extract
 %              elements. min(ind(:))>=1, max(ind(:))<=number of objects
 %              in the object array selected by iarray
 %
 % Output:
 % -------
-%   A           Object array obtained by indexing elements ind from the
+%   A          Object array obtained by indexing elements ind from the
 %              original array corresponding to index iarray
 
 

--- a/herbert_core/utilities/classes/@object_lookup/object_lookup.m
+++ b/herbert_core/utilities/classes/@object_lookup/object_lookup.m
@@ -573,7 +573,7 @@ classdef object_lookup < serializable
             end
             [~, sorted_idx] = sort(object_hashes);
             obj.object_store_ = obj.object_store_(sorted_idx);
-            [present, inverse_idx] = ismember(1:Nobj, sorted_idx);
+            [~, inverse_idx] = ismember(1:Nobj, sorted_idx);
 
             for ii=1:numel(obj.indx)
                 for jj=1:numel(obj.indx{ii})

--- a/herbert_core/utilities/classes/@object_lookup/object_lookup.m
+++ b/herbert_core/utilities/classes/@object_lookup/object_lookup.m
@@ -445,7 +445,6 @@ classdef object_lookup < serializable
             end
         end
 
-
         function obj = set.indx (obj, val)
             % Set index arrays into the object_store
             %
@@ -488,7 +487,6 @@ classdef object_lookup < serializable
                 obj = obj.check_combo_arg();
             end
         end
-
 
         function obj = set.sz (obj, val)
             % Set the array sizes for the object arrays in the object_store
@@ -566,6 +564,9 @@ classdef object_lookup < serializable
 
         function obj = sort(obj)
             Nobj = numel(obj.object_store_);
+            if Nobj==0
+                return;
+            end
             object_hashes = cell(Nobj,1);
             for ii=1:Nobj
                 [obj.object_store_(ii),object_hashes{ii}] = build_hash(obj.object_store_(ii));
@@ -573,17 +574,7 @@ classdef object_lookup < serializable
             [~, sorted_idx] = sort(object_hashes);
             obj.object_store_ = obj.object_store_(sorted_idx);
             [present, inverse_idx] = ismember(1:Nobj, sorted_idx);
-            % All these checks indicate that at this stage obect may be
-            % built incorectly. Why may it happen? Re #1797.
-            if any(~present)
-                error('HERBERT:object_lookup:invalid_argument','missing indices');
-            end
-            if numel(unique(inverse_idx))<numel(inverse_idx)
-                error('HERBERT:object_lookup:invalid_argument','duplicate indices');
-            end
-            if max(inverse_idx)>Nobj || min(inverse_idx)<1
-                error('HERBERT:object_lookup:invalid_argument','incorrect indices');
-            end
+
             for ii=1:numel(obj.indx)
                 for jj=1:numel(obj.indx{ii})
                     k = obj.indx{ii}(jj);
@@ -592,9 +583,21 @@ classdef object_lookup < serializable
             end
         end
         %------------------------------------------------------------------
+        % Return selected object elements of a given array from the
+        % original set of arrays
+        A = object_elements (obj, varargin);
+        % Generate random samples for indexed occurences within a
+        % particular object array
+        varargout = rand_ind (obj, iarray, varargin);
+        % Return a given object array from the original set of arrays
+        obj_out = object_repmat (obj, varargin);
+        % Return a given object array from the original set of arrays
+        A = object_array (obj, varargin);
+        % Evaluate a function or method for indexed occurences in an
+        % object lookup table.
+        varargout = func_eval_ind (obj, iarray, varargin);
     end
-
-
+    %
     %======================================================================
     % Interface to test private functions
     %======================================================================

--- a/herbert_core/utilities/misc/build_hash.m
+++ b/herbert_core/utilities/misc/build_hash.m
@@ -16,7 +16,6 @@ function [obj,hash,is_calculated] = build_hash(obj)
 is_calculated = true;
 % get config to use use_mex
 use_mex = config_store.instance().get_value('hor_config','use_mex');
-persistent Engine;
 % In case the java engine is going to be used, initialise it as
 % a persistent object
 if isa(obj,'uint8')
@@ -29,7 +28,7 @@ if use_mex
     % mex version to be used, use it
     hash = GetMD5(bytestream);
 else
-
+    persistent Engine;
     if isempty(Engine)
         Engine = java.security.MessageDigest.getInstance('MD5');
     end
@@ -50,5 +49,5 @@ else
     hash2 = dec2hex(hash1);
     hash3 = cellstr(hash2);
     hash4 = horzcat(hash3{:});
-    hash = lower(hash4); 
+    hash = lower(hash4);
 end


### PR DESCRIPTION
solves Re #1797.

This small PR solves the mentioned ticket by removing all checks present in sort function as the conditions verified by these checks are always satisfied.

Also minor modifications to `obj_lookup` interface. All public methods are mentioned in class file.